### PR TITLE
M3: real-system correctness — context persistence + concurrency fixes (M3.1, M3.2)

### DIFF
--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -1,0 +1,250 @@
+package workflow_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/ehabterra/workflow"
+)
+
+// abDefinition returns a minimal a --go--> b definition.
+func abDefinition(t *testing.T) *workflow.Definition {
+	t.Helper()
+	tr, err := workflow.NewTransition("go", []workflow.Place{"a"}, []workflow.Place{"b"})
+	if err != nil {
+		t.Fatalf("NewTransition: %v", err)
+	}
+	def, err := workflow.NewDefinition([]workflow.Place{"a", "b"}, []workflow.Transition{*tr})
+	if err != nil {
+		t.Fatalf("NewDefinition: %v", err)
+	}
+	return def
+}
+
+// A transition must fire exactly once even when many goroutines race to apply
+// it: the enablement re-check under the write lock rejects the losers.
+func TestConcurrentApplyTransition_FiresOnce(t *testing.T) {
+	def := abDefinition(t)
+	wf, err := workflow.NewWorkflow("wf", def, "a")
+	if err != nil {
+		t.Fatalf("NewWorkflow: %v", err)
+	}
+
+	const racers = 32
+	var wg sync.WaitGroup
+	errs := make([]error, racers)
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = wf.ApplyTransition("go")
+		}(i)
+	}
+	wg.Wait()
+
+	succeeded := 0
+	for _, err := range errs {
+		switch {
+		case err == nil:
+			succeeded++
+		case errors.Is(err, workflow.ErrTransitionNotAllowed):
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if succeeded != 1 {
+		t.Fatalf("transition fired %d times, want exactly 1", succeeded)
+	}
+	if wf.Marking().HasPlace("a") {
+		t.Fatal("place a still marked after firing")
+	}
+	if got := wf.TokenCount("b"); got != 1 {
+		t.Fatalf("TokenCount(b) = %d, want 1 (no duplicate produce)", got)
+	}
+}
+
+// With a colored token, a lost race must not fall back to producing a phantom
+// uncolored token at the output place.
+func TestConcurrentApplyTransition_NoPhantomToken(t *testing.T) {
+	def := abDefinition(t)
+	wf, err := workflow.NewWorkflow("wf", def, "a")
+	if err != nil {
+		t.Fatalf("NewWorkflow: %v", err)
+	}
+	wf.ClearPlace("a")
+	tok, err := wf.CreateToken("a", workflow.TokenData{"order": "A-1"})
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+
+	const racers = 16
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = wf.ApplyTransition("go")
+		}()
+	}
+	wg.Wait()
+
+	if got := wf.TokenCount("b"); got != 1 {
+		t.Fatalf("TokenCount(b) = %d, want 1 (phantom token produced by racing fire)", got)
+	}
+	toks := wf.GetTokens("b")
+	if len(toks) != 1 || toks[0].ID() != tok.ID() {
+		t.Fatalf("token at b = %+v, want the original colored token %s", toks, tok.ID())
+	}
+}
+
+// marshalingStorage encodes what it is handed, like a real SQL backend, so the
+// race detector sees any concurrent mutation of live state during a save.
+type marshalingStorage struct{}
+
+func (marshalingStorage) LoadState(ctx context.Context, id string) (workflow.Marking, map[string]any, error) {
+	return nil, nil, workflow.ErrWorkflowNotFound
+}
+
+func (marshalingStorage) SaveState(ctx context.Context, id string, marking workflow.Marking, ctxData map[string]any) error {
+	if _, err := json.Marshal(marking); err != nil {
+		return err
+	}
+	_, err := json.Marshal(ctxData)
+	return err
+}
+
+func (marshalingStorage) DeleteState(ctx context.Context, id string) error { return nil }
+
+// SaveWorkflow must snapshot marking and context under the workflow lock;
+// otherwise this test races SetContext and transition firing against the
+// storage layer's marshaling.
+func TestManagerSaveWorkflow_ConcurrentMutation(t *testing.T) {
+	tr1, _ := workflow.NewTransition("go", []workflow.Place{"a"}, []workflow.Place{"b"})
+	tr2, _ := workflow.NewTransition("back", []workflow.Place{"b"}, []workflow.Place{"a"})
+	def, err := workflow.NewDefinition([]workflow.Place{"a", "b"}, []workflow.Transition{*tr1, *tr2})
+	if err != nil {
+		t.Fatalf("NewDefinition: %v", err)
+	}
+
+	mgr := workflow.NewManager(workflow.NewRegistry(), marshalingStorage{})
+	ctx := context.Background()
+	wf, err := mgr.CreateWorkflow(ctx, "wf", def, "a")
+	if err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			wf.SetContext("counter", i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = wf.ApplyTransition("go")
+			_ = wf.ApplyTransition("back")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if err := mgr.SaveWorkflow(ctx, "wf", wf); err != nil {
+				t.Errorf("SaveWorkflow: %v", err)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+}
+
+// Listeners may be added and removed on the definition, manager, and instance
+// while transitions fire on another goroutine.
+func TestListeners_ConcurrentAddRemoveWhileFiring(t *testing.T) {
+	tr1, _ := workflow.NewTransition("go", []workflow.Place{"a"}, []workflow.Place{"b"})
+	tr2, _ := workflow.NewTransition("back", []workflow.Place{"b"}, []workflow.Place{"a"})
+	def, err := workflow.NewDefinition([]workflow.Place{"a", "b"}, []workflow.Transition{*tr1, *tr2})
+	if err != nil {
+		t.Fatalf("NewDefinition: %v", err)
+	}
+
+	mgr := workflow.NewManager(workflow.NewRegistry(), marshalingStorage{})
+	wf, err := mgr.CreateWorkflow(context.Background(), "wf", def, "a")
+	if err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+
+	noop := func(workflow.Event) error { return nil }
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			hd := def.AddEventListener(workflow.EventAfterTransition, noop)
+			hm := mgr.AddEventListener(workflow.EventBeforeTransition, noop)
+			hw := wf.AddEventListener(workflow.EventAfterTransition, noop)
+			def.RemoveListener(hd)
+			mgr.RemoveListener(hm)
+			wf.RemoveListener(hw)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = wf.ApplyTransition("go")
+			_ = wf.ApplyTransition("back")
+		}
+	}()
+	wg.Wait()
+}
+
+// Removing a listener of one event type must not corrupt the handle indices of
+// another event type's listeners (regression: the handle map was shared across
+// event types, so a removal shifted every later index regardless of type).
+func TestRemoveListener_CrossEventTypeIndices(t *testing.T) {
+	def := abDefinition(t)
+
+	var calls []string
+	record := func(name string) workflow.EventListener {
+		return func(workflow.Event) error {
+			calls = append(calls, name)
+			return nil
+		}
+	}
+
+	h1 := def.AddEventListener(workflow.EventBeforeTransition, record("L1"))
+	h2 := def.AddEventListener(workflow.EventBeforeTransition, record("L2"))
+	h3 := def.AddEventListener(workflow.EventAfterTransition, record("L3"))
+	_ = h1
+
+	// Removing the after-listener must not shift the before-listeners' indices…
+	def.RemoveListener(h3)
+	// …so removing L2 by handle must remove L2, not L1.
+	def.RemoveListener(h2)
+
+	wf, err := workflow.NewWorkflow("wf", def, "a")
+	if err != nil {
+		t.Fatalf("NewWorkflow: %v", err)
+	}
+	if err := wf.ApplyTransition("go"); err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+
+	if len(calls) != 1 || calls[0] != "L1" {
+		t.Fatalf("fired listeners = %v, want [L1] (wrong listener removed)", calls)
+	}
+	if got := def.ListenerCount(workflow.EventBeforeTransition); got != 1 {
+		t.Fatalf("before-listener count = %d, want 1", got)
+	}
+	if got := def.ListenerCount(workflow.EventAfterTransition); got != 0 {
+		t.Fatalf("after-listener count = %d, want 0", got)
+	}
+}

--- a/definition.go
+++ b/definition.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"fmt"
-	"sync/atomic"
 )
 
 // Definition represents a workflow definition with places and transitions
