### PR TITLE
feat(dogfood): probe the library's limits — routing, cycles, manual review + UX pass

### DIFF
--- a/docs/roadmap/FRICTION.md
+++ b/docs/roadmap/FRICTION.md
@@ -92,6 +92,45 @@ workaround.
 - `WithClock`/explicit-`now` design meant zero sleeps anywhere in the tests.
 - The strict YAML loader caught every schema typo with a line number.
 
+## What is missing — ranked (the M5 answer)
+
+The dogfood app now exercises guards-from-context routing (XOR-split),
+cycles (revise/resubmit), per-token manual release, AND-split/join,
+timers, and the CPN batch — deliberately probing the library's limits.
+Priority order for what the library needs next, from what actually hurt:
+
+1. **Cancellation regions** (entries 1, and now the revise cycle). The
+   workaround graduated from "host checks a flag" to **host-side token
+   surgery**: `Revise` must `ClearPlace` six places by hand or round two
+   double-fires reviews and inherits round one's stale escalation deadline.
+   Every consumer with reject/timeout semantics on parallel branches will
+   have to reinvent this. Highest priority by a wide margin.
+
+2. **OR-input transitions** (entry 2). The escalation feature doubled the
+   approve/reject transitions; with the revise loop the duplication now
+   also infects every host-side action helper (`applyFirst` chains).
+
+3. **XOR-split routing primitive** (new). Guard-routed alternatives out of
+   one place (petty cash vs. review) work, but the host must try each
+   variant and interpret guard rejections (`routeSubmit`). An engine-level
+   "fire the enabled one of these" (free-choice conflict resolution) — or
+   just a documented recipe — belongs in the library.
+
+4. **`FireDue` side effects** (entry 4). Timer audit records are still
+   at-least-once while every interactive fire is exactly-once. Grows worse
+   as timers multiply.
+
+5. **Additive-change detection for fingerprints** (new). Adding `release`,
+   `revise`, and submit routing changed both nets' fingerprints; the
+   migration hook can only see two opaque hashes, so the host approves
+   blindly (safe here because the loader re-validates places — but the
+   hook can't distinguish "new transition added" from "place renamed").
+   A structural diff (places added/removed, transitions added/removed)
+   handed to the migration hook would make upgrade hooks trustworthy.
+
+6. **Creation seed** (entry 8) and **cross-instance recipes** (entry 5) —
+   real but tolerable with documented patterns.
+
 ## Verdict so far
 
 No bespoke persistence or scheduling layer was needed — the M5 exit

--- a/examples/expense_approval/README.md
+++ b/examples/expense_approval/README.md
@@ -75,12 +75,34 @@ in the *same transaction* as the state save (`app.go: fire`). The
 crash-consistency test injects a failing side effect and proves neither half
 lands. (Timer firings are the documented exception — see the friction log.)
 
+**Guards route, straight from context.** `submit` is an XOR-split decided
+by guard expressions over the workflow context: `amount <= 100.0` sends
+petty cash straight to `approved` (`submit_auto`), anything else into
+parallel review. No engine primitive picks the route — the host tries each
+variant and treats a guard rejection as "not this path" (`routeSubmit`),
+which is friction entry #3.
+
+**Cycles are just arcs too.** `revise` closes the loop: a rejected expense
+returns to `draft`, takes an updated amount, and re-routes through the
+submit guards — possibly straight to auto-approval. The catch is the
+cancellation-regions gap: the host must clear the stranded sibling branch's
+tokens BY HAND (`ClearPlace` × 6 in `Revise`) or round two double-fires and
+inherits round one's stale escalation deadline. That token surgery is the
+top-ranked finding in the friction log.
+
 **Colored tokens where entities flow together.** The payment net
 (`payment.yaml`) is the opposite modeling style: ONE long-lived instance,
 where every approved expense is a token carrying
-`{expense_id, amount, submitter}`. The batch run fires `pay` per token;
-the guard `token.amount <= 5000.0` holds big amounts in `payable` for manual
-review. Totals on the dashboard come from `AggregateTokens`.
+`{expense_id, amount, submitter}`. The batch run fires `pay` per token; the
+guard `token.amount <= 5000.0` holds big amounts in `payable`, and a
+reviewer pays those out individually with the `release` transition (manual
+review, reviewer recorded in the audit trail). Totals come from
+`AggregateTokens`.
+
+**Definitions evolve; the fingerprint notices.** Adding `release`/`revise`
+changed both nets' fingerprints, so the app installs a
+`WithDefinitionMigration` hook that approves the (additive) upgrades —
+and the loader still re-validates every loaded place afterwards.
 
 **What the library refuses to do for you** — and this app does explicitly:
 terminality on rejection (no cancellation regions yet; `ErrTerminal` in
@@ -94,13 +116,16 @@ go test -race ./...
 ```
 
 The tests are the acceptance criteria: escalation via a future-`now` tick
-(no sleeping), webhook redelivery dedup, reject terminality, the payment
-guard, crash consistency (state+history roll back together), concurrent
-approvals under optimistic-concurrency retry, restart resuming the fleet,
-reconcile repairing the documented crash windows (including deleting
-creation-crash drafts), the stranded-branch escalation staying harmless
-after a rejection, tick-vs-approve and batch-vs-batch races, and input
-validation (`Inf`/`NaN` amounts never reach storage).
+(no sleeping), webhook redelivery dedup, reject terminality, guard-routed
+auto-approval and its exact boundary, the revise/resubmit cycle (including
+the stranded-token surgery and a quiet due index afterwards), the payment
+guard plus manual release (idempotent, audited), crash consistency
+(state+history roll back together), concurrent approvals under
+optimistic-concurrency retry, restart resuming the fleet, reconcile
+repairing the documented crash windows (including deleting creation-crash
+drafts), the stranded-branch escalation staying harmless after a rejection,
+tick-vs-approve and batch-vs-batch races, and input validation (`Inf`/`NaN`
+amounts never reach storage).
 
 Set `EXPENSE_POSTGRES_DSN` to also run the lifecycle against PostgreSQL
 (CI does; it drops and recreates the app's tables — use a scratch

--- a/examples/expense_approval/app.go
+++ b/examples/expense_approval/app.go
@@ -12,7 +12,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -41,6 +43,15 @@ const paymentID = "payment-batch"
 // cancellation regions yet — see docs/DOGFOOD.md), so terminality is a host
 // rule enforced here.
 var ErrTerminal = errors.New("expense is already rejected")
+
+// ErrNotPayable is returned by ReleasePayment for an expense with no token in
+// the payment net's payable place (and none already paid out).
+var ErrNotPayable = errors.New("nothing to release")
+
+// payGuardLimit mirrors the payment net's pay guard (token.amount <= 5000.0):
+// amounts above it are held for manual release. Kept in one place so the UI
+// and PaymentStatus agree with the YAML guard.
+const payGuardLimit = 5000.0
 
 // schemaEnsurer is what both SQL storage backends provide beyond
 // workflow.Storage; the app only needs it at startup.
@@ -104,7 +115,18 @@ func NewApp(ctx context.Context, db *sql.DB, driver string, escalateAfter time.D
 
 	// Fresh loads on every request: correct across replicas, and the demo is
 	// nowhere near the scale where the registry cache would matter.
-	mgr := workflow.NewManager(workflow.NewRegistry(), store)
+	//
+	// The migration hook approves definition upgrades for both nets: every
+	// change so far has been additive (new transitions — release, revise,
+	// submit routing; no place was removed), so persisted markings stay
+	// valid — and the loader still validates every loaded place after the
+	// hook approves, so a marking that genuinely no longer fits fails
+	// anyway. A host removing places would need real migration logic here.
+	mgr := workflow.NewManager(workflow.NewRegistry(), store,
+		workflow.WithDefinitionMigration(func(ctx context.Context, id, stored, current string) error {
+			log.Printf("definition upgraded for %s (stored fingerprint %.8s… -> %.8s…): additive change, approving", id, stored, current)
+			return nil
+		}))
 
 	a := &App{
 		db:         db,
@@ -214,19 +236,87 @@ func (a *App) SubmitExpense(ctx context.Context, submitter, description string, 
 	if _, err := a.mgr.CreateWorkflow(ctx, id, a.expenseDef, "draft"); err != nil {
 		return "", fmt.Errorf("create expense: %w", err)
 	}
-	_, err = a.fire(ctx, id, a.expenseDef, submitter, func(wf *workflow.Workflow) ([]string, error) {
+	fired, err := a.fire(ctx, id, a.expenseDef, submitter, func(wf *workflow.Workflow) ([]string, error) {
 		wf.SetContext("submitter", submitter)
 		wf.SetContext("description", description)
 		wf.SetContext("amount", amount)
-		if err := wf.ApplyTransitionWithContext(ctx, "submit"); err != nil {
+		name, err := routeSubmit(ctx, wf)
+		if err != nil {
 			return nil, err
 		}
-		return []string{"submit"}, nil
+		return []string{name}, nil
 	})
 	if err != nil {
 		return "", err
 	}
+	// The petty-cash fast path lands directly in approved: queue it for the
+	// payment batch (crash window repaired by Reconcile, as with finalize).
+	if slices.Contains(fired, "submit_auto") {
+		if err := a.EnqueueApproved(ctx, id); err != nil {
+			log.Printf("enqueue auto-approved %s: %v (Reconcile will repair)", id, err)
+		}
+	}
 	return id, nil
+}
+
+// routeSubmit fires whichever submit variant the amount guard enables — the
+// XOR-split. There is no engine primitive for "fire the one enabled
+// transition out of this place" (friction-logged), so the host tries each
+// variant and treats a guard rejection as "not this route".
+func routeSubmit(ctx context.Context, wf *workflow.Workflow) (string, error) {
+	var lastErr error
+	for _, name := range []string{"submit_auto", "submit"} {
+		err := wf.ApplyTransitionWithContext(ctx, name)
+		if err == nil {
+			return name, nil
+		}
+		if !errors.Is(err, workflow.ErrTransitionNotAllowed) {
+			return "", err
+		}
+		lastErr = err
+	}
+	return "", fmt.Errorf("no submit route accepted the expense: %w", lastErr)
+}
+
+// Revise closes the loop on a rejection: the submitter updates the expense
+// and resubmits. The net's revise transition moves rejected back to draft —
+// but the sibling branch's stranded token (no cancellation regions) must be
+// cleared BY HAND here, or round two would double-fire reviews and inherit a
+// stale escalation deadline. This token surgery is exactly the friction the
+// cancellation-regions milestone exists for (docs/roadmap/FRICTION.md).
+func (a *App) Revise(ctx context.Context, id, actor, description string, amount float64) ([]string, error) {
+	if math.IsNaN(amount) || math.IsInf(amount, 0) || amount <= 0 || amount > 1e12 {
+		return nil, errors.New("amount must be a positive number")
+	}
+	fired, err := a.fire(ctx, id, a.expenseDef, actor, func(wf *workflow.Workflow) ([]string, error) {
+		if !hasPlace(wf, "rejected") {
+			return nil, fmt.Errorf("%w: only a rejected expense can be revised", workflow.ErrNotEnabled)
+		}
+		if err := wf.ApplyTransitionWithContext(ctx, "revise"); err != nil {
+			return nil, err
+		}
+		for _, p := range []workflow.Place{"pending_legal", "pending_finance", "escalated_legal", "escalated_finance", "legal_ok", "finance_ok"} {
+			wf.ClearPlace(p) // cancel the stranded round-one review tokens
+		}
+		wf.SetContext("amount", amount)
+		if description = strings.TrimSpace(description); description != "" {
+			wf.SetContext("description", description)
+		}
+		name, err := routeSubmit(ctx, wf)
+		if err != nil {
+			return nil, err
+		}
+		return []string{"revise", name}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if slices.Contains(fired, "submit_auto") {
+		if err := a.EnqueueApproved(ctx, id); err != nil {
+			log.Printf("enqueue auto-approved %s: %v (Reconcile will repair)", id, err)
+		}
+	}
+	return fired, nil
 }
 
 // Approve fires the branch's approve transition (from pending or escalated,
@@ -358,6 +448,67 @@ func (a *App) RunBatch(ctx context.Context, actor string) (*BatchResult, error) 
 	}
 	res.Elapsed = a.now().Sub(start)
 	return res, nil
+}
+
+// ReleasePayment is the manual-review path for a guard-held token: a reviewer
+// pays out one expense's token explicitly, bypassing the batch guard, with
+// the reviewer recorded in the audit trail. Releasing an expense that is not
+// in payable returns ErrNotPayable (already paid = redelivery no-op for the
+// caller to map; never enqueued = genuine error).
+func (a *App) ReleasePayment(ctx context.Context, expenseID, actor string) error {
+	released := false
+	_, err := a.fire(ctx, paymentID, a.paymentDef, actor, func(wf *workflow.Workflow) ([]string, error) {
+		released = false
+		for _, tok := range wf.GetTokens("payable") {
+			if id, ok := tokenExpenseID(tok); ok && id == expenseID {
+				if err := wf.ApplyTransitionForToken(ctx, "release", tok.ID()); err != nil {
+					return nil, err
+				}
+				released = true
+				return []string{"release"}, nil
+			}
+		}
+		// Not in payable: distinguish "already paid out" from "never there".
+		for _, tok := range wf.GetTokens("paid_out") {
+			if id, ok := tokenExpenseID(tok); ok && id == expenseID {
+				return nil, nil // already paid: idempotent no-op
+			}
+		}
+		return nil, fmt.Errorf("%w: expense %s has no payable token", ErrNotPayable, expenseID)
+	})
+	if err != nil {
+		return err
+	}
+	if released {
+		return a.markPaid(ctx, expenseID)
+	}
+	return nil
+}
+
+// PaymentStatus reports where an expense stands in the payment net:
+// "queued", "held" (guard will hold it; needs manual release), "paid", or ""
+// (not enqueued).
+func (a *App) PaymentStatus(ctx context.Context, expenseID string) (string, error) {
+	wf, err := a.mgr.LoadWorkflow(ctx, paymentID, a.paymentDef)
+	if err != nil {
+		return "", err
+	}
+	for _, tok := range wf.GetTokens("payable") {
+		if id, ok := tokenExpenseID(tok); ok && id == expenseID {
+			if v, ok := tok.Get("amount"); ok {
+				if amt, ok := v.(float64); ok && amt > payGuardLimit {
+					return "held", nil
+				}
+			}
+			return "queued", nil
+		}
+	}
+	for _, tok := range wf.GetTokens("paid_out") {
+		if id, ok := tokenExpenseID(tok); ok && id == expenseID {
+			return "paid", nil
+		}
+	}
+	return "", nil
 }
 
 func (a *App) markPaid(ctx context.Context, id string) error {

--- a/examples/expense_approval/flows_test.go
+++ b/examples/expense_approval/flows_test.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ehabterra/workflow"
+	"github.com/ehabterra/workflow/history"
+)
+
+// TestAutoApprovePettyCash: the guard-routed fast path. Amounts <= 100 skip
+// review entirely (submit_auto), land in approved, queue for payment, and
+// the batch pays them.
+func TestAutoApprovePettyCash(t *testing.T) {
+	app, _ := newTestApp(t)
+	ctx := context.Background()
+	id := mustSubmit(t, app, "alice", 50)
+
+	view, err := app.Expense(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !view.Has("approved") {
+		t.Fatalf("petty cash must auto-approve, marking %v", view.Places)
+	}
+	status, err := app.PaymentStatus(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != "queued" {
+		t.Fatalf("auto-approved expense must be queued for payment, got %q", status)
+	}
+
+	res, err := app.RunBatch(ctx, "op")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Paid) != 1 || res.Paid[0] != id {
+		t.Fatalf("batch must pay the petty-cash expense, got %+v", res)
+	}
+
+	recs, err := app.hist.ListHistory(ctx, id, history.QueryOptions{Transition: "submit_auto"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("want a submit_auto audit record, got %d", len(recs))
+	}
+}
+
+// TestSubmitRoutingBoundary pins the guard boundary: exactly 100 is petty
+// cash, a cent more goes to review.
+func TestSubmitRoutingBoundary(t *testing.T) {
+	app, _ := newTestApp(t)
+	ctx := context.Background()
+
+	atLimit := mustSubmit(t, app, "alice", 100)
+	view, err := app.Expense(ctx, atLimit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !view.Has("approved") {
+		t.Fatalf("100.00 must auto-approve, marking %v", view.Places)
+	}
+
+	over := mustSubmit(t, app, "alice", 100.01)
+	view, err = app.Expense(ctx, over)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !view.Has("pending_legal") || !view.Has("pending_finance") {
+		t.Fatalf("100.01 must go to parallel review, marking %v", view.Places)
+	}
+}
+
+// TestReviseAfterRejection drives the loop edge of the net: reject, let the
+// stranded sibling escalate (cancellation-regions gap), then revise. The
+// revision must clear the stranded round-one tokens by hand, quiet the due
+// index, update the amount, and re-route through the submit guards — here to
+// the petty-cash fast path.
+func TestReviseAfterRejection(t *testing.T) {
+	app, _ := newTestApp(t)
+	ctx := context.Background()
+	id := mustSubmit(t, app, "bob", 300)
+
+	if _, err := app.Reject(ctx, id, "legal", "lawyer"); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+	// Round one's finance token is stranded; its timer still fires.
+	later := time.Now().Add(73 * time.Hour)
+	if _, err := app.Tick(ctx, later); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	fired, err := app.Revise(ctx, id, "bob", "cheaper option", 90)
+	if err != nil {
+		t.Fatalf("revise: %v", err)
+	}
+	if !contains(fired, "revise") || !contains(fired, "submit_auto") {
+		t.Fatalf("revise must re-route to the fast path, fired %v", fired)
+	}
+
+	view, err := app.Expense(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !view.Has("approved") || view.Amount != 90 {
+		t.Fatalf("want approved at 90 after revision, got %v amount %.2f", view.Places, view.Amount)
+	}
+	// The token surgery must leave no round-one residue.
+	for _, p := range []string{"rejected", "pending_finance", "escalated_finance", "pending_legal", "escalated_legal"} {
+		if view.Has(p) {
+			t.Fatalf("stranded round-one token survived revision in %s: %v", p, view.Places)
+		}
+	}
+	// And the due index must be quiet — no zombie escalation from round one.
+	fired2, err := app.Tick(ctx, later.Add(200*time.Hour))
+	if err != nil {
+		t.Fatalf("tick after revise: %v", err)
+	}
+	if len(fired2) != 0 {
+		t.Fatalf("no timers may fire after revision cleared the branches, got %v", fired2)
+	}
+
+	// Revising a non-rejected expense is refused.
+	if _, err := app.Revise(ctx, id, "bob", "", 50); !errors.Is(err, workflow.ErrNotEnabled) {
+		t.Fatalf("revise on a non-rejected expense: want ErrNotEnabled, got %v", err)
+	}
+}
+
+// TestReviseBackToReview: a revision above the petty-cash limit goes through
+// full parallel review again — the cycle can run more than once.
+func TestReviseBackToReview(t *testing.T) {
+	app, _ := newTestApp(t)
+	ctx := context.Background()
+	id := mustSubmit(t, app, "carol", 800)
+	if _, err := app.Reject(ctx, id, "finance", "cfo"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.Revise(ctx, id, "carol", "with receipts this time", 750); err != nil {
+		t.Fatal(err)
+	}
+	view, err := app.Expense(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !view.Has("pending_legal") || !view.Has("pending_finance") {
+		t.Fatalf("revision above the limit must re-enter review, marking %v", view.Places)
+	}
+	// Round two is fully operable: reject again, revise again.
+	if _, err := app.Reject(ctx, id, "legal", "lawyer"); err != nil {
+		t.Fatalf("round-two reject: %v", err)
+	}
+	if _, err := app.Revise(ctx, id, "carol", "", 60); err != nil {
+		t.Fatalf("round-two revise: %v", err)
+	}
+	view, _ = app.Expense(ctx, id)
+	if !view.Has("approved") {
+		t.Fatalf("round-three fast path must approve, marking %v", view.Places)
+	}
+}
+
+// TestReleaseHeldPayment: the manual-review path for guard-held payouts.
+func TestReleaseHeldPayment(t *testing.T) {
+	app, _ := newTestApp(t)
+	ctx := context.Background()
+	id := mustSubmit(t, app, "dave", 9000)
+	for _, branch := range []string{"legal", "finance"} {
+		if _, err := app.Approve(ctx, id, branch, branch); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := app.EnqueueApproved(ctx, id); err != nil {
+		t.Fatal(err)
+	}
+
+	// The batch holds it; status says so.
+	res, err := app.RunBatch(ctx, "op")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Paid) != 0 || res.Held != 1 {
+		t.Fatalf("batch must hold the 9000 token, got %+v", res)
+	}
+	if status, _ := app.PaymentStatus(ctx, id); status != "held" {
+		t.Fatalf("want status held, got %q", status)
+	}
+
+	// Manual release pays it out and advances the expense.
+	if err := app.ReleasePayment(ctx, id, "cfo"); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if status, _ := app.PaymentStatus(ctx, id); status != "paid" {
+		t.Fatalf("want status paid after release, got %q", status)
+	}
+	view, err := app.Expense(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !view.Has("paid") {
+		t.Fatalf("expense must be paid after release, marking %v", view.Places)
+	}
+	// The reviewer is on the record.
+	recs, err := app.hist.ListHistory(ctx, paymentID, history.QueryOptions{Transition: "release"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 1 || recs[0].Actor != "cfo" {
+		t.Fatalf("release must be audited with the reviewer, got %+v", recs)
+	}
+
+	// Releasing again is an idempotent no-op; releasing something that was
+	// never enqueued is a real error.
+	if err := app.ReleasePayment(ctx, id, "cfo"); err != nil {
+		t.Fatalf("redelivered release must no-op, got %v", err)
+	}
+	other := mustSubmit(t, app, "erin", 200)
+	if err := app.ReleasePayment(ctx, other, "cfo"); !errors.Is(err, ErrNotPayable) {
+		t.Fatalf("release of a non-enqueued expense: want ErrNotPayable, got %v", err)
+	}
+}
+
+// TestReleaseAndReviseHTTP drives the new endpoints through the real HTTP
+// surface, including flash redirects for browsers.
+func TestReleaseAndReviseHTTP(t *testing.T) {
+	ts, _ := newTestServer(t)
+	id := submitViaHTTP(t, ts, "frank", "7500")
+	for _, branch := range []string{"legal", "finance"} {
+		postForm(t, ts.URL+"/expenses/"+id+"/approve", url.Values{"branch": {branch}})
+	}
+	postForm(t, ts.URL+"/batch/run", nil)
+
+	// The batch page shows the held token with its release control.
+	resp, err := http.Get(ts.URL + "/batch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !strings.Contains(string(page), "held by guard") || !strings.Contains(string(page), "/payments/"+id+"/release") {
+		t.Fatalf("batch page must offer release for the held token:\n%s", page)
+	}
+
+	code, body := postForm(t, ts.URL+"/payments/"+id+"/release", url.Values{"actor": {"cfo"}})
+	if code != http.StatusOK || !strings.Contains(body, "Released payment for "+id) {
+		t.Fatalf("release: %d %q", code, body)
+	}
+	code, _ = postForm(t, ts.URL+"/payments/exp-nope/release", nil)
+	if code != http.StatusConflict {
+		t.Fatalf("release of unknown expense: want 409, got %d", code)
+	}
+
+	// A browser gets a redirect carrying the flash message.
+	req, _ := http.NewRequest("POST", ts.URL+"/expenses/"+id+"/reject", strings.NewReader("branch=legal"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "text/html")
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther || !strings.Contains(resp.Header.Get("Location"), "flash=") {
+		t.Fatalf("browser action must redirect with flash, got %d %q", resp.StatusCode, resp.Header.Get("Location"))
+	}
+
+	// Revise over HTTP: paid expense can't be revised…
+	code, _ = postForm(t, ts.URL+"/expenses/"+id+"/revise", url.Values{"amount": {"50"}})
+	if code != http.StatusConflict {
+		t.Fatalf("revise of a paid expense: want 409, got %d", code)
+	}
+	// …but a rejected one can.
+	id2 := submitViaHTTP(t, ts, "grace", "400")
+	postForm(t, ts.URL+"/expenses/"+id2+"/reject", url.Values{"branch": {"legal"}})
+	code, body = postForm(t, ts.URL+"/expenses/"+id2+"/revise", url.Values{"amount": {"80"}, "actor": {"grace"}})
+	if code != http.StatusOK || !strings.Contains(body, "auto-approved") {
+		t.Fatalf("revise to petty cash: %d %q", code, body)
+	}
+}
+
+// TestDashboardFilter: the stat chips filter the fleet by state.
+func TestDashboardFilter(t *testing.T) {
+	ts, _ := newTestServer(t)
+	small := submitViaHTTP(t, ts, "alice", "40") // auto-approved
+	large := submitViaHTTP(t, ts, "bob", "4000") // in review
+
+	resp, err := http.Get(ts.URL + "/?state=approved")
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !strings.Contains(string(page), small) || strings.Contains(string(page), large) {
+		t.Fatalf("filter must show only approved expenses (want %s, not %s):\n%s", small, large, page)
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/examples/expense_approval/payment.yaml
+++ b/examples/expense_approval/payment.yaml
@@ -1,8 +1,9 @@
 # The payment net: ONE long-lived instance for the whole system (the
 # CPN-flavored component). Every approved expense becomes a colored token in
 # `payable` carrying {expense_id, amount, submitter}; the batch run fires
-# `pay` per token. The guard holds back large amounts for manual review —
-# those tokens simply stay in `payable`.
+# `pay` per token. The guard holds back large amounts — those tokens stay in
+# `payable` until a reviewer fires `release` on them individually (manual
+# review, actor recorded in the audit trail).
 #
 # `batch_control` holds a permanent presence token: a persisted marking must
 # contain at least one place, so a net whose real places can all be empty
@@ -19,3 +20,9 @@ workflow:
       from: [payable]
       to: [paid_out]
       guard: "token.amount <= 5000.0"
+    - name: release
+      from: [payable]
+      to: [paid_out]
+      metadata:
+        manual: true
+        description: reviewer-approved payout of a guard-held token

--- a/examples/expense_approval/robustness_test.go
+++ b/examples/expense_approval/robustness_test.go
@@ -25,7 +25,7 @@ import (
 func TestStrandedBranchEscalatesHarmlessly(t *testing.T) {
 	app, _ := newTestApp(t)
 	ctx := context.Background()
-	id := mustSubmit(t, app, "alice", 100)
+	id := mustSubmit(t, app, "alice", 150)
 
 	if _, err := app.Reject(ctx, id, "legal", "lawyer"); err != nil {
 		t.Fatalf("reject: %v", err)

--- a/examples/expense_approval/server.go
+++ b/examples/expense_approval/server.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -18,31 +19,32 @@ import (
 var templateFS embed.FS
 
 // Server is the thin web layer over App: server-rendered pages plus the
-// webhook-style approve/reject endpoints an external system would call.
+// webhook-style endpoints an external system would call.
 type Server struct {
 	app  *App
 	tmpl *template.Template
 	mux  *http.ServeMux
 }
 
-// NewServer builds the routes. Pages: dashboard, submit form, expense
-// detail, batch page. Endpoints: approve/reject webhooks, batch run,
-// reconcile, metrics.
+// NewServer builds the routes. Pages: dashboard (filterable), submit form,
+// expense detail (lanes, payment status, revise), batch page (with manual
+// release of guard-held payouts). Endpoints: approve/reject/revise webhooks,
+// payment release, batch run, reconcile, metrics, healthz.
 func NewServer(app *App) (*Server, error) {
 	tmpl, err := template.New("").Funcs(template.FuncMap{
 		"money": func(v float64) string { return fmt.Sprintf("%.2f", v) },
 		// stateClass turns a state label into a CSS class suffix
 		// ("in review" -> "in-review").
 		"stateClass": func(s string) string { return strings.ReplaceAll(s, " ", "-") },
-		// held mirrors the payment net's guard (token.amount <= 5000.0) so
-		// the batch page can flag tokens the run will hold back.
+		// held mirrors the payment net's guard so the batch page can flag
+		// tokens the run will hold back.
 		"held": func(t workflow.Token) bool {
 			v, ok := t.Get("amount")
 			if !ok {
 				return false
 			}
 			f, ok := v.(float64)
-			return ok && f > 5000
+			return ok && f > payGuardLimit
 		},
 		"tokenField": func(t workflow.Token, key string) string {
 			v, ok := t.Get(key)
@@ -58,6 +60,18 @@ func NewServer(app *App) (*Server, error) {
 				return fmt.Sprint(v)
 			}
 		},
+		// deadline humanizes an absolute next-due instant relative to now.
+		"deadline": func(t *time.Time) string {
+			if t == nil {
+				return "—"
+			}
+			d := time.Until(*t)
+			if d < 0 {
+				return "overdue " + humanDur(-d)
+			}
+			return "in " + humanDur(d)
+		},
+		"overdue": func(t *time.Time) bool { return t != nil && time.Now().After(*t) },
 	}).ParseFS(templateFS, "templates/*.html")
 	if err != nil {
 		return nil, err
@@ -70,12 +84,38 @@ func NewServer(app *App) (*Server, error) {
 	s.mux.HandleFunc("GET /expenses/{id}", s.expenseDetail)
 	s.mux.HandleFunc("POST /expenses/{id}/approve", s.decision("approve"))
 	s.mux.HandleFunc("POST /expenses/{id}/reject", s.decision("reject"))
+	s.mux.HandleFunc("POST /expenses/{id}/revise", s.revise)
+	s.mux.HandleFunc("POST /payments/{id}/release", s.releasePayment)
 	s.mux.HandleFunc("GET /batch", s.batchPage)
 	s.mux.HandleFunc("POST /batch/run", s.runBatch)
 	s.mux.HandleFunc("POST /batch/reconcile", s.reconcile)
 	s.mux.HandleFunc("GET /metrics", s.metrics)
 	s.mux.HandleFunc("GET /healthz", s.healthz)
 	return s, nil
+}
+
+// humanDur renders a duration in at most two human units ("2d 3h", "5m").
+func humanDur(d time.Duration) string {
+	switch {
+	case d >= 24*time.Hour:
+		days := d / (24 * time.Hour)
+		hours := (d % (24 * time.Hour)) / time.Hour
+		if hours == 0 {
+			return fmt.Sprintf("%dd", days)
+		}
+		return fmt.Sprintf("%dd %dh", days, hours)
+	case d >= time.Hour:
+		h := d / time.Hour
+		m := (d % time.Hour) / time.Minute
+		if m == 0 {
+			return fmt.Sprintf("%dh", h)
+		}
+		return fmt.Sprintf("%dh %dm", h, m)
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm", d/time.Minute)
+	default:
+		return fmt.Sprintf("%ds", d/time.Second)
+	}
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -98,11 +138,32 @@ func (r *statusRecorder) WriteHeader(code int) {
 	r.ResponseWriter.WriteHeader(code)
 }
 
-func (s *Server) render(w http.ResponseWriter, name string, data any) {
+func (s *Server) render(w http.ResponseWriter, name string, data map[string]any) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := s.tmpl.ExecuteTemplate(w, name, data); err != nil {
 		log.Printf("render %s: %v", name, err)
 	}
+}
+
+// wantsHTML reports whether the caller is a browser (form navigation) rather
+// than a webhook/API client; browsers get redirects with flash feedback.
+func wantsHTML(r *http.Request) bool {
+	return strings.Contains(r.Header.Get("Accept"), "text/html")
+}
+
+// respond answers an action: browsers are redirected to `back` with the
+// message as a flash banner; API callers get the status code and plain text.
+func (s *Server) respond(w http.ResponseWriter, r *http.Request, back string, code int, msg string) {
+	if wantsHTML(r) {
+		sep := "?"
+		if strings.Contains(back, "?") {
+			sep = "&"
+		}
+		http.Redirect(w, r, back+sep+"flash="+url.QueryEscape(msg), http.StatusSeeOther)
+		return
+	}
+	w.WriteHeader(code)
+	fmt.Fprintln(w, msg)
 }
 
 func (s *Server) dashboard(w http.ResponseWriter, r *http.Request) {
@@ -120,15 +181,29 @@ func (s *Server) dashboard(w http.ResponseWriter, r *http.Request) {
 	for _, v := range views {
 		stats[v.State]++
 	}
+	// Optional state filter (the stat chips double as filters).
+	filter := r.URL.Query().Get("state")
+	if filter != "" {
+		kept := views[:0]
+		for _, v := range views {
+			if v.State == filter {
+				kept = append(kept, v)
+			}
+		}
+		views = kept
+	}
 	s.render(w, "dashboard.html", map[string]any{
+		"Flash":    r.URL.Query().Get("flash"),
 		"Expenses": views,
 		"Payment":  payment,
 		"Stats":    stats,
+		"Filter":   filter,
+		"Refresh":  r.URL.Query().Get("refresh") != "",
 	})
 }
 
 func (s *Server) newExpenseForm(w http.ResponseWriter, r *http.Request) {
-	s.render(w, "new.html", nil)
+	s.render(w, "new.html", map[string]any{"Flash": r.URL.Query().Get("flash")})
 }
 
 func (s *Server) submitExpense(w http.ResponseWriter, r *http.Request) {
@@ -142,7 +217,7 @@ func (s *Server) submitExpense(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	http.Redirect(w, r, "/expenses/"+id, http.StatusSeeOther)
+	s.respond(w, r, "/expenses/"+id, http.StatusOK, "Expense "+id+" submitted")
 }
 
 func (s *Server) expenseDetail(w http.ResponseWriter, r *http.Request) {
@@ -155,13 +230,22 @@ func (s *Server) expenseDetail(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	s.render(w, "detail.html", view)
+	payStatus, err := s.app.PaymentStatus(r.Context(), view.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.render(w, "detail.html", map[string]any{
+		"Flash":     r.URL.Query().Get("flash"),
+		"V":         view,
+		"PayStatus": payStatus,
+	})
 }
 
 // decision is the webhook endpoint for approve/reject. Its status codes are
 // the point of the M3.4 error split:
 //
-//	200 fired            — the decision advanced the workflow
+//	200 fired             — the decision advanced the workflow
 //	200 already-processed — redelivery: ErrNotEnabled, safe no-op
 //	409 terminal          — the expense was already rejected
 //	403 guard-rejected    — a guard refused the transition
@@ -174,6 +258,7 @@ func (s *Server) decision(action string) http.HandlerFunc {
 		if actor == "" {
 			actor = branch + "-reviewer"
 		}
+		back := "/expenses/" + id
 		var fired []string
 		var err error
 		if action == "approve" {
@@ -192,31 +277,75 @@ func (s *Server) decision(action string) http.HandlerFunc {
 					}
 				}
 			}
-			s.respond(w, r, id, http.StatusOK, fmt.Sprintf("fired %s", strings.Join(fired, ", ")))
+			s.respond(w, r, back, http.StatusOK, "Fired "+strings.Join(fired, ", ")+" as "+actor)
 		case errors.Is(err, workflow.ErrWorkflowNotFound):
 			http.NotFound(w, r)
 		case errors.Is(err, ErrTerminal):
-			s.respond(w, r, id, http.StatusConflict, "expense already rejected")
+			s.respond(w, r, back, http.StatusConflict, "Expense already rejected — revise it to resubmit")
 		case errors.Is(err, workflow.ErrGuardRejected):
-			s.respond(w, r, id, http.StatusForbidden, "guard rejected the transition")
+			s.respond(w, r, back, http.StatusForbidden, "A guard rejected the transition")
 		case errors.Is(err, workflow.ErrNotEnabled):
 			// Redelivered webhook: the branch already moved on. Idempotent.
-			s.respond(w, r, id, http.StatusOK, "already processed (no-op)")
+			s.respond(w, r, back, http.StatusOK, "Already processed (no-op)")
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}
 }
 
-// respond redirects browsers back to the detail page and answers API
-// callers (curl, webhook senders) with a plain-text status.
-func (s *Server) respond(w http.ResponseWriter, r *http.Request, id string, code int, msg string) {
-	if strings.Contains(r.Header.Get("Accept"), "text/html") {
-		http.Redirect(w, r, "/expenses/"+id, http.StatusSeeOther)
+// revise resubmits a rejected expense with an updated amount/description —
+// the loop edge of the net (rejected -> draft -> submit routing).
+func (s *Server) revise(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	actor := r.FormValue("actor")
+	if actor == "" {
+		actor = "submitter"
+	}
+	amount, err := strconv.ParseFloat(strings.TrimSpace(r.FormValue("amount")), 64)
+	if err != nil {
+		http.Error(w, "amount must be a number", http.StatusBadRequest)
 		return
 	}
-	w.WriteHeader(code)
-	fmt.Fprintln(w, msg)
+	back := "/expenses/" + id
+	fired, err := s.app.Revise(r.Context(), id, actor, r.FormValue("description"), amount)
+	switch {
+	case err == nil:
+		msg := "Resubmitted for review"
+		for _, n := range fired {
+			if n == "submit_auto" {
+				msg = "Resubmitted and auto-approved (petty cash)"
+			}
+		}
+		s.respond(w, r, back, http.StatusOK, msg)
+	case errors.Is(err, workflow.ErrWorkflowNotFound):
+		http.NotFound(w, r)
+	case errors.Is(err, workflow.ErrNotEnabled):
+		s.respond(w, r, back, http.StatusConflict, "Only a rejected expense can be revised")
+	default:
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+}
+
+// releasePayment is the manual-review action for a guard-held payout.
+func (s *Server) releasePayment(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	actor := r.FormValue("actor")
+	if actor == "" {
+		actor = "payment-reviewer"
+	}
+	back := r.FormValue("back")
+	if back == "" {
+		back = "/batch"
+	}
+	err := s.app.ReleasePayment(r.Context(), id, actor)
+	switch {
+	case err == nil:
+		s.respond(w, r, back, http.StatusOK, "Released payment for "+id+" as "+actor)
+	case errors.Is(err, ErrNotPayable):
+		s.respond(w, r, back, http.StatusConflict, "Nothing to release for "+id)
+	default:
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func (s *Server) batchPage(w http.ResponseWriter, r *http.Request) {
@@ -225,7 +354,10 @@ func (s *Server) batchPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	s.render(w, "batch.html", payment)
+	s.render(w, "batch.html", map[string]any{
+		"Flash": r.URL.Query().Get("flash"),
+		"P":     payment,
+	})
 }
 
 func (s *Server) runBatch(w http.ResponseWriter, r *http.Request) {
@@ -238,11 +370,8 @@ func (s *Server) runBatch(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if strings.Contains(r.Header.Get("Accept"), "text/html") {
-		http.Redirect(w, r, "/batch", http.StatusSeeOther)
-		return
-	}
-	fmt.Fprintf(w, "paid %d expense(s), %d held by guard\n", len(res.Paid), res.Held)
+	msg := fmt.Sprintf("paid %d expense(s), %d held by guard", len(res.Paid), res.Held)
+	s.respond(w, r, "/batch", http.StatusOK, msg)
 }
 
 func (s *Server) reconcile(w http.ResponseWriter, r *http.Request) {
@@ -251,22 +380,9 @@ func (s *Server) reconcile(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if strings.Contains(r.Header.Get("Accept"), "text/html") {
-		http.Redirect(w, r, "/batch", http.StatusSeeOther)
-		return
-	}
-	fmt.Fprintf(w, "reconciled: %d enqueued, %d marked paid, %d stale draft(s) deleted\n",
+	msg := fmt.Sprintf("reconciled: %d enqueued, %d marked paid, %d stale draft(s) deleted",
 		rep.Enqueued, rep.Marked, rep.DraftsDeleted)
-}
-
-// healthz answers liveness/readiness probes: 200 when the database
-// responds, 503 otherwise.
-func (s *Server) healthz(w http.ResponseWriter, r *http.Request) {
-	if err := s.app.db.PingContext(r.Context()); err != nil {
-		http.Error(w, "database unreachable", http.StatusServiceUnavailable)
-		return
-	}
-	fmt.Fprintln(w, "ok")
+	s.respond(w, r, "/batch", http.StatusOK, msg)
 }
 
 func (s *Server) metrics(w http.ResponseWriter, r *http.Request) {
@@ -274,4 +390,14 @@ func (s *Server) metrics(w http.ResponseWriter, r *http.Request) {
 	for _, c := range s.app.metrics.snapshot() {
 		fmt.Fprintf(w, "workflow_firings_total{transition=%q} %d\n", c.Name, c.Count)
 	}
+}
+
+// healthz answers liveness/readiness probes: 200 when the database responds,
+// 503 otherwise.
+func (s *Server) healthz(w http.ResponseWriter, r *http.Request) {
+	if err := s.app.db.PingContext(r.Context()); err != nil {
+		http.Error(w, "database unreachable", http.StatusServiceUnavailable)
+		return
+	}
+	fmt.Fprintln(w, "ok")
 }

--- a/examples/expense_approval/server_test.go
+++ b/examples/expense_approval/server_test.go
@@ -36,25 +36,21 @@ func postForm(t *testing.T, url string, form url.Values) (int, string) {
 
 func submitViaHTTP(t *testing.T, ts *httptest.Server, submitter, amount string) string {
 	t.Helper()
-	// Don't follow the redirect: the Location header carries the new ID.
-	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
-	}}
-	resp, err := client.PostForm(ts.URL+"/expenses", url.Values{
+	// API callers (no html Accept header) get a plain-text confirmation
+	// carrying the new ID: "Expense exp-xxxxxxxx submitted".
+	code, body := postForm(t, ts.URL+"/expenses", url.Values{
 		"submitter":   {submitter},
 		"description": {"via http"},
 		"amount":      {amount},
 	})
-	if err != nil {
-		t.Fatalf("submit: %v", err)
+	if code != http.StatusOK {
+		t.Fatalf("submit: status %d: %s", code, body)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusSeeOther {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("submit: status %d: %s", resp.StatusCode, body)
+	fields := strings.Fields(body)
+	if len(fields) < 2 || !strings.HasPrefix(fields[1], "exp-") {
+		t.Fatalf("submit response has no expense id: %q", body)
 	}
-	loc := resp.Header.Get("Location")
-	return strings.TrimPrefix(loc, "/expenses/")
+	return fields[1]
 }
 
 // TestFullLifecycle drives the real HTTP surface end to end: submit →
@@ -105,14 +101,14 @@ func TestFullLifecycle(t *testing.T) {
 // approval is a 200 no-op, not an error and not a double fire.
 func TestWebhookRedelivery(t *testing.T) {
 	ts, _ := newTestServer(t)
-	id := submitViaHTTP(t, ts, "bob", "80")
+	id := submitViaHTTP(t, ts, "bob", "800")
 
 	code, _ := postForm(t, ts.URL+"/expenses/"+id+"/approve", url.Values{"branch": {"legal"}})
 	if code != http.StatusOK {
 		t.Fatalf("first delivery: %d", code)
 	}
 	code, body := postForm(t, ts.URL+"/expenses/"+id+"/approve", url.Values{"branch": {"legal"}})
-	if code != http.StatusOK || !strings.Contains(body, "already processed") {
+	if code != http.StatusOK || !strings.Contains(body, "Already processed") {
 		t.Fatalf("redelivery must be a 200 no-op, got %d %q", code, body)
 	}
 }
@@ -121,7 +117,7 @@ func TestWebhookRedelivery(t *testing.T) {
 // closed — later decisions on either branch get 409.
 func TestRejectIsTerminal(t *testing.T) {
 	ts, _ := newTestServer(t)
-	id := submitViaHTTP(t, ts, "carol", "60")
+	id := submitViaHTTP(t, ts, "carol", "600")
 
 	code, body := postForm(t, ts.URL+"/expenses/"+id+"/reject", url.Values{"branch": {"legal"}})
 	if code != http.StatusOK || !strings.Contains(body, "legal_reject") {

--- a/examples/expense_approval/templates/batch.html
+++ b/examples/expense_approval/templates/batch.html
@@ -1,7 +1,8 @@
 {{template "head" "Payment batch"}}
+{{template "flash" .Flash}}
 <p class="eyebrow">Colored-token net</p>
 <h1>Payment batch</h1>
-<p class="lede">Approved expenses land here as tokens in <span class="mono">payable</span>. Running the batch pays each token out; the guard <span class="mono">token.amount &le; 5000</span> holds larger ones for manual review.</p>
+<p class="lede">Approved expenses land here as tokens in <span class="mono">payable</span>. Running the batch pays each token out; the guard <span class="mono">token.amount &le; 5000</span> holds larger ones for manual review — release those individually below.</p>
 
 <div class="actions-row">
   <form class="inline" method="post" action="/batch/run"><button class="btn-approve" type="submit">Run payment batch</button></form>
@@ -9,27 +10,35 @@
   <span class="muted" style="font-size:.85rem">Reconcile repairs interrupted hand-offs between an expense and this net.</span>
 </div>
 
-<h2>Awaiting payout · {{len .Payable}} token(s) · total <span class="mono">{{money .PayableTotal}}</span></h2>
+<h2>Awaiting payout · {{len .P.Payable}} token(s) · total <span class="mono">{{money .P.PayableTotal}}</span></h2>
 <div class="card table-wrap">
 <table>
-  <tr><th>Expense</th><th>Submitter</th><th class="num">Amount</th></tr>
-  {{range .Payable}}
+  <tr><th>Expense</th><th>Submitter</th><th class="num">Amount</th><th>Review</th></tr>
+  {{range .P.Payable}}
   <tr>
     <td><a class="mono" href="/expenses/{{tokenField . "expense_id"}}">{{tokenField . "expense_id"}}</a>{{if held .}}<span class="chip-held">held by guard</span>{{end}}</td>
     <td>{{tokenField . "submitter"}}</td>
     <td class="num">{{tokenField . "amount"}}</td>
+    <td>
+      {{if held .}}
+      <form class="inline" method="post" action="/payments/{{tokenField . "expense_id"}}/release"
+            onsubmit="return confirm('Release {{tokenField . "amount"}} to {{tokenField . "submitter"}}? This bypasses the batch guard and is recorded in the audit trail.')">
+        <button class="btn-release" type="submit">Review &amp; release</button>
+      </form>
+      {{else}}<span class="muted">next batch run</span>{{end}}
+    </td>
   </tr>
   {{else}}
-  <tr><td colspan="3" class="empty">Nothing awaiting payout — approved expenses land here.</td></tr>
+  <tr><td colspan="4" class="empty">Nothing awaiting payout — approved expenses land here.</td></tr>
   {{end}}
 </table>
 </div>
 
-<h2>Paid out · {{len .PaidOut}} token(s) · total <span class="mono">{{money .PaidOutTotal}}</span></h2>
+<h2>Paid out · {{len .P.PaidOut}} token(s) · total <span class="mono">{{money .P.PaidOutTotal}}</span></h2>
 <div class="card table-wrap">
 <table>
   <tr><th>Expense</th><th>Submitter</th><th class="num">Amount</th></tr>
-  {{range .PaidOut}}
+  {{range .P.PaidOut}}
   <tr>
     <td><a class="mono" href="/expenses/{{tokenField . "expense_id"}}">{{tokenField . "expense_id"}}</a></td>
     <td>{{tokenField . "submitter"}}</td>

--- a/examples/expense_approval/templates/dashboard.html
+++ b/examples/expense_approval/templates/dashboard.html
@@ -1,15 +1,25 @@
 {{template "head" "Dashboard"}}
+{{template "flash" .Flash}}
 <p class="eyebrow">Fleet</p>
 <h1>Expenses</h1>
 <p class="lede">Every expense is one workflow instance; this table is the live marking of the fleet.</p>
 
 <div class="stats">
+  <a class="stat{{if not .Filter}} active{{end}}" href="/">all</a>
   {{range $state, $n := .Stats}}
-  <span class="stat{{if eq $state "escalated"}} warn{{end}}"><b>{{$n}}</b>{{$state}}</span>
+  <a class="stat{{if eq $state "escalated"}} warn{{end}}{{if eq $state $.Filter}} active{{end}}" href="/?state={{$state}}"><b>{{$n}}</b>{{$state}}</a>
   {{end}}
   <span class="stat"><b>{{money .Payment.PayableTotal}}</b>awaiting payout</span>
   <span class="stat"><b>{{money .Payment.PaidOutTotal}}</b>paid out</span>
 </div>
+
+<div class="toolbar">
+  <span class="muted" style="font-size:.85rem">
+    {{if .Refresh}}Auto-refresh on (10s) · <a href="/{{if .Filter}}?state={{.Filter}}{{end}}">turn off</a>
+    {{else}}<a href="/?refresh=10{{if .Filter}}&state={{.Filter}}{{end}}">Auto-refresh</a> to watch escalations live{{end}}
+  </span>
+</div>
+{{if .Refresh}}<meta http-equiv="refresh" content="10">{{end}}
 
 <div class="card table-wrap">
 <table>
@@ -21,10 +31,12 @@
     <td class="num">{{money .Amount}}</td>
     <td><span class="state state-{{stateClass .State}}">{{.State}}</span></td>
     <td class="mono muted">{{range .Places}}{{.}} {{end}}</td>
-    <td class="mono muted">{{if .NextDue}}{{.NextDue.Format "Jan 2, 15:04"}}{{else}}—{{end}}</td>
+    <td class="mono {{if overdue .NextDue}}deadline-overdue{{else}}muted{{end}}">{{deadline .NextDue}}</td>
   </tr>
   {{else}}
-  <tr><td colspan="6" class="empty">No expenses yet — <a href="/expenses/new">submit the first one</a>.</td></tr>
+  <tr><td colspan="6" class="empty">
+    {{if .Filter}}No {{.Filter}} expenses. <a href="/">Show all</a>.{{else}}No expenses yet — <a href="/expenses/new">submit the first one</a>.{{end}}
+  </td></tr>
   {{end}}
 </table>
 </div>

--- a/examples/expense_approval/templates/detail.html
+++ b/examples/expense_approval/templates/detail.html
@@ -1,20 +1,25 @@
-{{template "head" .ID}}
+{{template "head" .V.ID}}
+{{template "flash" .Flash}}
 <p class="eyebrow">Expense</p>
-<h1><span class="mono">{{.ID}}</span> <span class="state state-{{stateClass .State}}">{{.State}}</span></h1>
-<p class="lede">{{if .Description}}{{.Description}} — {{end}}<span class="mono">{{money .Amount}}</span> submitted by <strong>{{.Submitter}}</strong>{{if .NextDue}} · next deadline <span class="mono">{{.NextDue.Format "Jan 2, 15:04"}}</span>{{end}}</p>
+<h1><span class="mono">{{.V.ID}}</span> <span class="state state-{{stateClass .V.State}}">{{.V.State}}</span>
+{{if .PayStatus}}<span class="state pay-{{.PayStatus}}">payment: {{.PayStatus}}</span>{{end}}</h1>
+<p class="lede">{{if .V.Description}}{{.V.Description}} — {{end}}<span class="mono">{{money .V.Amount}}</span> submitted by <strong>{{.V.Submitter}}</strong>{{if .V.NextDue}} · deadline <span class="mono">{{deadline .V.NextDue}}</span>{{end}}</p>
 
-{{if .Has "rejected"}}
-<div class="banner banner-rejected">Rejected — this expense is closed. The review lanes below show where each token stopped.</div>
-{{else if .Has "paid"}}
+{{if .V.Has "rejected"}}
+<div class="banner banner-rejected">Rejected — revise it below to resubmit, or leave it closed. The lanes show where each token stopped.</div>
+{{else if .V.Has "paid"}}
 <div class="banner banner-paid">Paid out by the payment batch. The audit trail below is the complete record.</div>
-{{else if .Has "approved"}}
-<div class="banner banner-approved">Approved by both reviews — awaiting the next <a href="/batch">payment batch</a>.</div>
+{{else if .V.Has "approved"}}
+<div class="banner banner-approved">Approved
+{{- if eq .PayStatus "held"}} — the payment guard is holding this amount; <a href="/batch">release it on the batch page</a>.
+{{- else if eq .PayStatus "queued"}} — awaiting the next <a href="/batch">payment batch</a>.
+{{- else}} by both reviews.{{end}}</div>
 {{end}}
 
 <h2>Review lanes</h2>
-<div class="net{{if not .Open}} closed{{end}}">
-  {{range $branch := .Branches}}
-  {{$stage := $.Branch $branch}}
+<div class="net{{if not .V.Open}} closed{{end}}">
+  {{range $branch := .V.Branches}}
+  {{$stage := $.V.Branch $branch}}
   <div class="lane">
     <span class="lane-name">{{$branch}}</span>
     <ol class="places">
@@ -22,13 +27,13 @@
       <li class="place {{if eq $stage "escalated"}}here warn{{end}}"><span class="dot"></span>escalated</li>
       <li class="place {{if eq $stage "approved"}}here{{end}}"><span class="dot"></span>approved</li>
     </ol>
-    {{if and $.Open (or (eq $stage "pending") (eq $stage "escalated"))}}
+    {{if and $.V.Open (or (eq $stage "pending") (eq $stage "escalated"))}}
     <div class="lane-actions">
-      <form class="inline" method="post" action="/expenses/{{$.ID}}/approve">
+      <form class="inline" method="post" action="/expenses/{{$.V.ID}}/approve">
         <input type="hidden" name="branch" value="{{$branch}}">
         <button class="btn-approve" type="submit">Approve</button>
       </form>
-      <form class="inline" method="post" action="/expenses/{{$.ID}}/reject">
+      <form class="inline" method="post" action="/expenses/{{$.V.ID}}/reject" onsubmit="return confirm('Reject this expense ({{$branch}})? The submitter will have to revise and resubmit.')">
         <input type="hidden" name="branch" value="{{$branch}}">
         <button class="btn-reject" type="submit">Reject</button>
       </form>
@@ -37,13 +42,27 @@
   </div>
   {{end}}
 </div>
-<p class="muted" style="font-size:.85rem">Both lanes run in parallel (one AND-split token each); approval joins them. An escalated lane is overdue but still open.</p>
+<p class="muted" style="font-size:.85rem">Petty cash (≤ 100.00) skips review entirely; both lanes run in parallel otherwise, and approval joins them. An escalated lane is overdue but still open.</p>
+
+{{if .V.Has "rejected"}}
+<h2>Revise &amp; resubmit</h2>
+<form class="card form-card" method="post" action="/expenses/{{.V.ID}}/revise">
+  <label>Amount
+    <span class="hint">Update the amount — ≤ 100.00 auto-approves; over 5000.00 will be held by the payment guard.</span>
+    <input class="mono" name="amount" type="number" step="0.01" min="0.01" value="{{money .V.Amount}}" required>
+  </label>
+  <label>Description
+    <input name="description" value="{{.V.Description}}">
+  </label>
+  <div><button class="btn-approve" type="submit">Resubmit for review</button></div>
+</form>
+{{end}}
 
 <h2>Audit trail</h2>
 <div class="card table-wrap">
 <table>
   <tr><th>When</th><th>Transition</th><th>From → To</th><th>Actor</th><th>Notes</th></tr>
-  {{range .History}}
+  {{range .V.History}}
   <tr>
     <td class="mono muted">{{.CreatedAt.Format "Jan 2, 15:04:05"}}</td>
     <td class="mono">{{.Transition}}</td>

--- a/examples/expense_approval/templates/layout.html
+++ b/examples/expense_approval/templates/layout.html
@@ -161,6 +161,40 @@
   }
   .actions-row { display: flex; gap: .6rem; align-items: center; flex-wrap: wrap; margin: 1rem 0 0; }
 
+  /* Flash feedback after actions: slides in, fades out on its own. */
+  .flash {
+    background: var(--pine-soft); color: var(--pine-deep); border: 1px solid var(--pine);
+    border-radius: 9px; padding: .6rem 1rem; margin: 0 0 1.2rem; font-size: .92rem;
+    animation: flash-in .25s ease-out, flash-out .8s ease-in 6s forwards;
+  }
+  @keyframes flash-in { from { opacity: 0; transform: translateY(-.4rem); } }
+  @keyframes flash-out { to { opacity: 0; visibility: hidden; margin: 0; padding: 0; height: 0; border: 0; } }
+
+  /* Stat chips double as dashboard filters. */
+  a.stat { text-decoration: none; }
+  a.stat:hover { border-color: var(--pine); }
+  .stat.active { border-color: var(--pine); background: var(--pine-soft); color: var(--pine-deep); }
+  .stat.active b { color: var(--pine-deep); }
+
+  .deadline-overdue { color: var(--amber); font-weight: 600; }
+
+  /* Payment status pill on the expense page. */
+  .pay-queued { background: var(--pine-soft); color: var(--pine-deep); }
+  .pay-held { background: var(--amber-soft); color: var(--amber); }
+  .pay-paid { background: var(--sky-soft); color: var(--sky); }
+
+  .btn-release { background: var(--amber); color: #fff; }
+  .btn-release:hover { background: #935e07; }
+
+  /* Acting-as identity in the top bar, injected into every action form. */
+  .whoami { margin-left: auto; display: flex; align-items: center; gap: .4rem; font-size: .85rem; color: var(--slate); }
+  .whoami input {
+    width: 9rem; padding: .3rem .5rem; font-size: .85rem;
+    border: 1px solid var(--line); border-radius: 6px; background: var(--card);
+  }
+  .toolbar { display: flex; gap: .8rem; align-items: center; flex-wrap: wrap; margin: 0 0 1rem; }
+  .toolbar .muted a { color: var(--pine); }
+
   @media (prefers-reduced-motion: reduce) {
     * { animation: none !important; transition: none !important; }
   }
@@ -179,13 +213,37 @@
       <a href="/batch">Payment batch</a>
       <a href="/metrics">Metrics</a>
     </nav>
+    <label class="whoami">acting as
+      <input id="whoami" placeholder="your name" autocomplete="username">
+    </label>
   </div>
 </header>
 <main>
 {{end}}
 
+{{define "flash"}}{{if .}}<div class="flash" role="status">{{.}}</div>{{end}}{{end}}
+
 {{define "foot"}}
 </main>
+<script>
+  // "Acting as" identity: remembered locally, injected into every action
+  // form as the actor field (server defaults sensibly when empty). Plain
+  // inline script — no build step; the app works fully without JS.
+  (function () {
+    var box = document.getElementById('whoami');
+    if (!box) return;
+    box.value = localStorage.getItem('whoami') || '';
+    box.addEventListener('change', function () { localStorage.setItem('whoami', box.value); });
+    document.addEventListener('submit', function (e) {
+      var form = e.target;
+      if (form.method.toLowerCase() !== 'post' || !box.value) return;
+      if (form.querySelector('input[name=actor]')) return; // explicit field wins
+      var actor = document.createElement('input');
+      actor.type = 'hidden'; actor.name = 'actor'; actor.value = box.value;
+      form.appendChild(actor);
+    });
+  })();
+</script>
 </body>
 </html>
 {{end}}

--- a/examples/expense_approval/templates/new.html
+++ b/examples/expense_approval/templates/new.html
@@ -1,7 +1,8 @@
 {{template "head" "Submit expense"}}
+{{template "flash" .Flash}}
 <p class="eyebrow">New instance</p>
 <h1>Submit an expense</h1>
-<p class="lede">Submitting starts legal and finance review in parallel. Each review escalates if it sits for 3 days.</p>
+<p class="lede">Petty cash (≤ 100.00) is approved on the spot. Everything else starts legal and finance review in parallel; each review escalates if it sits for 3 days.</p>
 
 <form class="card form-card" method="post" action="/expenses">
   <label>Submitter
@@ -11,7 +12,7 @@
     <input name="description" placeholder="Team dinner, client visit…">
   </label>
   <label>Amount
-    <span class="hint">Amounts over 5000.00 are approved as usual but held from the payment batch for manual review.</span>
+    <span class="hint">≤ 100.00 auto-approves · over 5000.00 is approved as usual but held from the payment batch until a reviewer releases it.</span>
     <input class="mono" name="amount" type="number" step="0.01" min="0.01" required placeholder="240.75">
   </label>
   <div><button class="btn-approve" type="submit">Submit expense</button></div>

--- a/examples/expense_approval/workflow.yaml
+++ b/examples/expense_approval/workflow.yaml
@@ -1,9 +1,13 @@
 # The expense-approval net: one workflow instance per expense.
 #
-# submit AND-splits into two parallel review branches (legal, finance);
-# finalize AND-joins them. Each pending branch escalates after 72h (M4
-# host-driven timer) but stays approvable/rejectable. mark_paid is fired by
-# the batch payment run (see payment.yaml).
+# submit routes by amount (guards read the workflow context): petty cash
+# (<= 100) auto-approves; everything else AND-splits into two parallel
+# review branches (legal, finance) that finalize AND-joins. Each pending
+# branch escalates after 72h (M4 host-driven timer) but stays
+# approvable/rejectable. revise closes the loop: a rejected expense returns
+# to draft for resubmission (a cycle — the host must clear the stranded
+# sibling branch's token by hand; see docs/DOGFOOD.md). mark_paid is fired
+# by the batch payment run (see payment.yaml).
 #
 # Known modeling friction (docs/DOGFOOD.md): rejection does not cancel the
 # sibling branch (no cancellation regions yet), and "approve from pending OR
@@ -23,9 +27,14 @@ workflow:
     - name: rejected
     - name: paid
   transitions:
+    - name: submit_auto
+      from: [draft]
+      to: [approved]
+      guard: "amount <= 100.0"
     - name: submit
       from: [draft]
       to: [pending_legal, pending_finance]
+      guard: "amount > 100.0"
     - name: legal_approve
       from: [pending_legal]
       to: [legal_ok]
@@ -61,6 +70,9 @@ workflow:
     - name: finalize
       from: [legal_ok, finance_ok]
       to: [approved]
+    - name: revise
+      from: [rejected]
+      to: [draft]
     - name: mark_paid
       from: [approved]
       to: [paid]


### PR DESCRIPTION
## Summary

Per the directive that this example exists to **test the limits of the workflow library and rank what's missing**, this pushes the flow well past the original spec and closes the manual-review gap.

**New flow capabilities (each probing a different library edge):**
- **Guard-routed XOR-split**: `amount <= 100` auto-approves via `submit_auto` — guards read the workflow context directly. The host needs a try-each `routeSubmit` helper because there's no free-choice routing primitive (friction #3).
- **Cycles**: `revise` sends a rejected expense back through `draft` with an updated amount, re-routed by the guards (possibly straight to auto-approval). This graduated the cancellation-regions gap from 'host checks a flag' to **host-side token surgery** — `Revise` must `ClearPlace` six places or round two double-fires with round one's stale deadline.
- **Manual payment review** (the missing capability): guard-held tokens (> 5000) now have a per-token `release` transition — reviewer identity recorded in the audit trail, idempotent on redelivery, 409 for never-enqueued expenses.
- **Definition evolution**: both nets' fingerprints changed, so `WithDefinitionMigration` is now genuinely exercised — and its blindness to *what* changed is friction #5.

**The M5 answer** — `FRICTION.md` gains a ranked **'What is missing'** section: (1) cancellation regions, (2) OR-input transitions, (3) an XOR-routing primitive, (4) FireDue side effects, (5) a structural diff for the migration hook, (6) creation seeding / cross-instance recipes.

**UX pass:** flash feedback after every action (auto-dismissing), 'acting as' identity injected into all forms (localStorage, no build step; app fully works without JS), dashboard state-filter chips + humanized deadlines with overdue highlighting + auto-refresh toggle, payment-status pill and contextual banners on the expense page, a revise form on rejected expenses, and review-and-release buttons with confirmation dialogs.

**Verified:** 7 new tests (routing boundary, multi-round revise cycles including the zombie-timer check, release idempotency + audit, HTTP flows, dashboard filter) — 25 tests total, `-race` green; every flow also driven against the live server (auto-approve → hold → release → revise → auto-approve).

## Roadmap milestone

M5.1 depth + M5.4 (ranked verdict). Stacked on #22 → #21.

## Checklist

- [x] `gofmt -s -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] `CHANGELOG.md` — example-only change; covered by the existing M5.1 entry
- [x] Docs/examples only describe behavior the engine can actually execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)