### PR TITLE
feat: WithFireDueTxSideEffect — exactly-once timer audit records (friction #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`WithFireDueTxSideEffect` — exactly-once timer audit records** (friction
+  log #4). A `FireDue`-scoped transactional side effect that receives the
+  steps the pass fired (**`FiredStep`**: transition + the marking before and
+  after it) *inside* the save's transaction. A plain `WithTxSideEffect`
+  could never serve here — `FireDue` returns the fired names only after its
+  save commits, leaving an at-least-once crash window for post-hoc history
+  writes. Now a timer firing and its audit record commit or roll back
+  together, exactly like an interactive `Execute` fire; the effect is
+  skipped when the pass fired nothing, and plain `Execute` rejects the
+  option (only `FireDue` knows what fired). The dogfood's escalation tick
+  deleted its post-hoc write and its timer records gained from/to markings.
 - **Normalized token storage + cross-instance token queries.** The SQL
   backends now persist a marking as one row per token in a child table
   (`<state_table>_tokens`: workflow_id, place, token_id, full token JSON)

--- a/docs/guides/TIMERS_GUIDE.md
+++ b/docs/guides/TIMERS_GUIDE.md
@@ -205,6 +205,31 @@ deadlines are measured from one consistent instant.
 limit. To page a very large backlog, drain a batch with `FireDue` before rescanning,
 or raise `before` in steps.
 
+### Exactly-once audit records for timer firings
+
+To record each firing in a history/audit table, don't write it after `FireDue`
+returns — a crash between the state commit and your write loses the record. Use
+`WithFireDueTxSideEffect`, which runs *inside* the save's transaction with the
+fired steps in hand (transition plus the marking on each side), so the state
+change and its record commit or roll back together:
+
+```go
+fired, err := mgr.FireDue(ctx, id, def, now,
+    workflow.WithFireDueTxSideEffect(func(ctx context.Context, tx any, steps []workflow.FiredStep) error {
+        for _, s := range steps {
+            if err := hist.SaveTransitionTx(ctx, tx.(*sql.Tx), &history.TransitionRecord{
+                WorkflowID: id, Transition: s.Transition, Actor: "timer", CreatedAt: now,
+            }); err != nil {
+                return err
+            }
+        }
+        return nil
+    }))
+```
+
+The effect is skipped when the pass fires nothing, and it requires a
+`TransactionalStorage` backend (the SQLite and Postgres backends qualify).
+
 ### Guards don't lose to the clock (and vice versa)
 
 A timer says *when* a transition may fire; a **guard** still says *whether* it may.

--- a/docs/roadmap/FRICTION.md
+++ b/docs/roadmap/FRICTION.md
@@ -70,12 +70,21 @@ workaround.
    (`workflow.TokenQueryStorage` / `Manager.ListPlaceTokens`) — has shipped
    too, closing the doc's open work (see its §9.6 for the as-built shape).
 
-4. **`FireDue` cannot join a caller transaction.** Interactive fires get
-   atomic state+history via `Execute` + `WithTxSideEffect`, but `FireDue`
-   returns the fired names only after its own save commits, so timer audit
-   records are written post-hoc (at-least-once; a crash between commit and
-   history write loses the record). Wanted: a `FireDue` option receiving the
-   fired transitions *inside* the transaction.
+4. ✅ **SHIPPED: `WithFireDueTxSideEffect`** (was: `FireDue` cannot join a
+   caller transaction). A `FireDue`-scoped tx side effect now receives the
+   pass's fired steps — transition plus the marking on each side — *inside*
+   the save's transaction, so a timer firing and its audit record commit or
+   roll back together, exactly like an interactive fire. The dogfood's
+   `Tick` deleted its post-hoc `SaveTransition` loop, its timer records
+   gained from/to markings, and plain `Execute` rejects the option (only
+   `FireDue` knows what fired). Original finding kept below.
+
+   **Original entry**: interactive fires get atomic state+history via
+   `Execute` + `WithTxSideEffect`, but `FireDue` returns the fired names
+   only after its own save commits, so timer audit records are written
+   post-hoc (at-least-once; a crash between commit and history write loses
+   the record). Wanted: a `FireDue` option receiving the fired transitions
+   *inside* the transaction.
 
 5. **Cross-instance steps are the host's problem** (expected — but the
    recipe deserves docs). Expense → payment-net enqueue and pay →