@@ -10,12 +9,10 @@ type Definition struct {
 	Places      []Place
 	Transitions []Transition
 
-	// Default listeners for this workflow type
-	Listeners map[EventType][]any
-
-	// Handle tracking for reliable listener removal
-	listenerHandles map[uint64]int // handle ID -> index in slice
-	nextHandleID    uint64         // atomic counter for unique handle IDs
+	// listeners holds the default listeners for every workflow instance built
+	// from this definition. It is concurrency-safe: listeners may be added or
+	// removed while instances fire transitions on other goroutines.
+	listeners listenerSet
 }
 
 // NewDefinition creates a new workflow definition
@@ -86,78 +83,25 @@ func (d *Definition) Place(place Place) bool {
 // AddEventListener adds a default event listener for a specific event type
 // It returns a handle that can be used to remove the listener later
 func (d *Definition) AddEventListener(eventType EventType, listener EventListener) *ListenerHandle {
-	if d.Listeners == nil {
-		d.Listeners = make(map[EventType][]any)
-	}
-	if d.listenerHandles == nil {
-		d.listenerHandles = make(map[uint64]int)
-	}
-
-	handleID := atomic.AddUint64(&d.nextHandleID, 1)
-	index := len(d.Listeners[eventType])
-	d.Listeners[eventType] = append(d.Listeners[eventType], listener)
-	d.listenerHandles[handleID] = index
-
-	return &ListenerHandle{
-		id:        handleID,
-		eventType: eventType,
-		owner:     d,
-	}
+	return d.listeners.add(eventType, listener, d)
 }
 
 // AddGuardEventListener adds a default guard event listener
 // It returns a handle that can be used to remove the listener later
 func (d *Definition) AddGuardEventListener(listener GuardEventListener) *ListenerHandle {
-	if d.Listeners == nil {
-		d.Listeners = make(map[EventType][]any)
-	}
-	if d.listenerHandles == nil {
-		d.listenerHandles = make(map[uint64]int)
-	}
-
-	handleID := atomic.AddUint64(&d.nextHandleID, 1)
-	index := len(d.Listeners[EventGuard])
-	d.Listeners[EventGuard] = append(d.Listeners[EventGuard], listener)
-	d.listenerHandles[handleID] = index
-
-	return &ListenerHandle{
-		id:        handleID,
-		eventType: EventGuard,
-		owner:     d,
-	}
+	return d.listeners.add(EventGuard, listener, d)
 }
 
 // RemoveListener removes a listener using its handle
 // This is the recommended way to remove listeners as it's reliable and efficient
 func (d *Definition) RemoveListener(handle *ListenerHandle) {
-	if d.Listeners == nil || d.listenerHandles == nil || handle == nil {
+	if handle == nil || handle.owner != d {
 		return
 	}
+	d.listeners.remove(handle)
+}
 
-	// Verify the handle belongs to this definition
-	if handle.owner != d {
-		return
-	}
-
-	index, ok := d.listenerHandles[handle.id]
-	if !ok {
-		return // Handle not found
-	}
-
-	listeners := d.Listeners[handle.eventType]
-	if index >= len(listeners) {
-		return // Index out of bounds
-	}
-
-	// Remove from slice
-	d.Listeners[handle.eventType] = append(listeners[:index], listeners[index+1:]...)
-
-	// Update indices for handles after the removed one
-	for id, idx := range d.listenerHandles {
-		if idx > index {
-			d.listenerHandles[id] = idx - 1
-		}
-	}
-
-	delete(d.listenerHandles, handle.id)
+// ListenerCount returns the number of listeners registered for eventType.
+func (d *Definition) ListenerCount(eventType EventType) int {
+	return d.listeners.count(eventType)
 }

--- a/definition_test.go
+++ b/definition_test.go
@@ -292,30 +292,27 @@ func TestDefinition_AddEventListener(t *testing.T) {
 	listener1 := func(event workflow.Event) error { return nil }
 	def.AddEventListener(workflow.EventBeforeTransition, listener1)
 
-	if def.Listeners == nil {
-		t.Error("AddEventListener() did not initialize Listeners map")
-	}
-	if len(def.Listeners[workflow.EventBeforeTransition]) != 1 {
-		t.Errorf("AddEventListener() listener count = %d, want 1", len(def.Listeners[workflow.EventBeforeTransition]))
+	if def.ListenerCount(workflow.EventBeforeTransition) != 1 {
+		t.Errorf("AddEventListener() listener count = %d, want 1", def.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Test adding multiple listeners
 	listener2 := func(event workflow.Event) error { return nil }
 	def.AddEventListener(workflow.EventBeforeTransition, listener2)
 
-	if len(def.Listeners[workflow.EventBeforeTransition]) != 2 {
-		t.Errorf("AddEventListener() listener count = %d, want 2", len(def.Listeners[workflow.EventBeforeTransition]))
+	if def.ListenerCount(workflow.EventBeforeTransition) != 2 {
+		t.Errorf("AddEventListener() listener count = %d, want 2", def.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Test adding listener for different event type
 	listener3 := func(event workflow.Event) error { return nil }
 	def.AddEventListener(workflow.EventAfterTransition, listener3)
 
-	if len(def.Listeners[workflow.EventAfterTransition]) != 1 {
-		t.Errorf("AddEventListener() listener count for EventAfterTransition = %d, want 1", len(def.Listeners[workflow.EventAfterTransition]))
+	if def.ListenerCount(workflow.EventAfterTransition) != 1 {
+		t.Errorf("AddEventListener() listener count for EventAfterTransition = %d, want 1", def.ListenerCount(workflow.EventAfterTransition))
 	}
-	if len(def.Listeners[workflow.EventBeforeTransition]) != 2 {
-		t.Errorf("AddEventListener() listener count for EventBeforeTransition = %d, want 2", len(def.Listeners[workflow.EventBeforeTransition]))
+	if def.ListenerCount(workflow.EventBeforeTransition) != 2 {
+		t.Errorf("AddEventListener() listener count for EventBeforeTransition = %d, want 2", def.ListenerCount(workflow.EventBeforeTransition))
 	}
 }
 
@@ -329,19 +326,16 @@ func TestDefinition_AddGuardEventListener(t *testing.T) {
 	guardListener1 := func(event *workflow.GuardEvent) error { return nil }
 	def.AddGuardEventListener(guardListener1)
 
-	if def.Listeners == nil {
-		t.Error("AddGuardEventListener() did not initialize Listeners map")
-	}
-	if len(def.Listeners[workflow.EventGuard]) != 1 {
-		t.Errorf("AddGuardEventListener() listener count = %d, want 1", len(def.Listeners[workflow.EventGuard]))
+	if def.ListenerCount(workflow.EventGuard) != 1 {
+		t.Errorf("AddGuardEventListener() listener count = %d, want 1", def.ListenerCount(workflow.EventGuard))
 	}
 
 	// Test adding multiple guard listeners
 	guardListener2 := func(event *workflow.GuardEvent) error { return nil }
 	def.AddGuardEventListener(guardListener2)
 
-	if len(def.Listeners[workflow.EventGuard]) != 2 {
-		t.Errorf("AddGuardEventListener() listener count = %d, want 2", len(def.Listeners[workflow.EventGuard]))
+	if def.ListenerCount(workflow.EventGuard) != 2 {
+		t.Errorf("AddGuardEventListener() listener count = %d, want 2", def.ListenerCount(workflow.EventGuard))
 	}
 }
 
@@ -356,29 +350,29 @@ func TestDefinition_RemoveListener(t *testing.T) {
 	handle2 := def.AddEventListener(workflow.EventBeforeTransition, func(event workflow.Event) error { return nil })
 	handle3 := def.AddEventListener(workflow.EventBeforeTransition, func(event workflow.Event) error { return nil })
 
-	if len(def.Listeners[workflow.EventBeforeTransition]) != 3 {
-		t.Fatalf("Expected 3 listeners, got %d", len(def.Listeners[workflow.EventBeforeTransition]))
+	if def.ListenerCount(workflow.EventBeforeTransition) != 3 {
+		t.Fatalf("Expected 3 listeners, got %d", def.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Remove middle listener using handle
 	def.RemoveListener(handle2)
 
-	if len(def.Listeners[workflow.EventBeforeTransition]) != 2 {
-		t.Errorf("RemoveListener() listener count = %d, want 2", len(def.Listeners[workflow.EventBeforeTransition]))
+	if def.ListenerCount(workflow.EventBeforeTransition) != 2 {
+		t.Errorf("RemoveListener() listener count = %d, want 2", def.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Remove last listener
 	def.RemoveListener(handle3)
 
-	if len(def.Listeners[workflow.EventBeforeTransition]) != 1 {
-		t.Errorf("RemoveListener() listener count = %d, want 1", len(def.Listeners[workflow.EventBeforeTransition]))
+	if def.ListenerCount(workflow.EventBeforeTransition) != 1 {
+		t.Errorf("RemoveListener() listener count = %d, want 1", def.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Remove first listener
 	def.RemoveListener(handle1)
 
-	if len(def.Listeners[workflow.EventBeforeTransition]) != 0 {
-		t.Errorf("RemoveListener() listener count = %d, want 0", len(def.Listeners[workflow.EventBeforeTransition]))
+	if def.ListenerCount(workflow.EventBeforeTransition) != 0 {
+		t.Errorf("RemoveListener() listener count = %d, want 0", def.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Test removing with nil handle (should not panic)
@@ -408,29 +402,29 @@ func TestDefinition_RemoveEventListener(t *testing.T) {
 	handle2 := def.AddEventListener(workflow.EventBeforeTransition, listener2)
 	handle3 := def.AddEventListener(workflow.EventBeforeTransition, listener3)
 
-	if len(def.Listeners[workflow.EventBeforeTransition]) != 3 {
-		t.Fatalf("Expected 3 listeners, got %d", len(def.Listeners[workflow.EventBeforeTransition]))
+	if def.ListenerCount(workflow.EventBeforeTransition) != 3 {
+		t.Fatalf("Expected 3 listeners, got %d", def.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Remove middle listener using handle
 	def.RemoveListener(handle2)
 
-	if len(def.Listeners[workflow.EventBeforeTransition]) != 2 {
-		t.Errorf("RemoveListener() listener count = %d, want 2", len(def.Listeners[workflow.EventBeforeTransition]))
+	if def.ListenerCount(workflow.EventBeforeTransition) != 2 {
+		t.Errorf("RemoveListener() listener count = %d, want 2", def.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Remove last listener
 	def.RemoveListener(handle3)
 
-	if len(def.Listeners[workflow.EventBeforeTransition]) != 1 {
-		t.Errorf("RemoveListener() listener count = %d, want 1", len(def.Listeners[workflow.EventBeforeTransition]))
+	if def.ListenerCount(workflow.EventBeforeTransition) != 1 {
+		t.Errorf("RemoveListener() listener count = %d, want 1", def.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Remove first listener
 	def.RemoveListener(handle1)
 
-	if len(def.Listeners[workflow.EventBeforeTransition]) != 0 {
-		t.Errorf("RemoveListener() listener count = %d, want 0", len(def.Listeners[workflow.EventBeforeTransition]))
+	if def.ListenerCount(workflow.EventBeforeTransition) != 0 {
+		t.Errorf("RemoveListener() listener count = %d, want 0", def.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Test removing with nil handle (should not panic)
@@ -459,8 +453,8 @@ func TestDefinition_RemoveListener_EdgeCases(t *testing.T) {
 
 	// Try to remove handle2 (from def2) from def1 - should not remove anything
 	def.RemoveListener(handle2)
-	if len(def.Listeners[workflow.EventBeforeTransition]) != 1 {
-		t.Errorf("RemoveListener() with wrong owner should not remove listener, got %d", len(def.Listeners[workflow.EventBeforeTransition]))
+	if def.ListenerCount(workflow.EventBeforeTransition) != 1 {
+		t.Errorf("RemoveListener() with wrong owner should not remove listener, got %d", def.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Clean up

--- a/examples/migration_example/main_test.go
+++ b/examples/migration_example/main_test.go
@@ -223,6 +223,7 @@ func TestMigrationBackwardCompatibility(t *testing.T) {
 			id TEXT PRIMARY KEY,
 			state TEXT NOT NULL,
 			version INTEGER NOT NULL DEFAULT 0,
+			context TEXT NOT NULL DEFAULT '{}',
 			title TEXT,
 			content TEXT
 		)

--- a/examples/migration_example/migrations/000001_initial_schema.up.sql
+++ b/examples/migration_example/migrations/000001_initial_schema.up.sql
@@ -1,10 +1,12 @@
 -- Initial schema for workflow states table.
--- The `version` column backs optimistic-concurrency control (workflow.VersionedStorage);
--- it is part of the baseline schema the SQLite backend expects.
+-- The `version` column backs optimistic-concurrency control (workflow.VersionedStorage)
+-- and the `context` column persists the workflow's full context map as JSON;
+-- both are part of the baseline schema the SQLite backend expects.
 CREATE TABLE IF NOT EXISTS workflow_states (
     id TEXT PRIMARY KEY,
     state TEXT NOT NULL,
     version INTEGER NOT NULL DEFAULT 0,
+    context TEXT NOT NULL DEFAULT '{}',
     title TEXT,
     content TEXT
 );

--- a/listeners.go
+++ b/listeners.go
@@ -1,0 +1,124 @@
+package workflow
+
+import "sync"
+
+// listenerRef records where a handle's listener lives: which event type's list
+// and at which index. Tracking the event type per handle keeps removal of one
+// event type's listener from corrupting the indices of another's.
+type listenerRef struct {
+	eventType EventType
+	index     int
+}
+
+// listenerSet is the concurrency-safe listener registry shared by Definition,
+// Manager, and Workflow. All mutation and iteration goes through it, so
+// listeners can be added or removed while transitions fire on other goroutines.
+//
+// snapshot returns the current slice under the read lock; it stays safe to
+// iterate after the lock is released because add only appends (iteration is
+// bounded by the snapshot's length) and remove replaces the slice with a fresh
+// copy instead of shifting the shared backing array.
+type listenerSet struct {
+	mu      sync.RWMutex
+	lists   map[EventType][]any
+	handles map[uint64]listenerRef
+	nextID  uint64
+}
+
+// add registers a listener and returns a removal handle owned by owner (the
+// Definition, Manager, or Workflow the caller exposes to its users).
+func (s *listenerSet) add(eventType EventType, listener any, owner any) *ListenerHandle {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.lists == nil {
+		s.lists = make(map[EventType][]any)
+	}
+	if s.handles == nil {
+		s.handles = make(map[uint64]listenerRef)
+	}
+
+	s.nextID++
+	s.lists[eventType] = append(s.lists[eventType], listener)
+	s.handles[s.nextID] = listenerRef{eventType: eventType, index: len(s.lists[eventType]) - 1}
+
+	return &ListenerHandle{
+		id:        s.nextID,
+		eventType: eventType,
+		owner:     owner,
+	}
+}
+
+// remove unregisters the listener behind handle. Unknown or already-removed
+// handles are a no-op.
+func (s *listenerSet) remove(handle *ListenerHandle) {
+	if handle == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ref, ok := s.handles[handle.id]
+	if !ok {
+		return
+	}
+
+	old := s.lists[ref.eventType]
+	if ref.index >= len(old) {
+		return
+	}
+
+	// Copy-on-write removal: snapshots handed out earlier keep iterating their
+	// own backing array untouched.
+	replacement := make([]any, 0, len(old)-1)
+	replacement = append(replacement, old[:ref.index]...)
+	replacement = append(replacement, old[ref.index+1:]...)
+	s.lists[ref.eventType] = replacement
+
+	// Shift the recorded indices of this event type's later listeners.
+	for id, r := range s.handles {
+		if r.eventType == ref.eventType && r.index > ref.index {
+			s.handles[id] = listenerRef{eventType: r.eventType, index: r.index - 1}
+		}
+	}
+	delete(s.handles, handle.id)
+}
+
+// snapshot returns the listeners for eventType as of now; see the type comment
+// for why the returned slice is safe to iterate without the lock.
+func (s *listenerSet) snapshot(eventType EventType) []any {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lists[eventType]
+}
+
+// count returns how many listeners are registered for eventType.
+func (s *listenerSet) count(eventType EventType) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.lists[eventType])
+}
+
+// dispatchListeners invokes each listener with the event, stopping at the first
+// error. Guard events go to GuardEventListener entries, everything else to
+// EventListener entries; a listener of the wrong kind for the event is skipped.
+func dispatchListeners(listeners []any, event Event) error {
+	for _, l := range listeners {
+		switch event.Type() {
+		case EventGuard:
+			if gl, ok := l.(GuardEventListener); ok {
+				if err := gl(event.(*GuardEvent)); err != nil {
+					return err
+				}
+			}
+		default:
+			if el, ok := l.(EventListener); ok {
+				if err := el(event); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/manager.go
+++ b/manager.go
@@ -3,7 +3,6 @@ package workflow
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 )
 
 // Manager handles workflow instances and their persistence
@@ -11,12 +10,10 @@ type Manager struct {
 	registry *Registry
 	storage  Storage
 
-	// Dynamic listeners for all managed workflows
-	Listeners map[EventType][]any
-
-	// Handle tracking for reliable listener removal
-	listenerHandles map[uint64]int // handle ID -> index in slice
-	nextHandleID    uint64         // atomic counter for unique handle IDs
+	// listeners holds the dynamic listeners for all managed workflows. It is
+	// concurrency-safe: listeners may be added or removed while managed
+	// workflows fire transitions on other goroutines.
+	listeners listenerSet
 }
 
 // NewManager creates a new workflow manager
@@ -84,15 +81,19 @@ func (m *Manager) LoadWorkflow(ctx context.Context, id string, definition *Defin
 // current version: if another writer saved first, it returns ErrConflict and the
 // workflow's version is left unchanged so the caller can reload and retry.
 func (m *Manager) SaveWorkflow(ctx context.Context, id string, wf *Workflow) error {
+	// Snapshot marking and context under the workflow's lock: handing the live
+	// state to the storage layer would race concurrent transitions and
+	// SetContext calls while it marshals.
+	marking, ctxData := wf.snapshotState()
 	if vs, ok := m.storage.(VersionedStorage); ok {
-		newVersion, err := vs.SaveVersionedState(ctx, id, wf.Marking(), wf.context, wf.Version())
+		newVersion, err := vs.SaveVersionedState(ctx, id, marking, ctxData, wf.Version())
 		if err != nil {
 			return err
 		}
 		wf.setVersion(newVersion)
 		return nil
 	}
-	return m.storage.SaveState(ctx, id, wf.Marking(), wf.context)
+	return m.storage.SaveState(ctx, id, marking, ctxData)
 }
 
 // GetWorkflow gets a workflow instance from the registry or loads it from storage
@@ -117,13 +118,14 @@ func (m *Manager) CreateWorkflow(ctx context.Context, id string, definition *Def
 
 	// Save initial state. With a versioned backend this inserts at version 1 and
 	// fails with ErrConflict if a workflow with this id already exists.
+	marking, ctxData := wf.snapshotState()
 	if vs, ok := m.storage.(VersionedStorage); ok {
-		newVersion, err := vs.SaveVersionedState(ctx, id, wf.Marking(), wf.context, 0)
+		newVersion, err := vs.SaveVersionedState(ctx, id, marking, ctxData, 0)
 		if err != nil {
 			return nil, fmt.Errorf("failed to save initial state: %w", err)
 		}
 		wf.setVersion(newVersion)
-	} else if err := m.storage.SaveState(ctx, id, wf.Marking(), wf.context); err != nil {
+	} else if err := m.storage.SaveState(ctx, id, marking, ctxData); err != nil {
 		return nil, fmt.Errorf("failed to save initial state: %w", err)
 	}
 
@@ -146,78 +148,25 @@ func (m *Manager) DeleteWorkflow(ctx context.Context, id string) error {
 // AddEventListener adds a dynamic event listener for a specific event type
 // It returns a handle that can be used to remove the listener later
 func (m *Manager) AddEventListener(eventType EventType, listener EventListener) *ListenerHandle {
-	if m.Listeners == nil {
-		m.Listeners = make(map[EventType][]any)
-	}
-	if m.listenerHandles == nil {
-		m.listenerHandles = make(map[uint64]int)
-	}
-
-	handleID := atomic.AddUint64(&m.nextHandleID, 1)
-	index := len(m.Listeners[eventType])
-	m.Listeners[eventType] = append(m.Listeners[eventType], listener)
-	m.listenerHandles[handleID] = index
-
-	return &ListenerHandle{
-		id:        handleID,
-		eventType: eventType,
-		owner:     m,
-	}
+	return m.listeners.add(eventType, listener, m)
 }
 
 // AddGuardEventListener adds a dynamic guard event listener
 // It returns a handle that can be used to remove the listener later
 func (m *Manager) AddGuardEventListener(listener GuardEventListener) *ListenerHandle {
-	if m.Listeners == nil {
-		m.Listeners = make(map[EventType][]any)
-	}
-	if m.listenerHandles == nil {
-		m.listenerHandles = make(map[uint64]int)
-	}
-
-	handleID := atomic.AddUint64(&m.nextHandleID, 1)
-	index := len(m.Listeners[EventGuard])
-	m.Listeners[EventGuard] = append(m.Listeners[EventGuard], listener)
-	m.listenerHandles[handleID] = index
-
-	return &ListenerHandle{
-		id:        handleID,
-		eventType: EventGuard,
-		owner:     m,
-	}
+	return m.listeners.add(EventGuard, listener, m)
 }
 
 // RemoveListener removes a listener using its handle
 // This is the recommended way to remove listeners as it's reliable and efficient
 func (m *Manager) RemoveListener(handle *ListenerHandle) {
-	if m.Listeners == nil || m.listenerHandles == nil || handle == nil {
+	if handle == nil || handle.owner != m {
 		return
 	}
+	m.listeners.remove(handle)
+}
 
-	// Verify the handle belongs to this manager
-	if handle.owner != m {
-		return
-	}
-
-	index, ok := m.listenerHandles[handle.id]
-	if !ok {
-		return // Handle not found
-	}
-
-	listeners := m.Listeners[handle.eventType]
-	if index >= len(listeners) {
-		return // Index out of bounds
-	}
-
-	// Remove from slice
-	m.Listeners[handle.eventType] = append(listeners[:index], listeners[index+1:]...)
-
-	// Update indices for handles after the removed one
-	for id, idx := range m.listenerHandles {
-		if idx > index {
-			m.listenerHandles[id] = idx - 1
-		}
-	}
-
-	delete(m.listenerHandles, handle.id)
+// ListenerCount returns the number of listeners registered for eventType.
+func (m *Manager) ListenerCount(eventType EventType) int {
+	return m.listeners.count(eventType)
 }

--- a/manager_test.go
+++ b/manager_test.go
@@ -416,30 +416,27 @@ func TestManager_AddEventListener(t *testing.T) {
 	listener1 := func(event workflow.Event) error { return nil }
 	manager.AddEventListener(workflow.EventBeforeTransition, listener1)
 
-	if manager.Listeners == nil {
-		t.Error("AddEventListener() did not initialize Listeners map")
-	}
-	if len(manager.Listeners[workflow.EventBeforeTransition]) != 1 {
-		t.Errorf("AddEventListener() listener count = %d, want 1", len(manager.Listeners[workflow.EventBeforeTransition]))
+	if manager.ListenerCount(workflow.EventBeforeTransition) != 1 {
+		t.Errorf("AddEventListener() listener count = %d, want 1", manager.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Test adding multiple listeners
 	listener2 := func(event workflow.Event) error { return nil }
 	manager.AddEventListener(workflow.EventBeforeTransition, listener2)
 
-	if len(manager.Listeners[workflow.EventBeforeTransition]) != 2 {
-		t.Errorf("AddEventListener() listener count = %d, want 2", len(manager.Listeners[workflow.EventBeforeTransition]))
+	if manager.ListenerCount(workflow.EventBeforeTransition) != 2 {
+		t.Errorf("AddEventListener() listener count = %d, want 2", manager.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Test adding listener for different event type
 	listener3 := func(event workflow.Event) error { return nil }
 	manager.AddEventListener(workflow.EventAfterTransition, listener3)
 
-	if len(manager.Listeners[workflow.EventAfterTransition]) != 1 {
-		t.Errorf("AddEventListener() listener count for EventAfterTransition = %d, want 1", len(manager.Listeners[workflow.EventAfterTransition]))
+	if manager.ListenerCount(workflow.EventAfterTransition) != 1 {
+		t.Errorf("AddEventListener() listener count for EventAfterTransition = %d, want 1", manager.ListenerCount(workflow.EventAfterTransition))
 	}
-	if len(manager.Listeners[workflow.EventBeforeTransition]) != 2 {
-		t.Errorf("AddEventListener() listener count for EventBeforeTransition = %d, want 2", len(manager.Listeners[workflow.EventBeforeTransition]))
+	if manager.ListenerCount(workflow.EventBeforeTransition) != 2 {
+		t.Errorf("AddEventListener() listener count for EventBeforeTransition = %d, want 2", manager.ListenerCount(workflow.EventBeforeTransition))
 	}
 }
 
@@ -452,19 +449,16 @@ func TestManager_AddGuardEventListener(t *testing.T) {
 	guardListener1 := func(event *workflow.GuardEvent) error { return nil }
 	manager.AddGuardEventListener(guardListener1)
 
-	if manager.Listeners == nil {
-		t.Error("AddGuardEventListener() did not initialize Listeners map")
-	}
-	if len(manager.Listeners[workflow.EventGuard]) != 1 {
-		t.Errorf("AddGuardEventListener() listener count = %d, want 1", len(manager.Listeners[workflow.EventGuard]))
+	if manager.ListenerCount(workflow.EventGuard) != 1 {
+		t.Errorf("AddGuardEventListener() listener count = %d, want 1", manager.ListenerCount(workflow.EventGuard))
 	}
 
 	// Test adding multiple guard listeners
 	guardListener2 := func(event *workflow.GuardEvent) error { return nil }
 	manager.AddGuardEventListener(guardListener2)
 
-	if len(manager.Listeners[workflow.EventGuard]) != 2 {
-		t.Errorf("AddGuardEventListener() listener count = %d, want 2", len(manager.Listeners[workflow.EventGuard]))
+	if manager.ListenerCount(workflow.EventGuard) != 2 {
+		t.Errorf("AddGuardEventListener() listener count = %d, want 2", manager.ListenerCount(workflow.EventGuard))
 	}
 }
 
@@ -478,29 +472,29 @@ func TestManager_RemoveListener(t *testing.T) {
 	handle2 := manager.AddEventListener(workflow.EventBeforeTransition, func(event workflow.Event) error { return nil })
 	handle3 := manager.AddEventListener(workflow.EventBeforeTransition, func(event workflow.Event) error { return nil })
 
-	if len(manager.Listeners[workflow.EventBeforeTransition]) != 3 {
-		t.Fatalf("Expected 3 listeners, got %d", len(manager.Listeners[workflow.EventBeforeTransition]))
+	if manager.ListenerCount(workflow.EventBeforeTransition) != 3 {
+		t.Fatalf("Expected 3 listeners, got %d", manager.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Remove middle listener using handle
 	manager.RemoveListener(handle2)
 
-	if len(manager.Listeners[workflow.EventBeforeTransition]) != 2 {
-		t.Errorf("RemoveListener() listener count = %d, want 2", len(manager.Listeners[workflow.EventBeforeTransition]))
+	if manager.ListenerCount(workflow.EventBeforeTransition) != 2 {
+		t.Errorf("RemoveListener() listener count = %d, want 2", manager.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Remove last listener
 	manager.RemoveListener(handle3)
 
-	if len(manager.Listeners[workflow.EventBeforeTransition]) != 1 {
-		t.Errorf("RemoveListener() listener count = %d, want 1", len(manager.Listeners[workflow.EventBeforeTransition]))
+	if manager.ListenerCount(workflow.EventBeforeTransition) != 1 {
+		t.Errorf("RemoveListener() listener count = %d, want 1", manager.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Remove first listener
 	manager.RemoveListener(handle1)
 
-	if len(manager.Listeners[workflow.EventBeforeTransition]) != 0 {
-		t.Errorf("RemoveListener() listener count = %d, want 0", len(manager.Listeners[workflow.EventBeforeTransition]))
+	if manager.ListenerCount(workflow.EventBeforeTransition) != 0 {
+		t.Errorf("RemoveListener() listener count = %d, want 0", manager.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Test removing with nil handle (should not panic)
@@ -530,30 +524,30 @@ func TestManager_RemoveEventListener(t *testing.T) {
 	handle2 := manager.AddEventListener(workflow.EventBeforeTransition, listener2)
 	handle3 := manager.AddEventListener(workflow.EventBeforeTransition, listener3)
 
-	if len(manager.Listeners[workflow.EventBeforeTransition]) != 3 {
-		t.Fatalf("Expected 3 listeners, got %d", len(manager.Listeners[workflow.EventBeforeTransition]))
+	if manager.ListenerCount(workflow.EventBeforeTransition) != 3 {
+		t.Fatalf("Expected 3 listeners, got %d", manager.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Remove middle listener using its handle
 	manager.RemoveListener(handle2)
 
-	if len(manager.Listeners[workflow.EventBeforeTransition]) != 2 {
-		t.Errorf("RemoveListener() listener count = %d, want 2", len(manager.Listeners[workflow.EventBeforeTransition]))
+	if manager.ListenerCount(workflow.EventBeforeTransition) != 2 {
+		t.Errorf("RemoveListener() listener count = %d, want 2", manager.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Test removing with nil handle (should not panic)
 	manager.RemoveListener(nil)
 
-	if len(manager.Listeners[workflow.EventBeforeTransition]) != 2 {
-		t.Errorf("RemoveListener() listener count = %d, want 2", len(manager.Listeners[workflow.EventBeforeTransition]))
+	if manager.ListenerCount(workflow.EventBeforeTransition) != 2 {
+		t.Errorf("RemoveListener() listener count = %d, want 2", manager.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Remove remaining listeners
 	manager.RemoveListener(handle1)
 	manager.RemoveListener(handle3)
 
-	if len(manager.Listeners[workflow.EventBeforeTransition]) != 0 {
-		t.Errorf("RemoveListener() listener count = %d, want 0", len(manager.Listeners[workflow.EventBeforeTransition]))
+	if manager.ListenerCount(workflow.EventBeforeTransition) != 0 {
+		t.Errorf("RemoveListener() listener count = %d, want 0", manager.ListenerCount(workflow.EventBeforeTransition))
 	}
 }
 
@@ -569,8 +563,8 @@ func TestManager_RemoveListener_EdgeCases(t *testing.T) {
 
 	// Try to remove handle2 (from manager2) from manager1 - should not remove anything
 	manager.RemoveListener(handle2)
-	if len(manager.Listeners[workflow.EventBeforeTransition]) != 1 {
-		t.Errorf("RemoveListener() with wrong owner should not remove listener, got %d", len(manager.Listeners[workflow.EventBeforeTransition]))
+	if manager.ListenerCount(workflow.EventBeforeTransition) != 1 {
+		t.Errorf("RemoveListener() with wrong owner should not remove listener, got %d", manager.ListenerCount(workflow.EventBeforeTransition))
 	}
 
 	// Clean up

--- a/marking.go
+++ b/marking.go
@@ -214,3 +214,28 @@ func copyTokens(toks []Token) []Token {
 	copy(out, toks)
 	return out
 }
+
+// cloneMarking returns a deep copy of src. It is used to snapshot a marking
+// under the workflow lock so persistence can marshal it without racing
+// concurrent transitions.
+func cloneMarking(src Marking) Marking {
+	if m, ok := src.(*marking); ok {
+		out := make(map[Place][]Token, len(m.tokens))
+		for p, toks := range m.tokens {
+			out[p] = copyTokens(toks)
+		}
+		return &marking{tokens: out}
+	}
+	// Generic fallback for other Marking implementations.
+	out := NewMarking(nil)
+	for p, toks := range src.AllTokens() {
+		if len(toks) == 0 {
+			_ = out.AddPlace(p)
+			continue
+		}
+		for _, tok := range toks {
+			out.AddToken(p, tok)
+		}
+	}
+	return out
+}

--- a/storage/config.go
+++ b/storage/config.go
@@ -1,5 +1,10 @@
 package storage
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // config holds the table and column configuration shared by the SQL-backed
 // storage implementations. SQLiteStorage and PostgresStorage both embed it.
 type config struct {
@@ -7,6 +12,11 @@ type config struct {
 	idColumn      string
 	stateColumn   string
 	versionColumn string
+
+	// contextColumn stores the workflow's full context map as one JSON document,
+	// so every SetContext key round-trips through save/load — not just the keys
+	// configured as custom-field columns. Empty disables it (legacy tables).
+	contextColumn string
 
 	// customFields maps a context key to a full SQL column definition.
 	// Example: {"document_id": "document_id TEXT", "approver": "approver TEXT"}
@@ -19,6 +29,7 @@ func defaultConfig() config {
 		idColumn:      "id",
 		stateColumn:   "state",
 		versionColumn: "version",
+		contextColumn: "context",
 		customFields:  make(map[string]string),
 	}
 }
@@ -50,6 +61,16 @@ func WithVersionColumn(name string) Option {
 	return func(c *config) { c.versionColumn = name }
 }
 
+// WithContextColumn sets the name of the column that persists the workflow's
+// full context map as a single JSON document. Default: "context".
+//
+// Pass an empty name to disable it (e.g. for a pre-existing table without the
+// column) — then only the keys configured via WithCustomFields survive a
+// save/load round-trip and every other context key is dropped on save.
+func WithContextColumn(name string) Option {
+	return func(c *config) { c.contextColumn = name }
+}
+
 // WithCustomFields defines the schema for additional application-specific data.
 // The map key is the key used in the workflow's context map; the value is the
 // full SQL column definition (e.g. "title TEXT", "amount INTEGER NOT NULL").
@@ -70,6 +91,44 @@ func (c config) customColumns(ctxData map[string]any, encode func(val any, prese
 		values = append(values, encode(val, ok))
 	}
 	return names, values
+}
+
+// encodeContextJSON marshals the full context map for the context column.
+// A nil/empty map encodes as "{}" so the NOT NULL DEFAULT '{}' column stays
+// uniform. Values that JSON cannot represent (channels, funcs, …) are an error.
+func encodeContextJSON(ctxData map[string]any) (string, error) {
+	if len(ctxData) == 0 {
+		return "{}", nil
+	}
+	data, err := json.Marshal(ctxData)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal context: %w", err)
+	}
+	return string(data), nil
+}
+
+// decodeContextJSON decodes the context column value (JSON as string or []byte;
+// NULL/empty yields an empty map). Numbers decode to float64, per encoding/json.
+func decodeContextJSON(val any) (map[string]any, error) {
+	var data []byte
+	switch v := val.(type) {
+	case nil:
+		return map[string]any{}, nil
+	case []byte:
+		data = v
+	case string:
+		data = []byte(v)
+	default:
+		return nil, fmt.Errorf("unexpected type %T for context column", val)
+	}
+	if len(data) == 0 {
+		return map[string]any{}, nil
+	}
+	ctxData := make(map[string]any)
+	if err := json.Unmarshal(data, &ctxData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal context: %w", err)
+	}
+	return ctxData, nil
 }
 
 // firstField returns the first whitespace-delimited token of a column

--- a/storage/postgres.go
+++ b/storage/postgres.go
@@ -48,6 +48,9 @@ func (s *PostgresStorage) GenerateSchema() string {
 		fmt.Sprintf("%s TEXT NOT NULL", s.stateColumn),
 		fmt.Sprintf("%s BIGINT NOT NULL DEFAULT 0", s.versionColumn),
 	}
+	if s.contextColumn != "" {
+		columns = append(columns, fmt.Sprintf("%s JSONB NOT NULL DEFAULT '{}'", s.contextColumn))
+	}
 	for _, colDef := range s.customFields {
 		columns = append(columns, colDef)
 	}
@@ -71,6 +74,14 @@ func (s *PostgresStorage) saveState(ctx context.Context, q querier, id string, m
 	}
 
 	customCols, customVals := s.customColumns(ctxData, encodeValuePg)
+	if s.contextColumn != "" {
+		ctxJSON, err := encodeContextJSON(ctxData)
+		if err != nil {
+			return err
+		}
+		customCols = append([]string{s.contextColumn}, customCols...)
+		customVals = append([]any{ctxJSON}, customVals...)
+	}
 	columns := append([]string{s.idColumn, s.stateColumn}, customCols...)
 	values := append([]any{id, string(stateJSON)}, customVals...)
 
@@ -104,6 +115,10 @@ func (s *PostgresStorage) LoadStateTx(ctx context.Context, tx *sql.Tx, id string
 
 func (s *PostgresStorage) loadState(ctx context.Context, q querier, id string) (workflow.Marking, map[string]any, error) {
 	columns := []string{s.stateColumn}
+	if s.contextColumn != "" {
+		columns = append(columns, s.contextColumn)
+	}
+	customStart := len(columns)
 	customKeys := make([]string, 0, len(s.customFields))
 	for key, colDef := range s.customFields {
 		columns = append(columns, firstField(colDef))
@@ -115,9 +130,13 @@ func (s *PostgresStorage) loadState(ctx context.Context, q querier, id string) (
 	var stateJSON string
 	scanArgs := make([]any, len(columns))
 	scanArgs[0] = &stateJSON
+	var ctxJSON any
+	if s.contextColumn != "" {
+		scanArgs[1] = &ctxJSON
+	}
 	customVals := make([]any, len(customKeys))
 	for i := range customVals {
-		scanArgs[i+1] = &customVals[i]
+		scanArgs[customStart+i] = &customVals[i]
 	}
 
 	if err := q.QueryRowContext(ctx, query, id).Scan(scanArgs...); err != nil {
@@ -132,7 +151,16 @@ func (s *PostgresStorage) loadState(ctx context.Context, q querier, id string) (
 		return nil, nil, fmt.Errorf("failed to unmarshal state: %w", err)
 	}
 
+	// The context column holds the full context map; custom-field columns are
+	// queryable projections of individual keys and are overlaid afterwards so
+	// their natively-typed values win over the JSON decoding.
 	ctxData := make(map[string]any, len(customKeys))
+	if s.contextColumn != "" {
+		ctxData, err = decodeContextJSON(ctxJSON)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 	for i, key := range customKeys {
 		ctxData[key] = decodeValue(customVals[i])
 	}
@@ -186,6 +214,14 @@ func (s *PostgresStorage) saveVersionedState(ctx context.Context, q querier, id 
 		return 0, fmt.Errorf("failed to marshal state: %w", err)
 	}
 	customCols, customVals := s.customColumns(ctxData, encodeValuePg)
+	if s.contextColumn != "" {
+		ctxJSON, err := encodeContextJSON(ctxData)
+		if err != nil {
+			return 0, err
+		}
+		customCols = append([]string{s.contextColumn}, customCols...)
+		customVals = append([]any{ctxJSON}, customVals...)
+	}
 
 	if expectedVersion <= 0 {
 		columns := append([]string{s.idColumn, s.stateColumn, s.versionColumn}, customCols...)

--- a/storage/sqlite.go
+++ b/storage/sqlite.go
@@ -42,6 +42,9 @@ func (s *SQLiteStorage) GenerateSchema() string {
 		fmt.Sprintf("%s TEXT NOT NULL", s.stateColumn),
 		fmt.Sprintf("%s INTEGER NOT NULL DEFAULT 0", s.versionColumn),
 	}
+	if s.contextColumn != "" {
+		columns = append(columns, fmt.Sprintf("%s TEXT NOT NULL DEFAULT '{}'", s.contextColumn))
+	}
 
 	for _, colDef := range s.customFields {
 		columns = append(columns, colDef)
@@ -76,9 +79,19 @@ func (s *SQLiteStorage) saveState(ctx context.Context, q querier, id string, mar
 		return fmt.Errorf("failed to marshal state: %w", err)
 	}
 
+	columns := []string{s.idColumn, s.stateColumn}
+	values := []any{id, stateJSON}
+	if s.contextColumn != "" {
+		ctxJSON, err := encodeContextJSON(ctxData)
+		if err != nil {
+			return err
+		}
+		columns = append(columns, s.contextColumn)
+		values = append(values, ctxJSON)
+	}
 	customCols, customVals := s.customColumns(ctxData, encodeValue)
-	columns := append([]string{s.idColumn, s.stateColumn}, customCols...)
-	values := append([]any{id, stateJSON}, customVals...)
+	columns = append(columns, customCols...)
+	values = append(values, customVals...)
 	placeholders := make([]string, len(columns))
 	for i := range placeholders {
 		placeholders[i] = "?"
@@ -131,6 +144,10 @@ func (s *SQLiteStorage) LoadStateTx(ctx context.Context, tx *sql.Tx, id string) 
 
 func (s *SQLiteStorage) loadState(ctx context.Context, q querier, id string) (workflow.Marking, map[string]any, error) {
 	columns := []string{s.stateColumn}
+	if s.contextColumn != "" {
+		columns = append(columns, s.contextColumn)
+	}
+	customStart := len(columns)
 	customFieldKeys := make([]string, 0, len(s.customFields))
 
 	for key, colDef := range s.customFields {
@@ -174,10 +191,19 @@ func (s *SQLiteStorage) loadState(ctx context.Context, q querier, id string) (wo
 		return nil, nil, fmt.Errorf("failed to unmarshal state: %w", err)
 	}
 
+	// The context column holds the full context map; custom-field columns are
+	// queryable projections of individual keys and are overlaid afterwards so
+	// their typed values (e.g. INTEGER int64) win over the JSON decoding.
 	context := make(map[string]any)
+	if s.contextColumn != "" {
+		context, err = decodeContextJSON(*(scanArgs[1].(*any)))
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 
 	for i, key := range customFieldKeys {
-		val := *(scanArgs[i+1].(*any))
+		val := *(scanArgs[customStart+i].(*any))
 
 		// Check if this is a JSON string that should be unmarshaled
 		// This handles fields like "roles" (arrays) and "nested" (maps) which are stored as JSON
@@ -289,6 +315,14 @@ func (s *SQLiteStorage) saveVersionedState(ctx context.Context, q querier, id st
 		return 0, fmt.Errorf("failed to marshal state: %w", err)
 	}
 	customCols, customVals := s.customColumns(ctxData, encodeValue)
+	if s.contextColumn != "" {
+		ctxJSON, err := encodeContextJSON(ctxData)
+		if err != nil {
+			return 0, err
+		}
+		customCols = append([]string{s.contextColumn}, customCols...)
+		customVals = append([]any{ctxJSON}, customVals...)
+	}
 
 	if expectedVersion <= 0 {
 		// Create a new row at version 1; do nothing if the id already exists so we

--- a/storagetest/storagetest.go
+++ b/storagetest/storagetest.go
@@ -19,6 +19,7 @@ package storagetest
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/ehabterra/workflow"
@@ -137,6 +138,34 @@ func Run(t *testing.T, newStore Factory) {
 				if v, _ := tok.Get("amount"); v != float64(250) {
 					t.Fatalf("token t2 amount = %v, want 250", v)
 				}
+			}
+		}
+	})
+
+	t.Run("FullContextRoundTrip", func(t *testing.T) {
+		ctx := context.Background()
+		store := newStore(t)
+
+		// Arbitrary keys — none pre-declared as custom-field columns — must
+		// survive the round-trip. JSON-encoded values may change type in the
+		// usual encoding/json ways (numbers come back as float64).
+		saved := map[string]any{
+			"requester": "alice",
+			"urgent":    true,
+			"amount":    float64(1250.5),
+			"tags":      []any{"travel", "q3"},
+			"approver":  map[string]any{"dept": "finance", "level": float64(2)},
+		}
+		if err := store.SaveState(ctx, "wf", mk("submitted"), saved); err != nil {
+			t.Fatalf("SaveState: %v", err)
+		}
+		_, got, err := store.LoadState(ctx, "wf")
+		if err != nil {
+			t.Fatalf("LoadState: %v", err)
+		}
+		for key, want := range saved {
+			if !reflect.DeepEqual(got[key], want) {
+				t.Errorf("context[%q] = %#v (%T), want %#v (%T)", key, got[key], got[key], want, want)
 			}
 		}
 	})

--- a/workflow.go
+++ b/workflow.go
@@ -60,6 +60,12 @@ type Storage interface {
 	// SaveState saves the workflow's marking and its context data for the given ID.
 	// The full marking is persisted, so data-carrying (colored) tokens round-trip;
 	// simple boolean workflows serialize to the compact place-array form.
+	//
+	// Implementations must persist the ENTIRE context map, so every key set via
+	// SetContext survives a save/load round-trip (JSON-encoded values may come
+	// back with adjusted types, e.g. numbers as float64). Silently persisting
+	// only a subset of keys is a contract violation; the storagetest conformance
+	// suite checks this.
 	SaveState(ctx context.Context, id string, marking Marking, context map[string]any) error
 
 	// DeleteState removes the workflow state for the given ID.

--- a/workflow.go
+++ b/workflow.go
@@ -3,9 +3,9 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"sync"
-	"sync/atomic"
 )
 
 // Workflow represents a workflow instance
@@ -14,8 +14,11 @@ type Workflow struct {
 	definition    *Definition
 	initialPlaces []Place
 	marking       Marking
-	listeners     map[EventType][]any
 	context       map[string]any
+
+	// listeners holds this instance's listeners. It carries its own lock, so
+	// listeners can be added or removed while transitions fire.
+	listeners listenerSet
 
 	manager *Manager // pointer to manager, may be nil
 	mu      sync.RWMutex
@@ -24,10 +27,6 @@ type Workflow struct {
 	// a VersionedStorage backend. It is 0 for a workflow that has never been
 	// persisted, and ignored by non-versioned backends.
 	version int64
-
-	// Handle tracking for reliable listener removal
-	listenerHandles map[uint64]int // handle ID -> index in slice
-	nextHandleID    uint64         // atomic counter for unique handle IDs
 }
 
 // Version returns the workflow's current optimistic-concurrency version. It is 0
@@ -151,14 +150,12 @@ func NewWorkflowFromMarking(name string, definition *Definition, initial Marking
 // passed separately (so the two can never drift apart).
 func newWorkflow(name string, definition *Definition, marking Marking) *Workflow {
 	return &Workflow{
-		name:            name,
-		definition:      definition,
-		initialPlaces:   marking.Places(),
-		marking:         marking,
-		listeners:       make(map[EventType][]any),
-		context:         make(map[string]any),
-		manager:         nil,
-		listenerHandles: make(map[uint64]int),
+		name:          name,
+		definition:    definition,
+		initialPlaces: marking.Places(),
+		marking:       marking,
+		context:       make(map[string]any),
+		manager:       nil,
 	}
 }
 
@@ -172,76 +169,28 @@ func (w *Workflow) Name() string {
 // AddEventListener adds an event listener for a specific event type
 // It returns a handle that can be used to remove the listener later
 func (w *Workflow) AddEventListener(eventType EventType, listener EventListener) *ListenerHandle {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	handleID := atomic.AddUint64(&w.nextHandleID, 1)
-	index := len(w.listeners[eventType])
-	w.listeners[eventType] = append(w.listeners[eventType], listener)
-	w.listenerHandles[handleID] = index
-
-	return &ListenerHandle{
-		id:        handleID,
-		eventType: eventType,
-		owner:     w,
-	}
+	return w.listeners.add(eventType, listener, w)
 }
 
 // AddGuardEventListener adds a guard event listener
 // It returns a handle that can be used to remove the listener later
 func (w *Workflow) AddGuardEventListener(listener GuardEventListener) *ListenerHandle {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	eventType := EventGuard
-	handleID := atomic.AddUint64(&w.nextHandleID, 1)
-	index := len(w.listeners[eventType])
-	w.listeners[eventType] = append(w.listeners[eventType], listener)
-	w.listenerHandles[handleID] = index
-
-	return &ListenerHandle{
-		id:        handleID,
-		eventType: eventType,
-		owner:     w,
-	}
+	return w.listeners.add(EventGuard, listener, w)
 }
 
 // RemoveListener removes a listener using its handle
 // This is the recommended way to remove listeners as it's reliable and efficient
 func (w *Workflow) RemoveListener(handle *ListenerHandle) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	if w.listenerHandles == nil || handle == nil {
+	if handle == nil || handle.owner != w {
 		return
 	}
+	w.listeners.remove(handle)
+}
 
-	// Verify the handle belongs to this workflow
-	if handle.owner != w {
-		return
-	}
-
-	index, ok := w.listenerHandles[handle.id]
-	if !ok {
-		return // Handle not found
-	}
-
-	listeners := w.listeners[handle.eventType]
-	if index >= len(listeners) {
-		return // Index out of bounds
-	}
-
-	// Remove from slice
-	w.listeners[handle.eventType] = append(listeners[:index], listeners[index+1:]...)
-
-	// Update indices for handles after the removed one
-	for id, idx := range w.listenerHandles {
-		if idx > index {
-			w.listenerHandles[id] = idx - 1
-		}
-	}
-
-	delete(w.listenerHandles, handle.id)
+// ListenerCount returns the number of listeners registered on this instance for
+// eventType (definition- and manager-level listeners are not counted).
+func (w *Workflow) ListenerCount(eventType EventType) int {
+	return w.listeners.count(eventType)
 }
 
 // SetContext sets a value in the workflow context
@@ -263,11 +212,16 @@ func (w *Workflow) Context(key string) (any, bool) {
 func (w *Workflow) AllContext() map[string]any {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	result := make(map[string]any)
-	for k, v := range w.context {
-		result[k] = v
-	}
-	return result
+	return maps.Clone(w.context)
+}
+
+// snapshotState returns a deep copy of the marking and a copy of the context
+// map, both taken under the read lock, so persistence never marshals live
+// state that a concurrent transition or SetContext could mutate mid-encode.
+func (w *Workflow) snapshotState() (Marking, map[string]any) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return cloneMarking(w.marking), maps.Clone(w.context)
 }
 
 // SetManager sets the manager pointer for this workflow
@@ -277,72 +231,32 @@ func (w *Workflow) SetManager(m *Manager) {
 	w.manager = m
 }
 
-// fireEvent fires listeners from definition, manager, and instance (in that order)
+// fireEvent fires listeners from definition, manager, and instance (in that
+// order). Listener slices are snapshotted by the concurrency-safe listenerSet,
+// and no workflow lock is held while calling user listeners, so listeners may
+// re-enter the workflow and may be added/removed concurrently.
 func (w *Workflow) fireEvent(event Event) error {
-	// Do not hold lock while calling user listeners to avoid deadlocks
 	eventType := event.Type()
 
+	w.mu.RLock()
+	definition := w.definition
+	manager := w.manager
+	w.mu.RUnlock()
+
 	// 1. Definition listeners
-	if w.definition != nil && w.definition.Listeners != nil {
-		for _, l := range w.definition.Listeners[eventType] {
-			switch eventType {
-			case EventGuard:
-				if gl, ok := l.(GuardEventListener); ok {
-					if err := gl(event.(*GuardEvent)); err != nil {
-						return err
-					}
-				}
-			default:
-				if el, ok := l.(EventListener); ok {
-					if err := el(event); err != nil {
-						return err
-					}
-				}
-			}
+	if definition != nil {
+		if err := dispatchListeners(definition.listeners.snapshot(eventType), event); err != nil {
+			return err
 		}
 	}
 	// 2. Manager listeners
-	w.mu.RLock()
-	manager := w.manager
-	w.mu.RUnlock()
-	if manager != nil && manager.Listeners != nil {
-		for _, l := range manager.Listeners[eventType] {
-			switch eventType {
-			case EventGuard:
-				if gl, ok := l.(GuardEventListener); ok {
-					if err := gl(event.(*GuardEvent)); err != nil {
-						return err
-					}
-				}
-			default:
-				if el, ok := l.(EventListener); ok {
-					if err := el(event); err != nil {
-						return err
-					}
-				}
-			}
+	if manager != nil {
+		if err := dispatchListeners(manager.listeners.snapshot(eventType), event); err != nil {
+			return err
 		}
 	}
-	w.mu.RLock()
-	listeners := w.listeners[eventType]
-	w.mu.RUnlock()
-	for _, l := range listeners {
-		switch eventType {
-		case EventGuard:
-			if gl, ok := l.(GuardEventListener); ok {
-				if err := gl(event.(*GuardEvent)); err != nil {
-					return err
-				}
-			}
-		default:
-			if el, ok := l.(EventListener); ok {
-				if err := el(event); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
+	// 3. Instance listeners
+	return dispatchListeners(w.listeners.snapshot(eventType), event)
 }
 
 // Can check if transition to target places is possible
@@ -531,6 +445,17 @@ func (w *Workflow) ApplyTransitionWithContext(ctx context.Context, transitionNam
 	}
 	w.mu.Lock()
 
+	// Re-verify enablement under the write lock: the lock was released to run
+	// guards and before-listeners, and a concurrent firing may have consumed the
+	// input places in the meantime. Without this, two racing calls could both
+	// pass the earlier check and both move (double-firing the boolean case, or
+	// producing a phantom uncolored token in the colored case).
+	for _, p := range from {
+		if !w.marking.HasPlace(p) {
+			return ErrTransitionNotAllowed
+		}
+	}
+
 	// Move tokens from the input places to the output places, preserving colored
 	// token data and leaving unrelated places untouched.
 	w.moveMarking(from, to)
@@ -611,6 +536,15 @@ func (w *Workflow) ApplyWithContext(ctx context.Context, targetPlaces []Place) e
 		return err
 	}
 	w.mu.Lock()
+
+	// Re-verify enablement under the write lock (see ApplyTransitionWithContext):
+	// a concurrent firing may have consumed the input places while the lock was
+	// released for the before-listeners.
+	for _, p := range from {
+		if !w.marking.HasPlace(p) {
+			return ErrTransitionNotAllowed
+		}
+	}
 
 	// Move tokens from the input places to the output places, preserving colored
 	// token data and leaving unrelated places untouched.


### PR DESCRIPTION
Part 1 of milestone M3 (see the rewritten ROADMAP.md on main). Fixes the two highest-ranked blockers from the post-M2 readiness audit.

## M3.1 — Full context persistence
Previously only keys pre-declared as custom-field columns survived a save/load round-trip; every other `SetContext` key was **silently dropped**. Both backends now persist the entire context map in an always-on JSON column (SQLite `TEXT`, Postgres `JSONB`; `WithContextColumn` to rename/disable). Custom-field columns remain as queryable projections and are overlaid on load so their natively-typed values win. The `Storage` contract now requires full-map persistence and `storagetest` enforces it (`FullContextRoundTrip`).

## M3.2 — Concurrency fixes
- **Check-then-move gap**: whole-marking `Apply*` released the lock to run guards/before-listeners between the enablement check and `moveMarking`; two racing calls could both fire (double-move, or a phantom uncolored token in the colored case). Enablement is now re-verified under the write lock.
- **Save vs. mutation race**: `Manager.SaveWorkflow`/`CreateWorkflow` handed the live context map and live marking to storage; now they persist a deep snapshot taken under the workflow lock.
- **Listener locking**: `Definition`/`Manager` listener maps were mutated and iterated with no locking. All three owners now share one concurrency-safe `listenerSet` (snapshot iteration, copy-on-write removal). Also fixes a latent cross-event-type handle-index corruption bug.

**Breaking (pre-1.0):** `Definition.Listeners` / `Manager.Listeners` exported fields removed; use `AddEventListener`/`RemoveListener`/`ListenerCount`.

## Tests
New `-race` regression suite: concurrent same-transition firing fires exactly once with no phantom token; save-vs-mutation; listener add/remove while firing; cross-type handle removal. Full suite + Postgres conformance (testcontainer) green; lint clean.

Remaining M3 tasks (fingerprint, error split, atomic execute, registry hygiene, ListIDs, doc hotfixes) will follow on this branch or separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow state now preserves the full context map across save/load operations, including nested values.
  * Database schemas for supported storage backends now include a dedicated context field.

* **Bug Fixes**
  * Improved transition handling under concurrent updates to avoid duplicate or phantom token results.
  * Listener add/remove operations are now safer under concurrency, with more reliable counts and event handling.
  * Saving workflow state now uses a safe snapshot to prevent races during concurrent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->