### PR TITLE
feat: cancellation regions via reset arcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Cancellation regions via reset arcs** — the top-ranked finding of the M5
+  friction log. A transition can declare places it CLEARS when it fires:
+  `Transition.SetResets("b", "c")` in Go, `resets: [b, c]` in YAML. Firing
+  consumes the inputs, empties every reset place, and only then produces the
+  outputs (a place that is both reset and an output keeps what the firing
+  produces) — all inside the same atomic critical section as the marking
+  move, in every apply path including per-token firing. Reset places do not
+  affect enablement. Any timer running on a cleared token dies with it, so a
+  rejected instance can no longer leave a zombie escalation in the due
+  index. Reset places are validated by `NewDefinition`, included in the
+  definition fingerprint, and rendered in Mermaid diagrams. The canonical
+  use: a reject transition on one review branch resets the sibling branch,
+  cancelling its pending work — previously host-side token surgery.
+
 ### Breaking
+- The definition fingerprint encoding now includes each transition's reset
+  places, so **every fingerprint changes** with this version. Persisted
+  instances load again after a `WithDefinitionMigration` hook approves the
+  upgrade (the loader still validates every place).
 - **Versioning is now part of the `Storage` contract** (the library is pre-1.0
   with no compatibility guarantees; an unversioned backend loses updates by
   design, so the contract no longer allows one). `LoadState` returns

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -195,6 +195,14 @@ describing only shipping behavior.
 
 ---
 
+## Post-M5 — friction-log-driven features
+
+- **Cancellation regions (reset arcs)** — ✅ shipped (2026-07-07), the friction
+  log's #1 finding. `Transition.SetResets` / YAML `resets:` clear declared
+  places atomically on firing (validated, fingerprinted, timer-killing,
+  Mermaid-rendered); the dogfood's reject transitions adopted it and deleted
+  their token surgery.
+
 ## Parked — demand-driven (🟢, revisit after M5 friction log)
 
 Formerly M3–M8. None is deleted; none proceeds without a dogfood-proven need.

--- a/definition.go
+++ b/definition.go
@@ -42,6 +42,13 @@ func NewDefinition(places []Place, transitions []Transition) (*Definition, error
 				return nil, fmt.Errorf("place '%s' in transition '%s' is not defined in workflow places", place, trans.Name())
 			}
 		}
+
+		// Check reset places (cancellation regions)
+		for _, place := range trans.Resets() {
+			if !validPlaces[place] {
+				return nil, fmt.Errorf("reset place '%s' in transition '%s' is not defined in workflow places", place, trans.Name())
+			}
+		}
 	}
 
 	return &Definition{
@@ -51,8 +58,9 @@ func NewDefinition(places []Place, transitions []Transition) (*Definition, error
 }
 
 // Fingerprint returns a stable SHA-256 hash of the definition's structure: its
-// places and, for every transition, the name, input places, output places, and
-// guard expression string (as stored in the "guard" metadata). It is order-
+// places and, for every transition, the name, input places, output places,
+// guard expression string (as stored in the "guard" metadata), and reset
+// places. It is order-
 // independent — places and transitions are canonically sorted first — so two
 // definitions built in different orders but describing the same net share a
 // fingerprint. Every component is length-prefixed before hashing, so no choice
@@ -84,11 +92,14 @@ func (d *Definition) Fingerprint() string {
 		if g, ok := t.Metadata("guard"); ok {
 			guard, _ = g.(string)
 		}
+		resets := placeStrings(t.Resets())
+		slices.Sort(resets)
 		var rec strings.Builder
 		writeLenPrefixed(&rec, t.Name())
 		writeLenPrefixedList(&rec, from)
 		writeLenPrefixedList(&rec, to)
 		writeLenPrefixed(&rec, guard)
+		writeLenPrefixedList(&rec, resets)
 		transitions[i] = rec.String()
 	}
 	slices.Sort(transitions)

--- a/doc.go
+++ b/doc.go
@@ -41,12 +41,16 @@
 //
 // Implemented and tested: the unified colored-token marking (a place can hold
 // multiple data-carrying tokens; simple boolean workflows are the single-token
-// special case), per-token transition firing, token-aware guards, SQLite and
-// PostgreSQL storage backends with optimistic concurrency built into the Storage contract and
-// transactional building blocks, SQLite and PostgreSQL history stores, the strict YAML loader
-// with the polymorphic initial_marking key, and Mermaid diagram generation.
+// special case), per-token transition firing, token-aware guards, reset arcs
+// (cancellation regions — a transition clears declared places atomically when
+// it fires), host-driven timers (SetTimeoutAfter / Due / Manager.ListDue and
+// FireDue — the host owns the clock), SQLite and PostgreSQL storage backends
+// with optimistic concurrency built into the Storage contract and
+// transactional building blocks, SQLite and PostgreSQL history stores, the
+// strict YAML loader with the polymorphic initial_marking key, and Mermaid
+// diagram generation.
 //
-// Not yet available (tracked in ROADMAP.md): timers/scheduling, a signals API,
-// static validation (deadlock/soundness checking), hierarchical workflows (HCPN),
+// Not yet available (tracked in ROADMAP.md): a signals API, static validation
+// (deadlock/soundness checking), hierarchical workflows (HCPN),
 // compensation/rollback, and observability hooks.
 package workflow

--- a/docs/guides/TIMERS_GUIDE.md
+++ b/docs/guides/TIMERS_GUIDE.md
@@ -300,3 +300,13 @@ out of `ListDue` entirely. Run as many cron replicas as you like.
 See also: [CPN_GUIDE.md](CPN_GUIDE.md) for the token model that entry-time stamping
 builds on, and [`examples/timer_escalation`](../../examples/timer_escalation) for the
 runnable escalation recipe.
+
+## Cancelling timers with reset arcs
+
+A timer lives on a token; clear the token and the timer dies with it. A
+transition's reset arcs (`resets: [pending_finance]` in YAML,
+`SetResets(...)` in Go) empty the declared places atomically when it fires,
+so a reject/cancel transition can cancel a sibling branch's pending work —
+and its escalation deadline — in the same firing. The due index is derived
+from the marking on every save, so the instance drops out of `ListDue`
+without any host bookkeeping.