@@ -145,9 +154,8 @@ Priority order for what the library needs next, from what actually hurt:
    fires the first allowed candidate, skipping not-enabled and
    guard-rejected ones; the dogfood's `routeSubmit` is now one call.
 
-4. **`FireDue` side effects** (entry 4). Timer audit records are still
-   at-least-once while every interactive fire is exactly-once. Grows worse
-   as timers multiply.
+4. ✅ **SHIPPED: `FireDue` side effects** — `WithFireDueTxSideEffect` (see
+   resolved entry 4 above); timer audit records are exactly-once now.
 
 5. **Additive-change detection for fingerprints** (new). Adding `release`,
    `revise`, and submit routing changed both nets' fingerprints; the

--- a/examples/expense_approval/README.md
+++ b/examples/expense_approval/README.md
@@ -73,7 +73,11 @@ transition when the webhook arrives. The error split does the HTTP mapping:
 through `Manager.Execute` with `WithTxSideEffect` writing the history record
 in the *same transaction* as the state save (`app.go: fire`). The
 crash-consistency test injects a failing side effect and proves neither half
-lands. (Timer firings are the documented exception — see the friction log.)
+lands. Timer firings get the same guarantee via `WithFireDueTxSideEffect`:
+the effect receives the fired steps (transition + from/to marking) *inside*
+`FireDue`'s transaction, so the escalation tick's history records are
+exactly-once too — this was friction entry #4 until the library grew the
+option.
 
 **Guards route, straight from context.** `submit` is an XOR-split decided
 by guard expressions over the workflow context: `amount <= 100.0` sends

