### PR TITLE
docs: move [Unreleased] entries under 0.8.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-07
+
+Rolls up all work since v0.0.2: storage truth & hardening (M0), crash-safe ACID
+storage (M1), Colored Petri Nets (M2), real-system correctness (M3), and
+host-driven timers (M4).
+
 ### Added
+- Release automation: pushing a `vX.Y.Z` tag re-runs the race-enabled test suite
+  against the tagged commit, extracts that version's section from this file, and
+  publishes a GitHub Release (`.github/workflows/release.yml`). Tagging without a
+  matching changelog section fails the release.
 - Crash-safe persistence (M1.1): `storage.RunInTx` plus `SaveStateTx`/`LoadStateTx`/
   `DeleteStateTx` on the SQLite storage and `SaveTransitionTx` on the SQLite history
   store. Callers can now commit a workflow state change and its history record in a


### PR DESCRIPTION
## Summary

Promotes everything under **[Unreleased]** to a new **## [0.8.0] - 2026-07-07** section (M0–M4 roll-up since v0.0.2) and adds an entry for the release automation itself. Unblocks the failed v0.8.0 release run: the workflow correctly refused to publish because the tagged commit had no `## [0.8.0]` changelog section.

After merging, the v0.8.0 tag must be moved to the merge commit so the Release workflow picks up the section (no release was published, so moving the tag is safe):

```sh
git fetch origin main
git tag -f v0.8.0 origin/main
git push origin :refs/tags/v0.8.0
git push origin v0.8.0
```

## Roadmap milestone

Release prep for v0.8.0 (M0–M4).

## Checklist

- [x] Docs-only change; extraction verified locally with the workflow's exact awk logic (151-line section extracted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.8.0, summarizing recent product updates and platform changes.
  * Documented improvements to persistence reliability, storage consistency, timer handling, and workflow state handling.
  * Noted updated upgrade requirements, including migration expectations and a required API change for persistence operations.
  * Recorded an increase in the minimum supported Go version and removed an outdated example database artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->