--- a/docs/roadmap/FRICTION.md
+++ b/docs/roadmap/FRICTION.md
@@ -10,7 +10,14 @@ workaround.
 
 ## Hard / missing
 
-1. **No cancellation regions** (parked milestone, now dogfood-confirmed).
+1. ✅ **SHIPPED: cancellation regions via reset arcs** (was: no cancellation
+   regions). A transition now declares places it clears atomically when it
+   fires (`resets:` in YAML, `SetResets` in Go); the dogfood's reject
+   transitions cancel the sibling branch — token, timer and all — and
+   `Revise` dropped its six-place `ClearPlace` surgery. Original finding
+   kept below for the record.
+
+   **Original entry** (parked milestone, now dogfood-confirmed).
    Rejecting one review branch cannot cancel the sibling branch's token; the
    "rejected is terminal" rule had to move into the host (an `ErrTerminal`
    check before every decision). Workaround is fine but every consumer with
@@ -99,12 +106,9 @@ cycles (revise/resubmit), per-token manual release, AND-split/join,
 timers, and the CPN batch — deliberately probing the library's limits.
 Priority order for what the library needs next, from what actually hurt:
 
-1. **Cancellation regions** (entries 1, and now the revise cycle). The
-   workaround graduated from "host checks a flag" to **host-side token
-   surgery**: `Revise` must `ClearPlace` six places by hand or round two
-   double-fires reviews and inherits round one's stale escalation deadline.
-   Every consumer with reject/timeout semantics on parallel branches will
-   have to reinvent this. Highest priority by a wide margin.
+1. ✅ **SHIPPED: cancellation regions** — implemented as reset arcs
+   immediately after this ranking was written; the dogfood adopted them and
+   deleted its token surgery (see resolved entry 1 above).
 
 2. **OR-input transitions** (entry 2). The escalation feature doubled the
    approve/reject transitions; with the revise loop the duplication now

--- a/examples/expense_approval/README.md
+++ b/examples/expense_approval/README.md
@@ -84,11 +84,14 @@ which is friction entry #3.
 
 **Cycles are just arcs too.** `revise` closes the loop: a rejected expense
 returns to `draft`, takes an updated amount, and re-routes through the
-submit guards — possibly straight to auto-approval. The catch is the
-cancellation-regions gap: the host must clear the stranded sibling branch's
-tokens BY HAND (`ClearPlace` × 6 in `Revise`) or round two double-fires and
-inherits round one's stale escalation deadline. That token surgery is the
-top-ranked finding in the friction log.
+submit guards — possibly straight to auto-approval.
+
+**Rejection cancels the sibling branch — declaratively.** Each reject
+transition carries reset arcs (`resets: [pending_finance, …]`): firing it
+clears the other branch's places atomically, killing its pending token and
+any escalation timer running on it. This replaced the host-side `ClearPlace`
+token surgery that was the friction log's top-ranked finding — the library
+grew the feature and the app deleted the workaround.
 
 **Colored tokens where entities flow together.** The payment net
 (`payment.yaml`) is the opposite modeling style: ONE long-lived instance,