--- a/examples/expense_approval/app.go
+++ b/examples/expense_approval/app.go
@@ -607,9 +607,11 @@ func (a *App) markPaid(ctx context.Context, id string) error {
 // their due transitions. Wired to a time.Ticker in main and to a fake clock
 // in tests — same code path.
 //
-// History for timer firings is written after the state commit (FireDue owns
-// its transaction and returns the fired names only afterwards), so unlike
-// interactive fires it is at-least-once, not atomic — friction-logged.
+// History for timer firings commits in the SAME transaction as the state
+// change (WithFireDueTxSideEffect hands the fired steps to the effect inside
+// FireDue's save), so timer fires are exactly-once, just like interactive
+// fires — this replaced the post-hoc at-least-once write that was friction
+// entry #4.
 func (a *App) Tick(ctx context.Context, now time.Time) (fired map[string][]string, err error) {
 	ids, err := a.mgr.ListDue(ctx, now, 0)
 	if err != nil {
@@ -623,26 +625,30 @@ func (a *App) Tick(ctx context.Context, now time.Time) (fired map[string][]strin
 		if id == paymentID {
 			continue // the payment net has no timers
 		}
-		names, err := a.mgr.FireDue(ctx, id, a.expenseDef, now)
+		names, err := a.mgr.FireDue(ctx, id, a.expenseDef, now,
+			workflow.WithFireDueTxSideEffect(func(ctx context.Context, tx any, steps []workflow.FiredStep) error {
+				for _, s := range steps {
+					rec := &history.TransitionRecord{
+						WorkflowID: id,
+						FromState:  placesString(s.Before),
+						ToState:    placesString(s.After),
+						Transition: s.Transition,
+						Actor:      "timer",
+						Notes:      "fired by escalation tick",
+						CreatedAt:  now,
+					}
+					if err := a.hist.SaveTransitionTx(ctx, tx.(*sql.Tx), rec); err != nil {
+						return err
+					}
+				}
+				return nil
+			}))
 		if err != nil {
 			errs = append(errs, fmt.Errorf("fire due %s: %w", id, err))
 			continue
 		}
-		if len(names) == 0 {
-			continue
-		}
-		fired[id] = names
-		for _, name := range names {
-			rec := &history.TransitionRecord{
-				WorkflowID: id,
-				Transition: name,
-				Actor:      "timer",
-				Notes:      "fired by escalation tick",
-				CreatedAt:  now,
-			}
-			if err := a.hist.SaveTransition(ctx, rec); err != nil {
-				errs = append(errs, fmt.Errorf("record timer history for %s: %w", id, err))
-			}
+		if len(names) > 0 {
+			fired[id] = names
 		}
 	}
 	return fired, errors.Join(errs...)

--- a/examples/expense_approval/app_test.go
+++ b/examples/expense_approval/app_test.go
@@ -94,14 +94,23 @@ func TestEscalationTick(t *testing.T) {
 		t.Fatalf("want legal_approve (OR-input), fired %v", names)
 	}
 
-	// Timer firings are recorded in the audit trail (post-hoc, actor
-	// "timer").
+	// Timer firings are recorded in the audit trail atomically with the
+	// state commit (WithFireDueTxSideEffect), actor "timer", with the
+	// from/to markings of each step — no longer a post-hoc write.
 	recs, err := app.hist.ListHistory(ctx, id, history.QueryOptions{Actor: "timer"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(recs) != 2 {
 		t.Fatalf("want 2 timer history records, got %d", len(recs))
+	}
+	for _, r := range recs {
+		if r.FromState == "" || r.ToState == "" {
+			t.Fatalf("timer record must carry the step's from/to marking, got %+v", r)
+		}
+		if !strings.Contains(r.ToState, "escalated") {
+			t.Fatalf("timer record ToState = %q, want an escalated place", r.ToState)
+		}
 	}
 }
 

--- a/manager.go
+++ b/manager.go
@@ -291,6 +291,15 @@ type ExecuteOption func(*executeConfig)
 type executeConfig struct {
 	effects     []TxSideEffect
 	maxAttempts int
+
+	// firedEffects are FireDue-scoped tx side effects (WithFireDueTxSideEffect):
+	// like effects, but each receives the steps the FireDue pass fired.
+	// firedSteps is the provider FireDue installs so the wrapped effects can
+	// read the current attempt's steps at commit time; it is nil under plain
+	// Execute, which rejects firedEffects rather than silently dropping the
+	// payload.
+	firedEffects []FireDueTxSideEffect
+	firedSteps   func() []FiredStep
 }
 
 // WithMaxRetries sets how many times Execute retries the whole
@@ -333,6 +342,48 @@ func WithTxSideEffect(effect TxSideEffect) ExecuteOption {
 	return func(c *executeConfig) { c.effects = append(c.effects, effect) }
 }
 
+// FiredStep describes one timer firing inside a FireDue pass: the transition
+// that fired and the marking on each side of it — what a host needs to write
+// an audit/history record for the firing.
+type FiredStep struct {
+	Transition string
+	Before     []Place
+	After      []Place
+}
+
+// FireDueTxSideEffect is a write committed atomically with a FireDue save,
+// receiving the steps the pass fired. See WithFireDueTxSideEffect.
+type FireDueTxSideEffect func(ctx context.Context, tx any, steps []FiredStep) error
+
+// WithFireDueTxSideEffect registers a write committed atomically with the
+// FireDue save that receives the transitions the pass fired — the
+// exactly-once way to record timer firings. A plain WithTxSideEffect cannot
+// serve here: FireDue returns the fired names only after its save commits, so
+// a host writing history from the return value has an at-least-once crash
+// window between the two. This effect runs inside the save's transaction with
+// the fired steps in hand, so the state change and its audit record commit or
+// roll back together, exactly like an interactive Execute fire:
+//
+//	fired, err := mgr.FireDue(ctx, id, def, now,
+//	    workflow.WithFireDueTxSideEffect(func(ctx context.Context, tx any, steps []workflow.FiredStep) error {
+//	        for _, s := range steps {
+//	            if err := hist.SaveTransitionTx(ctx, tx.(*sql.Tx), &history.TransitionRecord{
+//	                WorkflowID: id, Transition: s.Transition, Actor: "timer", CreatedAt: now,
+//	            }); err != nil {
+//	                return err
+//	            }
+//	        }
+//	        return nil
+//	    }))
+//
+// The effect is skipped when the pass fired nothing (a due-index self-heal
+// save has no steps to record). Like WithTxSideEffect it requires a
+// TransactionalStorage backend, and it is only meaningful under FireDue —
+// plain Execute rejects it, since only FireDue knows what fired.
+func WithFireDueTxSideEffect(effect FireDueTxSideEffect) ExecuteOption {
+	return func(c *executeConfig) { c.firedEffects = append(c.firedEffects, effect) }
+}
+
 // Execute atomically advances a persisted instance: it loads the instance fresh
 // from storage, runs fn against it (fn typically applies one or more
 // transitions), and saves it back under optimistic concurrency. If the save
@@ -356,6 +407,26 @@ func (m *Manager) Execute(ctx context.Context, id string, definition *Definition
 	var cfg executeConfig
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+
+	// FireDue-scoped effects are only meaningful when a steps provider was
+	// installed (by FireDue itself): plain Execute has no fired steps to hand
+	// them, so reject rather than silently invoke with nothing. Wrapping them
+	// into plain effects BEFORE the transactional-support check keeps the
+	// atomicity requirement applying to them too.
+	if len(cfg.firedEffects) > 0 {
+		if cfg.firedSteps == nil {
+			return fmt.Errorf("WithFireDueTxSideEffect is only valid with FireDue: %w", errors.ErrUnsupported)
+		}
+		for _, fe := range cfg.firedEffects {
+			cfg.effects = append(cfg.effects, func(ctx context.Context, tx any) error {
+				steps := cfg.firedSteps()
+				if len(steps) == 0 {
+					return nil // a self-heal save with no firing needs no record
+				}
+				return fe(ctx, tx, steps)
+			})
+		}
 	}
 
 	// Atomic side effects need transactional support; fail loudly rather than
@@ -592,11 +663,22 @@ var errFireDueNoSave = errors.New("firedue: no save needed")
 // leaves no running timer the instance drops out of ListDue.
 //
 // Extra ExecuteOptions (e.g. WithMaxRetries, WithTxSideEffect) are forwarded to
-// the underlying Execute.
+// the underlying Execute; WithFireDueTxSideEffect additionally receives the
+// steps this pass fired, inside the save's transaction (see its doc).
 func (m *Manager) FireDue(ctx context.Context, id string, definition *Definition, now time.Time, opts ...ExecuteOption) ([]string, error) {
 	var fired []string
+	var steps []FiredStep
+	// Install the steps provider for WithFireDueTxSideEffect: the wrapped
+	// effects run after fn within the same attempt, so reading the shared
+	// slice hands them exactly this attempt's steps.
+	execOpts := make([]ExecuteOption, 0, len(opts)+1)
+	execOpts = append(execOpts, opts...)
+	execOpts = append(execOpts, func(c *executeConfig) {
+		c.firedSteps = func() []FiredStep { return steps }
+	})
 	err := m.Execute(ctx, id, definition, func(wf *Workflow) error {
 		fired = nil // Execute may re-run fn on a conflict retry; start clean.
+		steps = nil
 		wf.setClock(func() time.Time { return now })
 		for range maxFireDueSteps {
 			// Fire the first due transition that is actually allowed, then
@@ -604,6 +686,7 @@ func (m *Manager) FireDue(ctx context.Context, id string, definition *Definition
 			// fires — the set is empty, or every member is guard-blocked or was
 			// disabled earlier in this pass — the pass is done.
 			progressed := false
+			before := wf.CurrentPlaces()
 			for _, t := range wf.Due(now) {
 				err := wf.ApplyTransitionWithContext(ctx, t.Name())
 				if err != nil {
@@ -613,6 +696,7 @@ func (m *Manager) FireDue(ctx context.Context, id string, definition *Definition
 					return err
 				}
 				fired = append(fired, t.Name())
+				steps = append(steps, FiredStep{Transition: t.Name(), Before: before, After: wf.CurrentPlaces()})
 				progressed = true
 				break
 			}
@@ -632,7 +716,7 @@ func (m *Manager) FireDue(ctx context.Context, id string, definition *Definition
 			}
 		}
 		return nil
-	}, opts...)
+	}, execOpts...)
 	if err != nil && !errors.Is(err, errFireDueNoSave) {
 		return nil, err
 	}

--- a/timers_firedue_test.go
+++ b/timers_firedue_test.go
@@ -85,6 +85,60 @@ func (s *partialDueTxStore) SaveStateInTx(ctx context.Context, id string, m work
 	return v, nil
 }
 
+// txDueStore is a full in-memory TransactionalDueStorage: state, due index,
+// and side effects commit together, and an effect error rolls the whole save
+// back — mirroring the real SQL backends' transaction semantics.
+type txDueStore struct {
+	*memDueStore
+}
+
+func (s *txDueStore) SaveStateInTx(ctx context.Context, id string, m workflow.Marking, c map[string]any, expected int64, effects ...workflow.TxSideEffect) (int64, error) {
+	return s.saveWithRollback(ctx, id, m, c, expected, nil, false, effects)
+}
+
+func (s *txDueStore) SaveStateInTxWithDue(ctx context.Context, id string, m workflow.Marking, c map[string]any, expected int64, due *time.Time, effects ...workflow.TxSideEffect) (int64, error) {
+	return s.saveWithRollback(ctx, id, m, c, expected, due, true, effects)
+}
+
+func (s *txDueStore) saveWithRollback(ctx context.Context, id string, m workflow.Marking, c map[string]any, expected int64, due *time.Time, setDue bool, effects []workflow.TxSideEffect) (int64, error) {
+	// Snapshot the raw row + due entry so an effect error can restore them.
+	s.mu.Lock()
+	prevRow, existed := s.rows[id]
+	s.mu.Unlock()
+	prevDue, hadDue := s.storedDue(id)
+
+	var v int64
+	var err error
+	if setDue {
+		v, err = s.SaveStateWithDue(ctx, id, m, c, expected, due)
+	} else {
+		v, err = s.SaveState(ctx, id, m, c, expected)
+	}
+	if err != nil {
+		return 0, err
+	}
+	for _, e := range effects {
+		if err := e(ctx, nil); err != nil {
+			s.mu.Lock()
+			if existed {
+				s.rows[id] = prevRow
+			} else {
+				delete(s.rows, id)
+			}
+			s.mu.Unlock()
+			s.dmu.Lock()
+			if hadDue {
+				s.due[id] = prevDue
+			} else {
+				delete(s.due, id)
+			}
+			s.dmu.Unlock()
+			return 0, err
+		}
+	}
+	return v, nil
+}
+
 // fireDueEpoch is a fixed reference time so every FireDue test is deterministic
 // without ever sleeping.
 var fireDueEpoch = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
@@ -465,5 +519,139 @@ func TestFireDue_UnsupportedStorageForListDue(t *testing.T) {
 	mgr := workflow.NewManager(workflow.NewRegistry(), newMemStore())
 	if _, err := mgr.ListDue(context.Background(), fireDueEpoch, 0); !errors.Is(err, errors.ErrUnsupported) {
 		t.Fatalf("ListDue on non-DueStorage backend = %v, want ErrUnsupported", err)
+	}
+}
+
+// TestFireDueTxSideEffect_ReceivesStepsInTx: the FireDue-scoped effect runs
+// inside the save's transaction WITH the fired steps in hand — transition
+// plus the marking on each side — which is what makes timer audit records
+// exactly-once (friction #4).
+func TestFireDueTxSideEffect_ReceivesStepsInTx(t *testing.T) {
+	ctx := context.Background()
+	def := escalationDef(t, 72*time.Hour, "")
+	store := &txDueStore{memDueStore: newMemDueStore()}
+	mgr := workflow.NewManager(workflow.NewRegistry(), store)
+	seedSubmitted(t, mgr, "wf", def, fireDueEpoch, nil)
+
+	var got [][]workflow.FiredStep
+	fired, err := mgr.FireDue(ctx, "wf", def, fireDueEpoch.Add(72*time.Hour),
+		workflow.WithFireDueTxSideEffect(func(ctx context.Context, tx any, steps []workflow.FiredStep) error {
+			got = append(got, steps)
+			return nil
+		}))
+	if err != nil {
+		t.Fatalf("FireDue: %v", err)
+	}
+	if len(fired) != 1 || fired[0] != "escalate" {
+		t.Fatalf("fired = %v, want [escalate]", fired)
+	}
+	if len(got) != 1 {
+		t.Fatalf("effect invocations = %d, want exactly 1", len(got))
+	}
+	steps := got[0]
+	if len(steps) != 1 || steps[0].Transition != "escalate" {
+		t.Fatalf("steps = %+v, want one escalate step", steps)
+	}
+	if len(steps[0].Before) != 1 || steps[0].Before[0] != "submitted" {
+		t.Fatalf("step.Before = %v, want [submitted]", steps[0].Before)
+	}
+	if len(steps[0].After) != 1 || steps[0].After[0] != "escalated" {
+		t.Fatalf("step.After = %v, want [escalated]", steps[0].After)
+	}
+}
+
+// TestFireDueTxSideEffect_SkippedWhenNothingFires: a pass that fires nothing
+// (including the due-index self-heal save) has no steps to record, so the
+// effect is never invoked.
+func TestFireDueTxSideEffect_SkippedWhenNothingFires(t *testing.T) {
+	ctx := context.Background()
+	def := escalationDef(t, 72*time.Hour, "")
+	store := &txDueStore{memDueStore: newMemDueStore()}
+	mgr := workflow.NewManager(workflow.NewRegistry(), store)
+	seedSubmitted(t, mgr, "wf", def, fireDueEpoch, nil)
+
+	invoked := 0
+	fired, err := mgr.FireDue(ctx, "wf", def, fireDueEpoch.Add(time.Hour),
+		workflow.WithFireDueTxSideEffect(func(ctx context.Context, tx any, steps []workflow.FiredStep) error {
+			invoked++
+			return nil
+		}))
+	if err != nil {
+		t.Fatalf("FireDue(before deadline): %v", err)
+	}
+	if len(fired) != 0 || invoked != 0 {
+		t.Fatalf("fired %v, effect invoked %d times — want none/0 before the deadline", fired, invoked)
+	}
+}
+
+// TestFireDueTxSideEffect_EffectErrorRollsBack is the exactly-once guarantee:
+// when the audit write fails, the state change rolls back with it, the timer
+// stays due, and the next pass re-fires and re-records — never a firing
+// without its record or a record without its firing.
+func TestFireDueTxSideEffect_EffectErrorRollsBack(t *testing.T) {
+	ctx := context.Background()
+	def := escalationDef(t, 72*time.Hour, "")
+	store := &txDueStore{memDueStore: newMemDueStore()}
+	mgr := workflow.NewManager(workflow.NewRegistry(), store)
+	seedSubmitted(t, mgr, "wf", def, fireDueEpoch, nil)
+
+	boom := errors.New("history write failed")
+	fail := true
+	var recorded []string
+	effect := workflow.WithFireDueTxSideEffect(func(ctx context.Context, tx any, steps []workflow.FiredStep) error {
+		if fail {
+			return boom
+		}
+		for _, s := range steps {
+			recorded = append(recorded, s.Transition)
+		}
+		return nil
+	})
+
+	deadline := fireDueEpoch.Add(72 * time.Hour)
+	if _, err := mgr.FireDue(ctx, "wf", def, deadline, effect); !errors.Is(err, boom) {
+		t.Fatalf("FireDue with failing effect = %v, want the effect's error", err)
+	}
+
+	// The firing rolled back with the record: still submitted, still due.
+	wf, err := mgr.LoadWorkflow(ctx, "wf", def)
+	if err != nil {
+		t.Fatalf("LoadWorkflow: %v", err)
+	}
+	if !wf.Marking().HasPlace("submitted") {
+		t.Fatalf("marking = %v, want the firing rolled back to [submitted]", wf.CurrentPlaces())
+	}
+	if due, err := mgr.ListDue(ctx, deadline, 0); err != nil || len(due) != 1 || due[0] != "wf" {
+		t.Fatalf("ListDue after rollback = %v (%v), want [wf] still due", due, err)
+	}
+
+	// The next pass re-fires and records exactly once.
+	fail = false
+	fired, err := mgr.FireDue(ctx, "wf", def, deadline, effect)
+	if err != nil {
+		t.Fatalf("FireDue(retry): %v", err)
+	}
+	if len(fired) != 1 || fired[0] != "escalate" {
+		t.Fatalf("retry fired = %v, want [escalate]", fired)
+	}
+	if len(recorded) != 1 || recorded[0] != "escalate" {
+		t.Fatalf("recorded = %v, want exactly one escalate record", recorded)
+	}
+}
+
+// TestExecuteRejectsFireDueTxSideEffect: only FireDue knows what fired, so
+// plain Execute refuses the option instead of silently invoking the effect
+// with nothing.
+func TestExecuteRejectsFireDueTxSideEffect(t *testing.T) {
+	ctx := context.Background()
+	def := escalationDef(t, 72*time.Hour, "")
+	store := &txDueStore{memDueStore: newMemDueStore()}
+	mgr := workflow.NewManager(workflow.NewRegistry(), store)
+	seedSubmitted(t, mgr, "wf", def, fireDueEpoch, nil)
+
+	err := mgr.Execute(ctx, "wf", def, func(wf *workflow.Workflow) error { return nil },
+		workflow.WithFireDueTxSideEffect(func(ctx context.Context, tx any, steps []workflow.FiredStep) error { return nil }))
+	if !errors.Is(err, errors.ErrUnsupported) {
+		t.Fatalf("Execute with a FireDue-scoped effect = %v, want ErrUnsupported", err)
 	}
 }


### PR DESCRIPTION
## Summary

Friction log **#4**, shipped — the last ranked library gap from the M5 dogfood.

**The problem:** `FireDue` returned the fired names only after its own save committed, so a host writing timer history from the return value had an **at-least-once** crash window (a firing could commit and lose its record) — while every interactive fire was already exactly-once via `Execute` + `WithTxSideEffect`.

**The fix:** `WithFireDueTxSideEffect` registers a `FireDue`-scoped transactional side effect that **receives the pass's fired steps inside the save's transaction** — `FiredStep` carries the transition plus the marking on each side of it, which is exactly what an audit record needs. State change and record now commit or roll back together.

Semantics pinned by tests (against a new full in-memory `TransactionalDueStorage` fake with real rollback):
- the effect gets the steps `[{escalate, [submitted] → [escalated]}]`, exactly once per pass
- skipped when the pass fires nothing (a due-index self-heal save has no steps to record)
- an effect error **rolls the firing back**: still due, next pass re-fires and records exactly once — never a firing without its record or a record without its firing
- plain `Execute` rejects the option (`ErrUnsupported`) — only `FireDue` knows what fired
- conflict-retry safe: `fn` rebuilds the steps each attempt and the wrapped effect reads them at commit time

**Dogfood proof:** `Tick` deleted its post-hoc `SaveTransition` loop — the friction entry's workaround — and its timer records gained from/to markings (`TestEscalationTick` asserts both). `TIMERS_GUIDE.md` documents the recipe.

## Roadmap milestone

Post-M5 friction-log-driven feature #4 (the ranked list's last unshipped library item).

## Checklist

- [x] `gofmt -s -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (root + examples, run serialized)
- [x] `CHANGELOG.md` updated under **[Unreleased]**
- [x] Docs/examples only describe behavior the engine can actually execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)