### PR TITLE
feat: structural diffs for definition migration hooks (friction #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Structural diffs for definition migration** (friction log #5). Every
+  save stamps a compact definition *shape* (sorted place names plus a short
+  hash of each transition's structural record, a few hundred bytes under
+  the reserved `__workflow_def_shape` context key) alongside the
+  fingerprint. On a mismatch, the `WithDefinitionMigration` handler now
+  receives a **`DefinitionMismatch`** carrying both fingerprints and a
+  **`DefinitionDiff`** — places and transitions added/removed/changed, by
+  name (a renamed place reads as remove+add with its referencing
+  transitions marked changed). `Diff.Additive()` turns "new structure only,
+  approve mechanically" into a one-line policy; `Diff` is nil for state
+  saved by pre-shape versions ("no information", not "no change"). The
+  dogfood's hook now refuses non-additive expense-net changes instead of
+  approving every upgrade blindly.
 - **`WithFireDueTxSideEffect` — exactly-once timer audit records** (friction
   log #4). A `FireDue`-scoped transactional side effect that receives the
   steps the pass fired (**`FiredStep`**: transition + the marking before and
@@ -112,6 +125,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cancelling its pending work — previously host-side token surgery.
 
 ### Breaking
+- **`DefinitionMigrationFunc` signature changed**: the handler now receives
+  one `DefinitionMismatch` struct (workflow ID, stored/current fingerprints,
+  structural `Diff`) instead of `(id, storedFingerprint, currentFingerprint)`
+  strings — update handlers to
+  `func(ctx context.Context, mm workflow.DefinitionMismatch) error`. The
+  fingerprint itself is unchanged; the newly stamped shape rides in a second
+  reserved context key (`__workflow_def_shape`), stripped on load like the
+  fingerprint.
 - The definition fingerprint encoding now includes each transition's reset
   places and input mode (AND-join vs OR-input), so **every fingerprint
   changes** with this version. Persisted

--- a/definition.go
+++ b/definition.go
@@ -110,29 +110,7 @@ func (d *Definition) Fingerprint() string {
 	// fields), then sort the records for order independence.
 	transitions := make([]string, len(d.Transitions))
 	for i := range d.Transitions {
-		t := &d.Transitions[i]
-		from := placeStrings(t.From())
-		to := placeStrings(t.To())
-		slices.Sort(from)
-		slices.Sort(to)
-		guard := ""
-		if g, ok := t.Metadata("guard"); ok {
-			guard, _ = g.(string)
-		}
-		resets := placeStrings(t.Resets())
-		slices.Sort(resets)
-		inputMode := "all"
-		if t.FromAny() {
-			inputMode = "any"
-		}
-		var rec strings.Builder
-		writeLenPrefixed(&rec, t.Name())
-		writeLenPrefixedList(&rec, from)
-		writeLenPrefixedList(&rec, to)
-		writeLenPrefixed(&rec, guard)
-		writeLenPrefixedList(&rec, resets)
-		writeLenPrefixed(&rec, inputMode)
-		transitions[i] = rec.String()
+		transitions[i] = transitionRecord(&d.Transitions[i])
 	}
 	slices.Sort(transitions)
 
@@ -142,6 +120,36 @@ func (d *Definition) Fingerprint() string {
 	writeLenPrefixedList(&buf, transitions)
 	h.Write([]byte(buf.String()))
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+// transitionRecord serializes one transition's structural fields — name,
+// sorted inputs/outputs, guard string, sorted resets, input mode — into an
+// unambiguous length-prefixed record. Fingerprint hashes the whole sorted set
+// of records; the definition shape (see diff.go) hashes each record
+// individually so a later fingerprint mismatch can be diffed per transition.
+func transitionRecord(t *Transition) string {
+	from := placeStrings(t.From())
+	to := placeStrings(t.To())
+	slices.Sort(from)
+	slices.Sort(to)
+	guard := ""
+	if g, ok := t.Metadata("guard"); ok {
+		guard, _ = g.(string)
+	}
+	resets := placeStrings(t.Resets())
+	slices.Sort(resets)
+	inputMode := "all"
+	if t.FromAny() {
+		inputMode = "any"
+	}
+	var rec strings.Builder
+	writeLenPrefixed(&rec, t.Name())
+	writeLenPrefixedList(&rec, from)
+	writeLenPrefixedList(&rec, to)
+	writeLenPrefixed(&rec, guard)
+	writeLenPrefixedList(&rec, resets)
+	writeLenPrefixed(&rec, inputMode)
+	return rec.String()
 }
 
 // writeLenPrefixed writes s preceded by its byte length ("3:abc"), making the

--- a/diff.go
+++ b/diff.go
@@ -1,0 +1,132 @@
+package workflow
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// definitionShape is the compact structural summary the Manager persists
+// alongside the fingerprint (defShapeKey): the sorted place names plus a
+// short hash of each transition's structural record, keyed by transition
+// name. The fingerprint alone can only say THAT the definition changed; the
+// shape is what lets a later mismatch say WHAT changed (see DefinitionDiff),
+// without persisting the whole definition.
+type definitionShape struct {
+	Places      []string          `json:"p"`
+	Transitions map[string]string `json:"t"`
+}
+
+// shape returns the definition's structural summary. It covers exactly the
+// fields Fingerprint hashes — name, inputs, outputs, guard string, resets,
+// input mode per transition — so shapes are equal precisely when fingerprints
+// are.
+func (d *Definition) shape() definitionShape {
+	places := placeStrings(d.Places)
+	slices.Sort(places)
+	transitions := make(map[string]string, len(d.Transitions))
+	for i := range d.Transitions {
+		t := &d.Transitions[i]
+		sum := sha256.Sum256([]byte(transitionRecord(t)))
+		transitions[t.Name()] = hex.EncodeToString(sum[:8])
+	}
+	return definitionShape{Places: places, Transitions: transitions}
+}
+
+// DefinitionDiff describes how a currently-supplied definition differs
+// structurally from the one a persisted instance was last saved under. It is
+// handed to the WithDefinitionMigration handler (via DefinitionMismatch) so
+// approving an upgrade can be a POLICY over visible facts — "new transitions
+// only, fine" — instead of blind trust in two opaque hashes.
+//
+// A renamed place appears as one place removed plus one added, with every
+// transition that references it in TransitionsChanged — exactly the shape a
+// reviewer needs to distinguish a rename from an addition.
+type DefinitionDiff struct {
+	PlacesAdded   []Place
+	PlacesRemoved []Place
+
+	// Transition names present only in the current (added) or only in the
+	// stored (removed) definition, and names present in both whose structure
+	// — inputs, outputs, guard, resets, input mode — differs (changed).
+	TransitionsAdded   []string
+	TransitionsRemoved []string
+	TransitionsChanged []string
+}
+
+// Additive reports whether the change only ADDS structure: no place or
+// transition was removed, and no existing transition was rewired. Additive
+// changes cannot invalidate a persisted marking, so they are the class a
+// migration handler can safely approve mechanically.
+func (d *DefinitionDiff) Additive() bool {
+	return len(d.PlacesRemoved) == 0 && len(d.TransitionsRemoved) == 0 && len(d.TransitionsChanged) == 0
+}
+
+// String renders a compact one-line summary for logs, e.g.
+// "+places[archive] +transitions[archive_doc] ~transitions[approve]".
+func (d *DefinitionDiff) String() string {
+	var parts []string
+	section := func(prefix, kind string, names []string) {
+		if len(names) > 0 {
+			parts = append(parts, fmt.Sprintf("%s%s[%s]", prefix, kind, strings.Join(names, " ")))
+		}
+	}
+	section("+", "places", placeStrings(d.PlacesAdded))
+	section("-", "places", placeStrings(d.PlacesRemoved))
+	section("+", "transitions", d.TransitionsAdded)
+	section("-", "transitions", d.TransitionsRemoved)
+	section("~", "transitions", d.TransitionsChanged)
+	if len(parts) == 0 {
+		return "no structural change"
+	}
+	return strings.Join(parts, " ")
+}
+
+// diffShapes computes the structural difference from a stored shape to the
+// current one. All result slices are sorted for deterministic output.
+func diffShapes(stored, current definitionShape) *DefinitionDiff {
+	diff := &DefinitionDiff{}
+
+	storedPlaces := make(map[string]bool, len(stored.Places))
+	for _, p := range stored.Places {
+		storedPlaces[p] = true
+	}
+	currentPlaces := make(map[string]bool, len(current.Places))
+	for _, p := range current.Places {
+		currentPlaces[p] = true
+	}
+	for _, p := range current.Places {
+		if !storedPlaces[p] {
+			diff.PlacesAdded = append(diff.PlacesAdded, Place(p))
+		}
+	}
+	for _, p := range stored.Places {
+		if !currentPlaces[p] {
+			diff.PlacesRemoved = append(diff.PlacesRemoved, Place(p))
+		}
+	}
+
+	for name, hash := range current.Transitions {
+		storedHash, ok := stored.Transitions[name]
+		switch {
+		case !ok:
+			diff.TransitionsAdded = append(diff.TransitionsAdded, name)
+		case storedHash != hash:
+			diff.TransitionsChanged = append(diff.TransitionsChanged, name)
+		}
+	}
+	for name := range stored.Transitions {
+		if _, ok := current.Transitions[name]; !ok {
+			diff.TransitionsRemoved = append(diff.TransitionsRemoved, name)
+		}
+	}
+
+	slices.Sort(diff.PlacesAdded)
+	slices.Sort(diff.PlacesRemoved)
+	slices.Sort(diff.TransitionsAdded)
+	slices.Sort(diff.TransitionsRemoved)
+	slices.Sort(diff.TransitionsChanged)
+	return diff
+}

--- a/diff_test.go
+++ b/diff_test.go
@@ -1,0 +1,142 @@
+package workflow_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ehabterra/workflow"
+)
+
+// diffNet builds a small definition from a place list and (name, from, to,
+// guard) transition tuples, for exercising the structural diff.
+func diffNet(t *testing.T, places []workflow.Place, trans [][4]string) *workflow.Definition {
+	t.Helper()
+	var ts []workflow.Transition
+	for _, tr := range trans {
+		tt := workflow.MustNewTransition(tr[0], []workflow.Place{workflow.Place(tr[1])}, []workflow.Place{workflow.Place(tr[2])})
+		if tr[3] != "" {
+			tt.SetMetadata("guard", tr[3])
+		}
+		ts = append(ts, *tt)
+	}
+	def, err := workflow.NewDefinition(places, ts)
+	if err != nil {
+		t.Fatalf("NewDefinition: %v", err)
+	}
+	return def
+}
+
+// captureMismatch returns a Manager whose migration handler approves every
+// mismatch and records it for assertions.
+func captureMismatch(store workflow.Storage, out *workflow.DefinitionMismatch) *workflow.Manager {
+	return workflow.NewManager(workflow.NewRegistry(), store,
+		workflow.WithDefinitionMigration(func(_ context.Context, mm workflow.DefinitionMismatch) error {
+			*out = mm
+			return nil
+		}))
+}
+
+// TestDefinitionDiff_RemovalAndGuardChange: the diff distinguishes what the
+// bare fingerprint never could — a removed transition and a rewired one, by
+// name — so a hook can refuse non-additive changes specifically.
+func TestDefinitionDiff_RemovalAndGuardChange(t *testing.T) {
+	ctx := context.Background()
+	store := newMemStore()
+
+	v1 := diffNet(t, []workflow.Place{"a", "b", "c"}, [][4]string{
+		{"go", "a", "b", ""},
+		{"extra", "b", "c", ""},
+	})
+	mgr := workflow.NewManager(workflow.NewRegistry(), store)
+	if _, err := mgr.CreateWorkflow(ctx, "wf", v1, "a"); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+
+	// v2 drops "extra" and puts a guard on "go".
+	v2 := diffNet(t, []workflow.Place{"a", "b", "c"}, [][4]string{
+		{"go", "a", "b", "amount > 10"},
+	})
+
+	var mm workflow.DefinitionMismatch
+	if _, err := captureMismatch(store, &mm).LoadWorkflow(ctx, "wf", v2); err != nil {
+		t.Fatalf("LoadWorkflow(v2): %v", err)
+	}
+	if mm.Diff == nil {
+		t.Fatal("Diff = nil, want structural diff")
+	}
+	if got := mm.Diff.TransitionsRemoved; len(got) != 1 || got[0] != "extra" {
+		t.Errorf("TransitionsRemoved = %v, want [extra]", got)
+	}
+	if got := mm.Diff.TransitionsChanged; len(got) != 1 || got[0] != "go" {
+		t.Errorf("TransitionsChanged = %v, want [go] (guard change)", got)
+	}
+	if len(mm.Diff.PlacesAdded) != 0 || len(mm.Diff.PlacesRemoved) != 0 {
+		t.Errorf("place diff = +%v -%v, want none", mm.Diff.PlacesAdded, mm.Diff.PlacesRemoved)
+	}
+	if mm.Diff.Additive() {
+		t.Errorf("diff %q must not be additive", mm.Diff)
+	}
+}
+
+// TestDefinitionDiff_RenameReadsAsRemoveAddChange: a renamed place appears as
+// one removed + one added, with the referencing transition changed — the
+// exact shape a reviewer needs to tell a rename from an addition.
+func TestDefinitionDiff_RenameReadsAsRemoveAddChange(t *testing.T) {
+	ctx := context.Background()
+	store := newMemStore()
+
+	v1 := diffNet(t, []workflow.Place{"a", "b"}, [][4]string{{"go", "a", "b", ""}})
+	mgr := workflow.NewManager(workflow.NewRegistry(), store)
+	if _, err := mgr.CreateWorkflow(ctx, "wf", v1, "a"); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+
+	v2 := diffNet(t, []workflow.Place{"a", "b2"}, [][4]string{{"go", "a", "b2", ""}})
+
+	var mm workflow.DefinitionMismatch
+	if _, err := captureMismatch(store, &mm).LoadWorkflow(ctx, "wf", v2); err != nil {
+		t.Fatalf("LoadWorkflow(v2): %v", err)
+	}
+	d := mm.Diff
+	if d == nil {
+		t.Fatal("Diff = nil, want structural diff")
+	}
+	if len(d.PlacesAdded) != 1 || d.PlacesAdded[0] != "b2" ||
+		len(d.PlacesRemoved) != 1 || d.PlacesRemoved[0] != "b" {
+		t.Errorf("place diff = +%v -%v, want +[b2] -[b]", d.PlacesAdded, d.PlacesRemoved)
+	}
+	if len(d.TransitionsChanged) != 1 || d.TransitionsChanged[0] != "go" {
+		t.Errorf("TransitionsChanged = %v, want [go] (its output moved)", d.TransitionsChanged)
+	}
+	if got, want := d.String(), "+places[b2] -places[b] ~transitions[go]"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+// TestDefinitionDiff_NilForPreShapeState: state saved without a shape (an
+// older library version, or a row not written by this library) yields a nil
+// Diff — "no information", while the fingerprints still flow through.
+func TestDefinitionDiff_NilForPreShapeState(t *testing.T) {
+	ctx := context.Background()
+	store := newMemStore()
+
+	def := diffNet(t, []workflow.Place{"a", "b"}, [][4]string{{"go", "a", "b", ""}})
+
+	// Simulate a pre-shape row: fingerprint stamped, no shape key.
+	if _, err := store.SaveState(ctx, "old",
+		workflow.NewMarking([]workflow.Place{"a"}),
+		map[string]any{"__workflow_def_fingerprint": "deadbeef"}, 0); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var mm workflow.DefinitionMismatch
+	if _, err := captureMismatch(store, &mm).LoadWorkflow(ctx, "old", def); err != nil {
+		t.Fatalf("LoadWorkflow: %v", err)
+	}
+	if mm.StoredFingerprint != "deadbeef" || mm.CurrentFingerprint == "" {
+		t.Errorf("fingerprints = %q -> %q, want deadbeef -> current", mm.StoredFingerprint, mm.CurrentFingerprint)
+	}
+	if mm.Diff != nil {
+		t.Errorf("Diff = %v, want nil for a pre-shape row", mm.Diff)
+	}
+}

--- a/diff_test.go
+++ b/diff_test.go
@@ -97,10 +97,10 @@ func TestDefinitionDiff_RenameReadsAsRemoveAddChange(t *testing.T) {
 	if _, err := captureMismatch(store, &mm).LoadWorkflow(ctx, "wf", v2); err != nil {
 		t.Fatalf("LoadWorkflow(v2): %v", err)
 	}
-	d := mm.Diff
-	if d == nil {
+	if mm.Diff == nil {
 		t.Fatal("Diff = nil, want structural diff")
 	}
+	d := mm.Diff
 	if len(d.PlacesAdded) != 1 || d.PlacesAdded[0] != "b2" ||
 		len(d.PlacesRemoved) != 1 || d.PlacesRemoved[0] != "b" {
 		t.Errorf("place diff = +%v -%v, want +[b2] -[b]", d.PlacesAdded, d.PlacesRemoved)

--- a/docs/roadmap/FRICTION.md
+++ b/docs/roadmap/FRICTION.md
@@ -157,13 +157,19 @@ Priority order for what the library needs next, from what actually hurt:
 4. ✅ **SHIPPED: `FireDue` side effects** — `WithFireDueTxSideEffect` (see
    resolved entry 4 above); timer audit records are exactly-once now.
 
-5. **Additive-change detection for fingerprints** (new). Adding `release`,
-   `revise`, and submit routing changed both nets' fingerprints; the
-   migration hook can only see two opaque hashes, so the host approves
-   blindly (safe here because the loader re-validates places — but the
-   hook can't distinguish "new transition added" from "place renamed").
-   A structural diff (places added/removed, transitions added/removed)
-   handed to the migration hook would make upgrade hooks trustworthy.
+5. ✅ **SHIPPED: structural diffs for the migration hook** (was:
+   additive-change detection for fingerprints). Every save now stamps a
+   compact definition *shape* (place names + per-transition record hashes)
+   alongside the fingerprint, so a mismatch hands the hook a
+   `DefinitionMismatch` with a **`DefinitionDiff`**: places and transitions
+   added/removed/changed, by name — a rename reads as remove+add with the
+   referencing transitions marked changed. `Diff.Additive()` makes "new
+   structure only, approve mechanically" a one-line policy; the dogfood's
+   hook now refuses non-additive expense-net changes instead of approving
+   blindly, and state saved by pre-shape versions yields a nil diff ("no
+   information"). Original finding: the hook could only see two opaque
+   hashes, so the host approved blindly and couldn't distinguish "new
+   transition added" from "place renamed".
 
 6. **Creation seed** (entry 8) and **cross-instance recipes** (entry 5) —
    real but tolerable with documented patterns.

--- a/examples/expense_approval/README.md
+++ b/examples/expense_approval/README.md
@@ -129,14 +129,17 @@ a valid persisted state (`CreateWorkflowFromMarking` with an empty marking),
 so no always-marked anchor place is needed and tokens exist only for
 expenses actually flowing through.
 
-**Definitions evolve; the fingerprint notices.** Adding `release`/`revise`
-changed both nets' fingerprints, so the app installs a
-`WithDefinitionMigration` hook that approves the (additive) upgrades —
-and the loader still re-validates every loaded place afterwards. Deleting
-the payment net's `batch_control` anchor place is the one change approval
-alone can't cover: the hook runs real migration logic
-(`migratePaymentAnchor`), stripping the anchor from the stored marking
-before the manager reloads.
+**Definitions evolve; the fingerprint notices — and the diff says what.**
+Adding `release`/`revise` changed both nets' fingerprints, so the app
+installs a `WithDefinitionMigration` hook. The mismatch now carries a
+structural `DefinitionDiff` (places/transitions added, removed, changed —
+by name), so approval is a policy instead of blind trust:
+`Diff.Additive()` changes pass mechanically, non-additive expense-net
+changes are refused, and the loader still re-validates every loaded place
+afterwards. Deleting the payment net's `batch_control` anchor place is
+the one change approval alone can't cover: the hook runs real migration
+logic (`migratePaymentAnchor`), stripping the anchor from the stored
+marking before the manager reloads.
 
 **What the library refuses to do for you** — and this app does explicitly:
 terminality on rejection (no cancellation regions yet; `ErrTerminal` in

--- a/examples/expense_approval/app.go
+++ b/examples/expense_approval/app.go
@@ -126,20 +126,30 @@ func NewApp(ctx context.Context, db *sql.DB, driver string, escalateAfter time.D
 	// Fresh loads on every request: correct across replicas, and the demo is
 	// nowhere near the scale where the registry cache would matter.
 	//
-	// The migration hook approves definition upgrades for both nets. Expense-
-	// net changes have all been additive (new transitions — release, revise,
-	// submit routing), so persisted markings stay valid — and the loader still
-	// validates every loaded place after the hook approves, so a marking that
-	// genuinely no longer fits fails anyway. The payment net is the exception:
-	// it REMOVED a place (the batch_control anchor, obsolete now that an empty
-	// marking persists), which is the one change approval alone cannot cover —
-	// a stored marking still holding the anchor token needs rewriting first.
+	// The migration hook used to approve upgrades BLINDLY (two opaque hashes
+	// were all it saw — friction #5). The mismatch now carries a structural
+	// DIFF, so approval is a policy: additive changes (new places/transitions
+	// only) can never invalidate a persisted marking and pass mechanically;
+	// anything that removed or rewired structure must be handled explicitly —
+	// like the payment net deleting its batch_control anchor place, which
+	// needs the stored marking rewritten before the load can proceed. A nil
+	// diff (state saved by a pre-shape library) is "no information": approve
+	// and let the loader's place validation be the backstop, as before.
 	mgr := workflow.NewManager(workflow.NewRegistry(), store,
-		workflow.WithDefinitionMigration(func(ctx context.Context, id, stored, current string) error {
-			if id == paymentID {
-				return migratePaymentAnchor(ctx, store, id, stored, current)
+		workflow.WithDefinitionMigration(func(ctx context.Context, mm workflow.DefinitionMismatch) error {
+			if mm.WorkflowID == paymentID {
+				return migratePaymentAnchor(ctx, store, mm)
 			}
-			log.Printf("definition upgraded for %s (stored fingerprint %.8s… -> %.8s…): additive change, approving", id, stored, current)
+			switch {
+			case mm.Diff == nil:
+				log.Printf("definition upgraded for %s (%.8s… -> %.8s…): pre-shape state, approving (loader validates places)",
+					mm.WorkflowID, mm.StoredFingerprint, mm.CurrentFingerprint)
+			case mm.Diff.Additive():
+				log.Printf("definition upgraded for %s: additive change (%s), approving", mm.WorkflowID, mm.Diff)
+			default:
+				return fmt.Errorf("definition change for %s is not additive (%s): refusing to load without explicit migration",
+					mm.WorkflowID, mm.Diff)
+			}
 			return nil
 		}))
 
@@ -184,13 +194,15 @@ func NewApp(ctx context.Context, db *sql.DB, driver string, escalateAfter time.D
 // reloads. Idempotent: an already-clean marking is approved untouched, so
 // the hook firing again before the next save restamps the fingerprint is
 // harmless.
-func migratePaymentAnchor(ctx context.Context, store workflow.Storage, id, stored, current string) error {
+func migratePaymentAnchor(ctx context.Context, store workflow.Storage, mm workflow.DefinitionMismatch) error {
+	id := mm.WorkflowID
 	marking, wfCtx, version, err := store.LoadState(ctx, id)
 	if err != nil {
 		return fmt.Errorf("payment anchor migration: load: %w", err)
 	}
 	if !marking.HasPlace("batch_control") {
-		log.Printf("definition upgraded for %s (stored fingerprint %.8s… -> %.8s…): marking already clean, approving", id, stored, current)
+		log.Printf("definition upgraded for %s (%.8s… -> %.8s…): marking already clean, approving",
+			id, mm.StoredFingerprint, mm.CurrentFingerprint)
 		return nil
 	}
 	if err := marking.RemovePlace("batch_control"); err != nil {
@@ -204,7 +216,8 @@ func migratePaymentAnchor(ctx context.Context, store workflow.Storage, id, store
 		}
 		return fmt.Errorf("payment anchor migration: save: %w", err)
 	}
-	log.Printf("payment net %s migrated (fingerprint %.8s… -> %.8s…): batch_control anchor stripped from the stored marking", id, stored, current)
+	log.Printf("payment net %s migrated (%.8s… -> %.8s…): batch_control anchor stripped from the stored marking",
+		id, mm.StoredFingerprint, mm.CurrentFingerprint)
 	return nil
 }
 

--- a/m3_test.go
+++ b/m3_test.go
@@ -133,14 +133,15 @@ func TestManager_DefinitionFingerprint_RoundTripAndMismatch(t *testing.T) {
 		t.Fatalf("CreateWorkflow: %v", err)
 	}
 
-	// Same definition loads fine, and the fingerprint never leaks into context.
+	// Same definition loads fine, and the fingerprint and shape never leak
+	// into context.
 	wf, err := mgr.LoadWorkflow(ctx, "wf", def)
 	if err != nil {
 		t.Fatalf("LoadWorkflow(same def): %v", err)
 	}
 	for k := range wf.AllContext() {
-		if k == "__workflow_def_fingerprint" {
-			t.Fatal("definition fingerprint leaked into workflow context")
+		if k == "__workflow_def_fingerprint" || k == "__workflow_def_shape" {
+			t.Fatalf("reserved key %s leaked into workflow context", k)
 		}
 	}
 
@@ -159,13 +160,30 @@ func TestManager_DefinitionFingerprint_RoundTripAndMismatch(t *testing.T) {
 		t.Fatalf("LoadWorkflow(changed def) err = %v, want ErrDefinitionMismatch", err)
 	}
 
-	// ...unless a migration handler approves it.
+	// ...unless a migration handler approves it. The handler sees both
+	// fingerprints AND the structural diff of the change (extra place c,
+	// extra transition more — a purely additive upgrade).
 	called := false
 	migrating := workflow.NewManager(workflow.NewRegistry(), store,
-		workflow.WithDefinitionMigration(func(_ context.Context, id, stored, current string) error {
+		workflow.WithDefinitionMigration(func(_ context.Context, mm workflow.DefinitionMismatch) error {
 			called = true
-			if stored == "" || current == "" || stored == current {
-				t.Errorf("unexpected fingerprints stored=%q current=%q", stored, current)
+			if mm.WorkflowID != "wf" {
+				t.Errorf("mismatch.WorkflowID = %q, want wf", mm.WorkflowID)
+			}
+			if mm.StoredFingerprint == "" || mm.CurrentFingerprint == "" || mm.StoredFingerprint == mm.CurrentFingerprint {
+				t.Errorf("unexpected fingerprints stored=%q current=%q", mm.StoredFingerprint, mm.CurrentFingerprint)
+			}
+			if mm.Diff == nil {
+				t.Fatal("mismatch.Diff = nil, want the structural diff (the save stamped a shape)")
+			}
+			if !mm.Diff.Additive() {
+				t.Errorf("diff %s should be additive", mm.Diff)
+			}
+			if len(mm.Diff.PlacesAdded) != 1 || mm.Diff.PlacesAdded[0] != "c" {
+				t.Errorf("PlacesAdded = %v, want [c]", mm.Diff.PlacesAdded)
+			}
+			if len(mm.Diff.TransitionsAdded) != 1 || mm.Diff.TransitionsAdded[0] != "more" {
+				t.Errorf("TransitionsAdded = %v, want [more]", mm.Diff.TransitionsAdded)
 			}
 			return nil
 		}))
@@ -397,15 +415,15 @@ func TestManager_DefinitionMigration_RemovedPlaceAndReload(t *testing.T) {
 	// the handler must be consulted, and the load must see the rewrite.
 	called := false
 	migrating := workflow.NewManager(workflow.NewRegistry(), store,
-		workflow.WithDefinitionMigration(func(ctx context.Context, id, stored, current string) error {
+		workflow.WithDefinitionMigration(func(ctx context.Context, mm workflow.DefinitionMismatch) error {
 			called = true
-			_, _, version, err := store.LoadState(ctx, id)
+			_, _, version, err := store.LoadState(ctx, mm.WorkflowID)
 			if err != nil {
 				return err
 			}
-			_, err = store.SaveState(ctx, id,
+			_, err = store.SaveState(ctx, mm.WorkflowID,
 				workflow.NewMarking([]workflow.Place{"done"}),
-				map[string]any{"__workflow_def_fingerprint": current}, version)
+				map[string]any{"__workflow_def_fingerprint": mm.CurrentFingerprint}, version)
 			return err
 		}))
 	wf, err := migrating.LoadWorkflow(ctx, "wf", v2)

--- a/manager.go
+++ b/manager.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand/v2"
@@ -14,19 +15,47 @@ import (
 // workflow's user-visible context or guard environment.
 const defFingerprintKey = "__workflow_def_fingerprint"
 
+// defShapeKey is the reserved context key under which the Manager persists the
+// definition's structural shape (place names + per-transition record hashes,
+// a few hundred bytes). It is what turns a later fingerprint mismatch into a
+// DefinitionDiff for the migration handler. Written on save, stripped on load,
+// exactly like defFingerprintKey.
+const defShapeKey = "__workflow_def_shape"
+
+// DefinitionMismatch describes a stored-vs-supplied definition mismatch, as
+// handed to the WithDefinitionMigration handler.
+type DefinitionMismatch struct {
+	WorkflowID string
+
+	// StoredFingerprint is the fingerprint stamped on the instance's last
+	// save; empty for a row that was not written by this library's save path.
+	// CurrentFingerprint is the fingerprint of the definition supplied now.
+	StoredFingerprint  string
+	CurrentFingerprint string
+
+	// Diff is the structural difference from the definition the instance was
+	// last saved under to the one supplied now — what was added, removed, or
+	// rewired, by name. It is nil when the stored state carries no shape (it
+	// predates shape stamping, or was not written by this library): nil means
+	// "no information", not "no change".
+	Diff *DefinitionDiff
+}
+
 // DefinitionMigrationFunc is called by the Manager when a persisted instance's
 // stored definition fingerprint differs from the definition supplied to load it.
 // Returning nil lets the load proceed (the caller has confirmed the change is
 // safe, or has migrated the marking); returning an error aborts the load with
-// that error. storedFingerprint is empty for a row that was not written by this
-// library's save path (every save stamps one).
-type DefinitionMigrationFunc func(ctx context.Context, id, storedFingerprint, currentFingerprint string) error
+// that error. The mismatch carries both fingerprints and, when the stored
+// state includes a shape, the structural DefinitionDiff — so approval can be
+// a policy (e.g. mismatch.Diff.Additive()) rather than blind trust.
+type DefinitionMigrationFunc func(ctx context.Context, mismatch DefinitionMismatch) error
 
 // Manager handles workflow instances and their persistence.
 //
-// The Manager reserves the context key "__workflow_def_fingerprint" for the
-// definition fingerprint it stamps on every save: a user value stored under
-// that key is overwritten on save and stripped on load.
+// The Manager reserves the context keys "__workflow_def_fingerprint" and
+// "__workflow_def_shape" for the definition fingerprint and structural shape
+// it stamps on every save: user values stored under those keys are
+// overwritten on save and stripped on load.
 type Manager struct {
 	registry *Registry
 	storage  Storage
@@ -150,9 +179,10 @@ func (m *Manager) loadFromStorage(ctx context.Context, id string, definition *De
 			return nil, fmt.Errorf("reloading after definition migration: %w", err)
 		}
 	}
-	// Strip the fingerprint so it never reaches the workflow's user-visible
-	// context or guard environment.
+	// Strip the fingerprint and shape so they never reach the workflow's
+	// user-visible context or guard environment.
 	delete(wfContext, defFingerprintKey)
+	delete(wfContext, defShapeKey)
 
 	// Validate EVERY loaded place against the definition, not just the first:
 	// a stale marking referencing a place removed from the definition must fail
@@ -199,16 +229,17 @@ func (m *Manager) readState(ctx context.Context, id string) (Marking, map[string
 
 // checkFingerprint compares the stored definition fingerprint against the
 // supplied definition. A missing stored fingerprint (pre-fingerprint instance)
-// passes. A mismatch is an error unless a migration handler approves it; the
-// returned bool reports whether a handler was consulted and approved (the
-// caller then reloads state, since the handler may have rewritten it).
+// passes... to the migration handler, like any mismatch. A mismatch is an
+// error unless a migration handler approves it; the returned bool reports
+// whether a handler was consulted and approved (the caller then reloads
+// state, since the handler may have rewritten it).
 func (m *Manager) checkFingerprint(ctx context.Context, id string, definition *Definition, wfContext map[string]any) (migrated bool, err error) {
 	stored, ok := wfContext[defFingerprintKey].(string)
 	if !ok || stored == "" {
 		// Every save stamps the fingerprint, so a persisted instance without
 		// one was not written by this library's save path. Treat it exactly
 		// like a mismatch: fail loudly, or route to the migration handler
-		// (which receives an empty storedFingerprint).
+		// (which receives an empty StoredFingerprint).
 		stored = ""
 	}
 	current := definition.Fingerprint()
@@ -216,7 +247,13 @@ func (m *Manager) checkFingerprint(ctx context.Context, id string, definition *D
 		return false, nil
 	}
 	if m.onDefinitionMismatch != nil {
-		if err := m.onDefinitionMismatch(ctx, id, stored, current); err != nil {
+		mismatch := DefinitionMismatch{
+			WorkflowID:         id,
+			StoredFingerprint:  stored,
+			CurrentFingerprint: current,
+			Diff:               storedShapeDiff(wfContext, definition),
+		}
+		if err := m.onDefinitionMismatch(ctx, mismatch); err != nil {
 			return false, err
 		}
 		return true, nil
@@ -224,15 +261,34 @@ func (m *Manager) checkFingerprint(ctx context.Context, id string, definition *D
 	return false, fmt.Errorf("%w: instance %q stored fingerprint %s, definition fingerprint %s", ErrDefinitionMismatch, id, stored, current)
 }
 
+// storedShapeDiff parses the shape stamped on the instance's last save and
+// diffs it against the supplied definition. It returns nil when the stored
+// state carries no (parseable) shape — pre-shape instances, or rows not
+// written by this library — leaving the mismatch's Diff as "no information".
+func storedShapeDiff(wfContext map[string]any, definition *Definition) *DefinitionDiff {
+	raw, ok := wfContext[defShapeKey].(string)
+	if !ok || raw == "" {
+		return nil
+	}
+	var stored definitionShape
+	if err := json.Unmarshal([]byte(raw), &stored); err != nil {
+		return nil
+	}
+	return diffShapes(stored, definition.shape())
+}
+
 // contextForSave returns a copy of ctxData stamped with the definition
-// fingerprint, ready to hand to storage. The live workflow context is never
-// mutated (the caller passes a snapshot copy).
+// fingerprint and structural shape, ready to hand to storage. The live
+// workflow context is never mutated (the caller passes a snapshot copy).
 func contextForSave(ctxData map[string]any, definition *Definition) map[string]any {
 	if ctxData == nil {
-		ctxData = make(map[string]any, 1)
+		ctxData = make(map[string]any, 2)
 	}
 	if definition != nil {
 		ctxData[defFingerprintKey] = definition.Fingerprint()
+		if shape, err := json.Marshal(definition.shape()); err == nil {
+			ctxData[defShapeKey] = string(shape)
+		}
 	}
 	return ctxData
 }


### PR DESCRIPTION
## Summary

Friction log **#5** — the migration hook could only see two opaque fingerprint hashes, so hosts approved every definition upgrade blindly, unable to distinguish "new transition added" from "place renamed". Now the mismatch says **what** changed.

**Mechanism:** every save stamps a compact definition **shape** — sorted place names plus a short hash of each transition's structural record (the same fields the fingerprint covers) — under the reserved `__workflow_def_shape` context key (a few hundred bytes; stripped on load like the fingerprint). On a mismatch, the handler receives a `DefinitionMismatch`:

- `WorkflowID`, `StoredFingerprint`, `CurrentFingerprint`
- **`Diff *DefinitionDiff`** — places and transitions **added / removed / changed**, by name. A renamed place reads as remove+add with its referencing transitions marked changed — exactly the shape a reviewer needs.
- `Diff.Additive()` makes "new structure only, approve mechanically" a one-line policy; `Diff == nil` for state saved by pre-shape versions ("no information", not "no change").

**⚠️ Breaking (pre-1.0):** `DefinitionMigrationFunc` is now `func(ctx context.Context, mm workflow.DefinitionMismatch) error`. The fingerprint hash itself is unchanged (`Fingerprint()` refactored to share the per-transition record with the shape).

**Dogfood proof:** approval is now a policy instead of blind trust — additive changes pass mechanically (logged with the diff), non-additive expense-net changes are **refused loudly**, the payment net's anchor removal keeps its explicit `migratePaymentAnchor` migration, and nil-diff state approves with the loader's place validation as backstop.

**Tests:** additive add (place+transition, asserted through the hook), removal + guard change (non-additive, by name), rename shape with exact `String()` output, nil diff for pre-shape rows, reserved-key leak checks.

## Roadmap milestone

Post-M5 friction-log-driven feature #5 — with it, every library item in the friction log's ranked list is shipped.

## Checklist

- [x] `gofmt -s -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (root + examples, run serialized)
- [x] `CHANGELOG.md` updated under **[Unreleased]** (Added + Breaking)
- [x] Docs/examples only describe behavior the engine can actually execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)