--- a/examples/expense_approval/flows_test.go
+++ b/examples/expense_approval/flows_test.go
@@ -92,10 +92,11 @@ func TestReviseAfterRejection(t *testing.T) {
 	if _, err := app.Reject(ctx, id, "legal", "lawyer"); err != nil {
 		t.Fatalf("reject: %v", err)
 	}
-	// Round one's finance token is stranded; its timer still fires.
+	// The reject's reset arcs cancelled round one's finance token, so this
+	// tick fires nothing (it used to fire a stranded escalation).
 	later := time.Now().Add(73 * time.Hour)
-	if _, err := app.Tick(ctx, later); err != nil {
-		t.Fatalf("tick: %v", err)
+	if fired, err := app.Tick(ctx, later); err != nil || len(fired) != 0 {
+		t.Fatalf("tick after reject: fired %v, err %v (want nothing)", fired, err)
 	}
 
 	fired, err := app.Revise(ctx, id, "bob", "cheaper option", 90)

--- a/examples/expense_approval/robustness_test.go
+++ b/examples/expense_approval/robustness_test.go
@@ -17,12 +17,13 @@ import (
 	"github.com/ehabterra/workflow"
 )
 
-// TestStrandedBranchEscalatesHarmlessly documents the cancellation-regions
-// gap end to end: after legal rejects, finance's token is stranded in
-// pending_finance and its 72h timer still fires. That must stay harmless —
-// the expense reads rejected throughout, no actions reopen, and the timer
-// goes quiet afterwards (escalated has no further timer).
-func TestStrandedBranchEscalatesHarmlessly(t *testing.T) {
+// TestRejectCancelsSiblingBranch: the reject transition's reset arcs cancel
+// the sibling branch in the same atomic firing — no stranded token, no
+// zombie escalation ever fires, and the instance drops straight out of the
+// due index. (This test used to document the opposite: a stranded finance
+// token whose 72h timer still fired. Reset arcs closed that gap —
+// docs/roadmap/FRICTION.md, resolved entry 1.)
+func TestRejectCancelsSiblingBranch(t *testing.T) {
 	app, _ := newTestApp(t)
 	ctx := context.Background()
 	id := mustSubmit(t, app, "alice", 150)
@@ -31,34 +32,29 @@ func TestStrandedBranchEscalatesHarmlessly(t *testing.T) {
 		t.Fatalf("reject: %v", err)
 	}
 
-	later := time.Now().Add(73 * time.Hour)
-	fired, err := app.Tick(ctx, later)
-	if err != nil {
-		t.Fatalf("tick: %v", err)
-	}
-	if len(fired[id]) != 1 || fired[id][0] != "finance_escalate" {
-		t.Fatalf("want the stranded finance branch to escalate, fired %v", fired)
-	}
-
 	view, err := app.Expense(ctx, id)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if view.State != "rejected" {
-		t.Fatalf("state must stay rejected, got %q (marking %v)", view.State, view.Places)
+	if len(view.Places) != 1 || view.Places[0] != "rejected" {
+		t.Fatalf("reject must cancel the sibling branch, marking %v", view.Places)
 	}
-	if _, err := app.Approve(ctx, id, "finance", "cfo"); !errors.Is(err, ErrTerminal) {
-		t.Fatalf("the stranded branch must not be approvable, got %v", err)
+	if view.NextDue != nil {
+		t.Fatalf("no timer may survive the reset, next due %v", view.NextDue)
 	}
 
-	// The timer must now be quiet: escalated_finance has no timed
-	// transition, so the instance drops out of the due index.
-	fired, err = app.Tick(ctx, later.Add(100*time.Hour))
+	// No escalation ever fires — the due index is already quiet.
+	fired, err := app.Tick(ctx, time.Now().Add(200*time.Hour))
 	if err != nil {
-		t.Fatalf("second tick: %v", err)
+		t.Fatalf("tick: %v", err)
 	}
 	if len(fired) != 0 {
-		t.Fatalf("no further timers may fire on a closed expense, got %v", fired)
+		t.Fatalf("nothing may fire on a rejected expense, got %v", fired)
+	}
+
+	// And the cancelled branch is not approvable.
+	if _, err := app.Approve(ctx, id, "finance", "cfo"); !errors.Is(err, ErrTerminal) {
+		t.Fatalf("cancelled branch must not be approvable, got %v", err)
 	}
 }
 

--- a/examples/expense_approval/workflow.yaml
+++ b/examples/expense_approval/workflow.yaml
@@ -5,13 +5,13 @@
 # review branches (legal, finance) that finalize AND-joins. Each pending
 # branch escalates after 72h (M4 host-driven timer) but stays
 # approvable/rejectable. revise closes the loop: a rejected expense returns
-# to draft for resubmission (a cycle — the host must clear the stranded
-# sibling branch's token by hand; see docs/DOGFOOD.md). mark_paid is fired
-# by the batch payment run (see payment.yaml).
+# to draft for resubmission (a cycle; the reject already cancelled the
+# sibling branch via its reset arcs, so nothing is stranded). mark_paid is
+# fired by the batch payment run (see payment.yaml).
 #
-# Known modeling friction (docs/DOGFOOD.md): rejection does not cancel the
-# sibling branch (no cancellation regions yet), and "approve from pending OR
-# escalated" needs one transition per source place.
+# Known modeling friction (docs/DOGFOOD.md): "approve from pending OR
+# escalated" needs one transition per source place. (Rejection cancelling
+# the sibling branch is SOLVED by reset arcs — see the reject transitions.)
 workflow:
   name: expense_approval
   initial_marking: draft
@@ -55,18 +55,26 @@ workflow:
     - name: finance_approve_escalated
       from: [escalated_finance]
       to: [finance_ok]
+    # Rejecting one branch CANCELS the other via reset arcs: the sibling's
+    # pending/escalated token — and any escalation timer running on it —
+    # dies in the same atomic firing. (This replaced host-side ClearPlace
+    # token surgery; see docs/roadmap/FRICTION.md, resolved entry 1.)
     - name: legal_reject
       from: [pending_legal]
       to: [rejected]
+      resets: [pending_finance, escalated_finance, finance_ok]
     - name: finance_reject
       from: [pending_finance]
       to: [rejected]
+      resets: [pending_legal, escalated_legal, legal_ok]
     - name: legal_reject_escalated
       from: [escalated_legal]
       to: [rejected]
+      resets: [pending_finance, escalated_finance, finance_ok]
     - name: finance_reject_escalated
       from: [escalated_finance]
       to: [rejected]
+      resets: [pending_legal, escalated_legal, legal_ok]
     - name: finalize
       from: [legal_ok, finance_ok]
       to: [approved]

--- a/mermaid.go
+++ b/mermaid.go
@@ -145,6 +145,14 @@ func (w *Workflow) Diagram() string {
 				fmt.Fprintf(&diagram, "    %s --> %s : %s\n", trans.From()[0], trans.To()[0], displayLabel)
 			}
 		}
+
+		// Reset arcs (cancellation region): rendered as an edge from the
+		// cleared place back to the transition's first input, labelled so the
+		// cancellation is visible in the diagram.
+		for _, reset := range trans.Resets() {
+			fmt.Fprintf(&diagram, "    %s --> %s : %s\n", reset, trans.From()[0],
+				escapeMermaidLabel(trans.Name())+" resets")
+		}
 	}
 
 	// Add current place highlighting

--- a/resets_test.go
+++ b/resets_test.go
@@ -1,0 +1,256 @@
+package workflow_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ehabterra/workflow"
+)
+
+// rejectNet builds the canonical cancellation-region shape: an AND-split into
+// two parallel branches where rejecting one branch resets the other.
+func rejectNet(t *testing.T) *workflow.Definition {
+	t.Helper()
+	split := workflow.MustNewTransition("split", []workflow.Place{"start"}, []workflow.Place{"a", "b"})
+	okA := workflow.MustNewTransition("ok_a", []workflow.Place{"a"}, []workflow.Place{"a_done"})
+	rejectA := workflow.MustNewTransition("reject_a", []workflow.Place{"a"}, []workflow.Place{"rejected"})
+	rejectA.SetResets("b", "b_done")
+	okB := workflow.MustNewTransition("ok_b", []workflow.Place{"b"}, []workflow.Place{"b_done"})
+	def, err := workflow.NewDefinition(
+		[]workflow.Place{"start", "a", "b", "a_done", "b_done", "rejected"},
+		[]workflow.Transition{*split, *okA, *rejectA, *okB},
+	)
+	if err != nil {
+		t.Fatalf("NewDefinition: %v", err)
+	}
+	return def
+}
+
+// TestResetArcClearsPlacesOnFire: firing a transition with reset arcs empties
+// the reset places in the same atomic move.
+func TestResetArcClearsPlacesOnFire(t *testing.T) {
+	def := rejectNet(t)
+	wf, err := workflow.NewWorkflow("wf", def, "start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := wf.ApplyTransition("split"); err != nil {
+		t.Fatal(err)
+	}
+	if !wf.Marking().HasPlace("a") || !wf.Marking().HasPlace("b") {
+		t.Fatalf("precondition: both branches marked, got %v", wf.CurrentPlaces())
+	}
+
+	if err := wf.ApplyTransition("reject_a"); err != nil {
+		t.Fatalf("reject_a: %v", err)
+	}
+	places := wf.CurrentPlaces()
+	if len(places) != 1 || places[0] != "rejected" {
+		t.Fatalf("reset arc must clear the sibling branch, marking %v", places)
+	}
+	// The cancelled branch is dead: ok_b is no longer enabled.
+	if err := wf.ApplyTransition("ok_b"); !errors.Is(err, workflow.ErrNotEnabled) {
+		t.Fatalf("cancelled branch must not fire, got %v", err)
+	}
+}
+
+// TestResetArcDoesNotAffectEnablement: reset places are not inputs — the
+// transition fires whether or not they are marked.
+func TestResetArcDoesNotAffectEnablement(t *testing.T) {
+	def := rejectNet(t)
+	wf, err := workflow.NewWorkflow("wf", def, "start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := wf.ApplyTransition("split"); err != nil {
+		t.Fatal(err)
+	}
+	// Complete branch b first; reject_a resets b and b_done — b_done marked.
+	if err := wf.ApplyTransition("ok_b"); err != nil {
+		t.Fatal(err)
+	}
+	if err := wf.ApplyTransition("reject_a"); err != nil {
+		t.Fatalf("reject with empty/occupied reset places must fire: %v", err)
+	}
+	places := wf.CurrentPlaces()
+	if len(places) != 1 || places[0] != "rejected" {
+		t.Fatalf("want only rejected, got %v", places)
+	}
+}
+
+// TestResetArcOutputSurvives: a place that is both reset and an output keeps
+// what THIS firing produces (reset clears before produce).
+func TestResetArcOutputSurvives(t *testing.T) {
+	// restart: consumes trigger, resets pool, and refills pool with one token.
+	restart := workflow.MustNewTransition("restart", []workflow.Place{"trigger"}, []workflow.Place{"pool"})
+	restart.SetResets("pool")
+	def, err := workflow.NewDefinition(
+		[]workflow.Place{"trigger", "pool"},
+		[]workflow.Transition{*restart},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wf, err := workflow.NewWorkflow("wf", def, "trigger")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Fill the pool with stale colored tokens.
+	for _, d := range []workflow.TokenData{{"n": 1}, {"n": 2}, {"n": 3}} {
+		if _, err := wf.CreateToken("pool", d); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := wf.ApplyTransition("restart"); err != nil {
+		t.Fatal(err)
+	}
+	if got := wf.TokenCount("pool"); got != 1 {
+		t.Fatalf("pool must hold exactly the produced token, got %d", got)
+	}
+}
+
+// TestResetArcPerTokenFiring: reset arcs clear whole places in per-token
+// firing too — including sibling tokens of the input place when it resets
+// itself.
+func TestResetArcPerTokenFiring(t *testing.T) {
+	pick := workflow.MustNewTransition("pick", []workflow.Place{"queue"}, []workflow.Place{"chosen"})
+	pick.SetResets("queue") // picking one discards the rest
+	def, err := workflow.NewDefinition(
+		[]workflow.Place{"queue", "chosen"},
+		[]workflow.Transition{*pick},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := workflow.NewMarking(nil)
+	m.AddToken("queue", workflow.NewTokenWithID("t1", workflow.TokenData{"bid": 10}))
+	m.AddToken("queue", workflow.NewTokenWithID("t2", workflow.TokenData{"bid": 20}))
+	m.AddToken("queue", workflow.NewTokenWithID("t3", workflow.TokenData{"bid": 30}))
+	wf, err := workflow.NewWorkflowFromMarking("wf", def, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := wf.ApplyTransitionForToken(context.Background(), "pick", "t2"); err != nil {
+		t.Fatal(err)
+	}
+	if got := wf.TokenCount("queue"); got != 0 {
+		t.Fatalf("reset must discard the unchosen tokens, %d left", got)
+	}
+	chosen := wf.GetTokens("chosen")
+	if len(chosen) != 1 || chosen[0].ID() != "t2" {
+		t.Fatalf("want exactly t2 chosen, got %v", chosen)
+	}
+}
+
+// TestResetArcKillsTimer: clearing a place kills the timer running on its
+// token — the canonical zombie-escalation fix. The due index derives from the
+// marking, so NextDue goes quiet.
+func TestResetArcKillsTimer(t *testing.T) {
+	def := rejectNet(t)
+	// Put a 72h timer on branch b.
+	def.Transition("ok_b").SetTimeoutAfter(72 * time.Hour)
+
+	wf, err := workflow.NewWorkflow("wf", def, "start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := wf.ApplyTransition("split"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := wf.NextDue(); !ok {
+		t.Fatal("precondition: a timer must be running on branch b")
+	}
+
+	if err := wf.ApplyTransition("reject_a"); err != nil {
+		t.Fatal(err)
+	}
+	if due, ok := wf.NextDue(); ok {
+		t.Fatalf("reset must kill the branch timer, still due at %v", due)
+	}
+	if fired := wf.Due(time.Now().Add(100 * time.Hour)); len(fired) != 0 {
+		t.Fatalf("nothing may be due after the reset, got %v", fired)
+	}
+}
+
+// TestResetArcValidation: NewDefinition rejects reset places that don't exist.
+func TestResetArcValidation(t *testing.T) {
+	tr := workflow.MustNewTransition("t", []workflow.Place{"a"}, []workflow.Place{"b"})
+	tr.SetResets("ghost")
+	_, err := workflow.NewDefinition([]workflow.Place{"a", "b"}, []workflow.Transition{*tr})
+	if err == nil || !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("want validation error naming the ghost place, got %v", err)
+	}
+}
+
+// TestResetArcAccessors: SetResets deduplicates and Resets returns a copy.
+func TestResetArcAccessors(t *testing.T) {
+	tr := workflow.MustNewTransition("t", []workflow.Place{"a"}, []workflow.Place{"b"})
+	tr.SetResets("x", "y", "x")
+	got := tr.Resets()
+	if len(got) != 2 {
+		t.Fatalf("want deduplicated resets, got %v", got)
+	}
+	got[0] = "mutated"
+	if tr.Resets()[0] == "mutated" {
+		t.Fatal("Resets must return a copy")
+	}
+	if workflow.MustNewTransition("t2", []workflow.Place{"a"}, []workflow.Place{"b"}).Resets() != nil {
+		t.Fatal("no resets -> nil")
+	}
+}
+
+// TestResetArcChangesFingerprint: resets are part of the net's structure.
+func TestResetArcChangesFingerprint(t *testing.T) {
+	build := func(withReset bool) *workflow.Definition {
+		tr := workflow.MustNewTransition("t", []workflow.Place{"a"}, []workflow.Place{"b"})
+		if withReset {
+			tr.SetResets("c")
+		}
+		def, err := workflow.NewDefinition([]workflow.Place{"a", "b", "c"}, []workflow.Transition{*tr})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return def
+	}
+	if build(false).Fingerprint() == build(true).Fingerprint() {
+		t.Fatal("adding a reset arc must change the fingerprint")
+	}
+	if build(true).Fingerprint() != build(true).Fingerprint() {
+		t.Fatal("fingerprint must be stable")
+	}
+}
+
+// TestResetArcConcurrentFiring: a reset firing racing a fire on the reset
+// branch stays consistent — whatever interleaving wins, the final marking is
+// coherent (either rejected-only, or b completed before the reset cleared
+// b_done).
+func TestResetArcConcurrentFiring(t *testing.T) {
+	for range 50 {
+		def := rejectNet(t)
+		wf, err := workflow.NewWorkflow("wf", def, "start")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := wf.ApplyTransition("split"); err != nil {
+			t.Fatal(err)
+		}
+		var wg sync.WaitGroup
+		for _, name := range []string{"reject_a", "ok_b"} {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_ = wf.ApplyTransition(name) // one may lose: ErrNotEnabled
+			}()
+		}
+		wg.Wait()
+		places := wf.CurrentPlaces()
+		if len(places) != 1 || places[0] != "rejected" {
+			t.Fatalf("reset must leave only rejected whatever the interleaving, got %v", places)
+		}
+	}
+}

--- a/resets_test.go
+++ b/resets_test.go
@@ -220,7 +220,9 @@ func TestResetArcChangesFingerprint(t *testing.T) {
 	if build(false).Fingerprint() == build(true).Fingerprint() {
 		t.Fatal("adding a reset arc must change the fingerprint")
 	}
-	if build(true).Fingerprint() != build(true).Fingerprint() {
+	first := build(true).Fingerprint()
+	second := build(true).Fingerprint()
+	if first != second {
 		t.Fatal("fingerprint must be stable")
 	}
 }

--- a/token_firing.go
+++ b/token_firing.go
@@ -43,7 +43,7 @@ func (w *Workflow) coloredTokensAt(places []Place) []Token {
 // each output receives a fresh copy of every consumed token. When no colored
 // tokens are consumed it falls back to boolean presence (one uncolored token per
 // output). Callers must hold w.mu.
-func (w *Workflow) moveMarking(from, to []Place) {
+func (w *Workflow) moveMarking(from, to, resets []Place) {
 	var carried []Token
 	for _, f := range from {
 		for _, tok := range w.marking.TokensAt(f) {
@@ -52,6 +52,14 @@ func (w *Workflow) moveMarking(from, to []Place) {
 			}
 		}
 		_ = w.marking.RemovePlace(f) // removes all tokens at f; no-op error if empty
+	}
+	// Reset arcs (cancellation regions): empty every reset place after the
+	// inputs are consumed and BEFORE the outputs are produced, so a place
+	// that is both reset and an output keeps what this firing produces. Any
+	// timer running on a cleared token dies with it — the due index is
+	// recomputed from the marking on save.
+	for _, p := range resets {
+		_ = w.marking.RemovePlace(p)
 	}
 	w.produce(to, carried)
 }
@@ -204,6 +212,11 @@ func (w *Workflow) ApplyTransitionForToken(ctx context.Context, transitionName s
 	if err := w.marking.RemoveToken(inputPlace, tokenID); err != nil {
 		w.mu.Unlock()
 		return err
+	}
+	// Reset arcs clear WHOLE places, also in per-token firing — a reset on
+	// the input place removes the sibling tokens that were not consumed.
+	for _, p := range targetTransition.Resets() {
+		_ = w.marking.RemovePlace(p)
 	}
 	w.produce(to, []Token{tok})
 	w.mu.Unlock()

--- a/transition.go
+++ b/transition.go
@@ -21,6 +21,19 @@ type Transition struct {
 	// for the timeout; a zero value means the transition is not timed. The library
 	// never fires it on its own; a host schedules the check.
 	timeout time.Duration
+
+	// resets holds the places this transition CLEARS when it fires — reset
+	// arcs, the Petri-net primitive for cancellation regions. Firing removes
+	// every token from each reset place atomically with the marking move:
+	// inputs are consumed, reset places are emptied, and only then are
+	// outputs produced (so a place that is both reset and an output keeps
+	// what this firing produces). Reset places do not affect enablement.
+	//
+	// The canonical use is an OR-outcome AND-split: a reject transition on
+	// one review branch resets the sibling branch's places, cancelling its
+	// pending work — and any timer running on those tokens — in the same
+	// atomic firing.
+	resets []Place
 }
 
 // Constraint represents a validation constraint for a transition
@@ -116,6 +129,32 @@ func (t *Transition) SetTimeoutAfter(d time.Duration) {
 // mirror.
 func (t *Transition) TimeoutAfter() (time.Duration, bool) {
 	return t.timeout, t.timeout > 0
+}
+
+// SetResets declares the places this transition clears when it fires (reset
+// arcs / a cancellation region). Duplicates are collapsed; order is not
+// significant. Reset places must exist in the definition — NewDefinition
+// validates them. Resets are part of the definition's Fingerprint.
+func (t *Transition) SetResets(places ...Place) {
+	seen := make(map[Place]bool, len(places))
+	t.resets = t.resets[:0]
+	for _, p := range places {
+		if !seen[p] {
+			seen[p] = true
+			t.resets = append(t.resets, p)
+		}
+	}
+}
+
+// Resets returns the places this transition clears when it fires. The returned
+// slice is a copy.
+func (t *Transition) Resets() []Place {
+	if len(t.resets) == 0 {
+		return nil
+	}
+	out := make([]Place, len(t.resets))
+	copy(out, t.resets)
+	return out
 }
 
 // AddConstraint adds a constraint to the transition

--- a/workflow.go
+++ b/workflow.go
@@ -591,9 +591,10 @@ func (w *Workflow) ApplyTransitionWithContext(ctx context.Context, transitionNam
 		}
 	}
 
-	// Move tokens from the input places to the output places, preserving colored
-	// token data and leaving unrelated places untouched.
-	w.moveMarking(from, to)
+	// Move tokens from the input places to the output places (clearing any
+	// reset places), preserving colored token data and leaving unrelated
+	// places untouched.
+	w.moveMarking(from, to, targetTransition.Resets())
 
 	// Fire after transition event (unlock before calling listeners)
 	w.mu.Unlock()
@@ -681,9 +682,10 @@ func (w *Workflow) ApplyWithContext(ctx context.Context, targetPlaces []Place) e
 		}
 	}
 
-	// Move tokens from the input places to the output places, preserving colored
-	// token data and leaving unrelated places untouched.
-	w.moveMarking(from, targetPlaces)
+	// Move tokens from the input places to the output places (clearing any
+	// reset places), preserving colored token data and leaving unrelated
+	// places untouched.
+	w.moveMarking(from, targetPlaces, transition.Resets())
 
 	// Fire after transition event (unlock before calling listeners)
 	w.mu.Unlock()

--- a/yaml/config.go
+++ b/yaml/config.go
@@ -85,6 +85,7 @@ type TransitionConfig struct {
 	To           []string       `yaml:"to"`
 	Guard        string         `yaml:"guard,omitempty"`         // Expression string
 	After        string         `yaml:"after,omitempty"`         // Timeout duration, e.g. "72h" (Go time.ParseDuration)
+	Resets       []string       `yaml:"resets,omitempty"`        // Places cleared when this transition fires (cancellation region)
 	Metadata     map[string]any `yaml:"metadata,omitempty"`      // Transition metadata
 	Notes        string         `yaml:"notes,omitempty"`         // Default notes for history
 	Actor        string         `yaml:"actor,omitempty"`         // Default actor for history
@@ -204,6 +205,9 @@ func (c *Config) Validate() error {
 			for _, to := range trans.To {
 				placeSet[to] = true
 			}
+			for _, reset := range trans.Resets {
+				placeSet[reset] = true
+			}
 		}
 	}
 
@@ -237,6 +241,12 @@ func (c *Config) Validate() error {
 		for _, to := range trans.To {
 			if !placeSet[to] {
 				return fmt.Errorf("transition '%s' references undefined place '%s'", trans.Name, to)
+			}
+		}
+
+		for _, reset := range trans.Resets {
+			if !placeSet[reset] {
+				return fmt.Errorf("transition '%s' resets undefined place '%s'", trans.Name, reset)
 			}
 		}
 	}

--- a/yaml/loader.go
+++ b/yaml/loader.go
@@ -49,6 +49,9 @@ func (l *Loader) LoadDefinition(config *Config) (*workflow.Definition, error) {
 			for _, to := range trans.To {
 				placeSet[to] = true
 			}
+			for _, reset := range trans.Resets {
+				placeSet[reset] = true
+			}
 		}
 		for placeName := range placeSet {
 			places = append(places, workflow.Place(placeName))
@@ -103,6 +106,16 @@ func (l *Loader) LoadDefinition(config *Config) (*workflow.Definition, error) {
 				return nil, fmt.Errorf("transition '%s': after duration must be positive, got %q", transConfig.Name, transConfig.After)
 			}
 			transition.SetTimeoutAfter(d)
+		}
+
+		// Reset arcs (cancellation region): places cleared when this
+		// transition fires. Place existence is validated by NewDefinition.
+		if len(transConfig.Resets) > 0 {
+			resets := make([]workflow.Place, len(transConfig.Resets))
+			for i, p := range transConfig.Resets {
+				resets[i] = workflow.Place(p)
+			}
+			transition.SetResets(resets...)
 		}
 
 		// Add transition metadata

--- a/yaml/resets_test.go
+++ b/yaml/resets_test.go
@@ -1,0 +1,70 @@
+package yaml_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/workflow/yaml"
+)
+
+// TestResetsFromYAML: the `resets:` key wires reset arcs (cancellation
+// regions) through the strict loader.
+func TestResetsFromYAML(t *testing.T) {
+	cfg, err := yaml.LoadConfigFromBytes([]byte(`
+workflow:
+  name: cancel_demo
+  initial_marking: start
+  transitions:
+    - name: split
+      from: [start]
+      to: [a, b]
+    - name: reject_a
+      from: [a]
+      to: [rejected]
+      resets: [b]
+`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	wf, err := yaml.NewLoader().LoadWorkflow(cfg, "wf")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	if got := wf.Definition().Transition("reject_a").Resets(); len(got) != 1 || got[0] != "b" {
+		t.Fatalf("resets not wired, got %v", got)
+	}
+
+	// End to end: firing the reject clears the sibling branch.
+	if err := wf.ApplyTransition("split"); err != nil {
+		t.Fatal(err)
+	}
+	if err := wf.ApplyTransition("reject_a"); err != nil {
+		t.Fatal(err)
+	}
+	places := wf.Marking().Places()
+	if len(places) != 1 || places[0] != "rejected" {
+		t.Fatalf("want only rejected after the reset, got %v", places)
+	}
+}
+
+// TestResetsValidation: a reset naming an undefined place is rejected when
+// places are declared explicitly.
+func TestResetsValidation(t *testing.T) {
+	_, err := yaml.LoadConfigFromBytes([]byte(`
+workflow:
+  name: bad
+  initial_marking: a
+  places:
+    - name: a
+    - name: b
+  transitions:
+    - name: t
+      from: [a]
+      to: [b]
+      resets: [ghost]
+`))
+	if err == nil || !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("want validation error naming ghost, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

The friction log's **#1 ranked missing feature**, shipped as reset arcs — the standard Petri-net formalism for cancellation regions.

**The primitive:** a transition declares places it clears when it fires — `Transition.SetResets("b", "c")` in Go, `resets: [b, c]` in YAML. Firing consumes inputs, empties every reset place, then produces outputs (a place that is both reset and an output keeps what the firing produces), all inside the same critical section as the marking move — in every apply path, including per-token firing (where a reset clears the WHOLE place, siblings included). Reset places do not affect enablement.

**Why it matters:**
- **Timers die with their tokens.** The due index derives from the marking, so a reject that resets the sibling branch kills its escalation deadline in the same atomic firing — no zombie escalations, no host bookkeeping.
- **Validated, fingerprinted, visible**: `NewDefinition` rejects unknown reset places; the strict YAML loader wires and infers them; resets are part of the definition fingerprint (⚠️ Breaking: every fingerprint changes — `WithDefinitionMigration` is the path, and the dogfood demonstrates it); Mermaid renders reset edges.

**Dogfood proof:** the expense app's four reject transitions now declare resets on the sibling review branch, `Revise` **deleted its six-place `ClearPlace` token surgery**, and the old stranded-branch test asserts the opposite behavior now (`TestRejectCancelsSiblingBranch`: marking is exactly `[rejected]`, due index instantly quiet). The library grew the feature; the app deleted the workaround.

**Verification:** 9 new core tests (atomic clearing, enablement-neutrality, reset∩output survival, per-token whole-place semantics, timer kill, validation, fingerprint change, accessor copy/dedup, 50× concurrent race) + 2 YAML tests; full `-race` suite green on root and all example modules. Also fixes doc.go drift (timers were still listed as unavailable post-M4).

## Roadmap milestone

Post-M5 friction-log-driven feature #1 (new ROADMAP section). Stacked on #23 → #22 → #21.

## Checklist

- [x] `gofmt -s -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (root + example modules)
- [x] Exported symbols have godoc comments
- [x] `CHANGELOG.md` updated under **[Unreleased]** (Added + Breaking)
- [x] Docs/examples only describe behavior the engine can actually execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)