### PR TITLE
docs: M6 — mental model, production recipes, boundaries, godoc polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **M6 documentation pass** — the deep docs milestone, grounded in the
+  dogfood app: `docs/guides/MENTAL_MODEL.md` (the narrative "how to think
+  in Petri nets" guide, from marking-vs-status-column through a worked
+  requirements-to-net translation), `docs/guides/PRODUCTION_RECIPES.md`
+  (crash windows and idempotency — friction entries 5–8 as recipes:
+  `Execute` retry resets, exactly-once audit, webhook redelivery mapping,
+  cross-instance saga + reconciler, creation-seed GC, listener semantics,
+  token-query re-entrancy, migration-as-policy), and `docs/BOUNDARIES.md`
+  (what the library deliberately does not do). Godoc polished to match:
+  refreshed package doc, a RETRY RESETS callout with example on
+  `Manager.Execute`, and a LOCK RE-ENTRANCY warning on the token-query
+  APIs. The README gained a documentation index.
 - **Structural diffs for definition migration** (friction log #5). Every
   save stamps a compact definition *shape* (sorted place names plus a short
   hash of each transition's structural record, a few hundred bytes under

--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ Inspired by [Symfony Workflow Component](https://symfony.com/doc/current/workflo
 * Constraint system for custom validation logic
 * Comprehensive test coverage
 
+## Documentation
+
+Start here, in roughly this order:
+
+| Guide | What it covers |
+|---|---|
+| [Mental model](docs/guides/MENTAL_MODEL.md) | How to *think* in Petri nets: marking vs status column, parallelism as state, choice/merge, cycles, cancellation, the two modeling styles — with a worked requirements-to-net translation |
+| [Production recipes](docs/guides/PRODUCTION_RECIPES.md) | Crash windows and idempotency: `Execute` retry resets, exactly-once audit trails, webhook redelivery, cross-instance saga + reconciler, creation-seed GC, migration-as-policy |
+| [Boundaries](docs/BOUNDARIES.md) | What the library deliberately does **not** do, and the host-side pattern for each |
+| [Timers](docs/guides/TIMERS_GUIDE.md) | Host-driven time: `after:` durations, `ListDue`/`FireDue` crons, exactly-once timer audit records |
+| [Colored tokens (CPN)](docs/guides/CPN_GUIDE.md) | Data-carrying tokens, per-token firing, token-aware guards, queries and aggregation |
+| [Best practices](docs/guides/WORKFLOW_BEST_PRACTICES.md) | Net-design patterns: unambiguous transitions, conditional branches, API usage |
+
+The executable companion to all of them is the reference system at
+[`examples/expense_approval`](examples/expense_approval) — a production-shaped
+web app exercising every feature above, whose README maps each concept to code.
+
 ## Storage Layer
 
 We designed the storage interface to be flexible. You tell us where to put the data and what extra information you need to store.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -186,12 +186,31 @@ that finding outranks any roadmap item.
 
 ---
 
-## M6 — Docs & mental model (🟡) — target: **v0.10.0**
+## M6 — Docs & mental model (✅ 2026-07-08) — target: **v0.10.0**
 
-The deep pass, grounded in the dogfood app (not before): a narrative "how to think in
-Petri nets" guide, the signals/crash-recovery/idempotency recipes, `Boundaries` doc
-(below), pkg.go.dev polish. The **full README rewrite still lands last**, at the v1.0 gate,
-describing only shipping behavior.
+The deep pass, grounded in the dogfood app (not before) — delivered:
+
+- **[`docs/guides/MENTAL_MODEL.md`](docs/guides/MENTAL_MODEL.md)** — the
+  narrative "how to think in Petri nets" guide: marking vs status column,
+  parallelism as state, the three kinds of "or", cycles, reset arcs, time,
+  instance-per-entity vs shared-pool styles, and a worked
+  requirements-to-net translation. Every idea names its dogfood counterpart.
+- **[`docs/guides/PRODUCTION_RECIPES.md`](docs/guides/PRODUCTION_RECIPES.md)**
+  — the crash-recovery/idempotency recipes (friction entries 5–8): `Execute`
+  retry resets, exactly-once audit (interactive + timer), webhook error
+  mapping, cross-instance saga + reconciler, creation-seed GC, listener
+  at-least-once semantics, token-query re-entrancy, migration-as-policy —
+  each pointing at the dogfood code and test that proves it.
+- **[`docs/BOUNDARIES.md`](docs/BOUNDARIES.md)** — the honest statements
+  (below) written out, each with the host-side pattern.
+- **pkg.go.dev polish** — package doc refreshed (Execute write path,
+  transactional side effects, token read-model, current diagram renderer);
+  RETRY RESETS callout on `Manager.Execute`; LOCK RE-ENTRANCY warning on the
+  token-query APIs.
+
+The **full README rewrite still lands last**, at the v1.0 gate, describing
+only shipping behavior. (A signals API remains a parked feature, not a doc
+item.)
 
 ---
 
@@ -230,7 +249,7 @@ Formerly M3–M8. None is deleted; none proceeds without a dogfood-proven need.
 
 ---
 
-## Boundaries (honest statements, to be written into docs in M6)
+## Boundaries (honest statements — written out in [`docs/BOUNDARIES.md`](docs/BOUNDARIES.md), M6)
 
 1. **Not a durable-execution engine.** State is persisted, code is not. A crash loses
    in-memory progress since the last save — by design. Recovery = load + re-drive.

--- a/doc.go
+++ b/doc.go
@@ -29,13 +29,27 @@
 //
 // [Storage] and the history store persist workflow state and an audit trail. Both
 // interfaces take a context.Context as their first argument so callers can apply
-// cancellation and deadlines. A SQLite implementation ships in the storage and
-// history sub-packages; you can supply your own by implementing the interfaces.
+// cancellation and deadlines. SQLite and PostgreSQL implementations ship in the
+// storage and history sub-packages (with optimistic concurrency built into the
+// contract, a normalized one-row-per-token format, and the [TokenQueryStorage]
+// cross-instance read-model); you can supply your own by implementing the
+// interfaces — the storagetest sub-package is the conformance suite for it.
+//
+// [Manager.Execute] is the recommended write path: load fresh, run your
+// function, save under the instance's version, and retry the whole cycle on
+// conflict — with [WithTxSideEffect] committing audit/outbox writes in the same
+// transaction as the save ([WithFireDueTxSideEffect] is the timer-firing
+// variant). See docs/guides/PRODUCTION_RECIPES.md for the crash-window and
+// idempotency recipes, and docs/BOUNDARIES.md for what the library
+// deliberately leaves to the host.
 //
 // # Configuration and visualization
 //
 // Workflows can be defined programmatically or loaded from YAML (see the yaml
-// sub-package). [Workflow.Diagram] renders a Mermaid state diagram for documentation.
+// sub-package). [Definition.Diagram] renders the structure as a Mermaid
+// flowchart, and [Workflow.Diagram] adds the live marking — guards on edges,
+// BPMN-style gateway diamonds for splits and merges, reset arcs, timer styling,
+// and per-place token badges.
 //
 // # Status
 //
@@ -48,8 +62,10 @@
 // FireDue — the host owns the clock), SQLite and PostgreSQL storage backends
 // with optimistic concurrency built into the Storage contract and
 // transactional building blocks, SQLite and PostgreSQL history stores, the
-// strict YAML loader with the polymorphic initial_marking key, and Mermaid
-// diagram generation.
+// strict YAML loader with the polymorphic initial_marking key, definition
+// fingerprints with structural diffs for the migration hook, token queries
+// and aggregation, empty-marking (pool-net) persistence with the
+// cross-instance token read-model, and Mermaid diagram generation.
 //
 // Not yet available (tracked in ROADMAP.md): a signals API, static validation
 // (deadlock/soundness checking), hierarchical workflows (HCPN),

--- a/docs/BOUNDARIES.md
+++ b/docs/BOUNDARIES.md
@@ -1,0 +1,84 @@
+# Boundaries — what this library deliberately does not do
+
+Honest statements about where the library's responsibility ends and the
+host application's begins. None of these are roadmap gaps; they are design
+decisions, and most of the library's reliability properties *follow from*
+them. Each one names the pattern for living on the host side of the line —
+worked versions are in
+[`guides/PRODUCTION_RECIPES.md`](./guides/PRODUCTION_RECIPES.md) and running
+in [`examples/expense_approval`](../examples/expense_approval).
+
+## 1. Not a durable-execution engine
+
+**State is persisted; code is not.** There is no replayed event history, no
+resumable function, no captured call stack (the Temporal/Restate model). A
+crash loses all in-memory progress since the last save — by design.
+Recovery is: load the marking, look at it, decide what to drive next.
+
+What this buys: nothing to version-pin about your code's execution history,
+no non-determinism rules for what code may do, and a state model you can
+inspect with a SQL query. What it costs: multi-step *host* logic between
+saves needs its own crash story — which is recipe #1's `Execute` (make the
+whole step one atomic save) and the reconciler pattern for steps that span
+saves.
+
+## 2. No internal clock or scheduler
+
+The library never wakes up. Timed transitions record when tokens entered
+their places and answer "what is due at time T?" (`Due`, `Manager.ListDue`);
+firing what is due is a host loop calling `FireDue` with the host's `now`
+(see [`guides/TIMERS_GUIDE.md`](./guides/TIMERS_GUIDE.md)). Deadlines live
+in the database, so they survive restarts by construction; tests pass a
+future `now` instead of sleeping; and running two schedulers against the
+same fleet is safe because `FireDue` runs under the same optimistic
+concurrency as every other save.
+
+## 3. Listeners run at-least-once relative to persisted state
+
+Event listeners fire when a transition executes *in memory*. Under
+`Execute` retries the same logical change can run listeners more than once,
+and a change that fails to save still ran them once. So listener effects
+must be idempotent or harmless to repeat (metrics, cache invalidation) —
+they are notifications, not records. Writes that must agree with the
+database go through the transactional hook (`WithTxSideEffect`,
+`WithFireDueTxSideEffect`), where the library *does* guarantee atomicity
+with the state change. The library provides the transaction hook, not the
+idempotency.
+
+## 4. History is opt-in
+
+No transition is recorded automatically. The audit trail is a separate
+store you write to — either through the transactional hook (exactly-once,
+the recommended path) or the `yaml.ApplyTransitionByNameWithHistory` helper.
+Silent automatic history sounds convenient until you need to control the
+record's fields, actor, or transaction — so the library never grew it.
+
+## 5. Organizational structure stays in the host
+
+Users, roles, assignment, delegation, escalation *targets* — none of it is
+modeled here (see
+[`guides/ORGANIZATIONAL_FEATURES_EXPLAINED.md`](./guides/ORGANIZATIONAL_FEATURES_EXPLAINED.md)).
+The net models *what state the work is in*; *who may act* is a guard over
+context you supply (`hasRole(...)` and friends), and *who is asked* is your
+notification layer's job. Every org chart is different; a workflow engine
+that ships one is wrong for everyone but its author.
+
+## 6. Cross-instance atomicity is a seam, not a feature
+
+Saves are atomic per instance. A step spanning two instances is two
+transactions with a crash window between them — the library will not hide
+that behind a distributed transaction. The supported pattern is ordered
+idempotent writes plus a reconciler case per window (recipe in
+[`guides/PRODUCTION_RECIPES.md`](./guides/PRODUCTION_RECIPES.md)); the
+token read-model (`Manager.ListPlaceTokens`) exists partly to make those
+reconcilers cheap to write.
+
+## 7. No static analyzer (yet)
+
+The Petri-net foundation makes definitions *analyzable in principle*
+(soundness, deadlock-freedom, reachability), and `NewDefinition` validates
+structure (places exist, resets valid). But there is no shipped
+model-checker: a definition that can deadlock is your review's job to
+catch today. A static validator is on the roadmap; until it ships, the
+README's claim is deliberately "amenable to formal analysis", not
+"formally verified".

--- a/docs/guides/MENTAL_MODEL.md
+++ b/docs/guides/MENTAL_MODEL.md
@@ -1,0 +1,164 @@
+# Thinking in Petri nets
+
+This is the mental-model guide: how to *think* about a process so that
+modeling it with this library becomes mechanical. Everything here is
+grounded in the reference system at
+[`examples/expense_approval`](../../examples/expense_approval) — each idea
+names the file and concept that demonstrates it, so you can read the theory
+and the running code side by side.
+
+If you want API mechanics instead, start with the README and
+[`WORKFLOW_BEST_PRACTICES.md`](./WORKFLOW_BEST_PRACTICES.md); for
+data-carrying tokens see [`CPN_GUIDE.md`](./CPN_GUIDE.md); for deadlines see
+[`TIMERS_GUIDE.md`](./TIMERS_GUIDE.md); for crash windows and idempotency
+see [`PRODUCTION_RECIPES.md`](./PRODUCTION_RECIPES.md).
+
+## A marking, not a status column
+
+The habit to unlearn is `status VARCHAR`. A status column says a process is
+in exactly one state at a time — and the moment your process has two things
+in flight at once (legal review *and* finance review), one column can't say
+so, and flags start accumulating around it.
+
+A Petri net's state is a **marking**: the *set* of places currently holding
+a token. "Place" is a state where work rests; "token" is the thing resting
+there. An expense in parallel review has the marking
+`{pending_legal, pending_finance}` — two places, one instance, no flags.
+When you catch yourself adding a boolean next to a status column, you have
+found a second place.
+
+Everything else in the model is a consequence of this one move:
+
+- A **transition** consumes tokens from its input places and produces tokens
+  in its output places. That is the *only* way state changes.
+- A transition is **enabled** when its input places are marked. Nothing
+  fires on its own — some caller (a webhook handler, a batch job, a timer
+  tick) applies it.
+- A **guard** on a transition says whether the enabled transition may
+  actually fire, based on data (`amount <= 100.0`).
+
+## Parallelism is state, not threads
+
+`submit` in the dogfood's `workflow.yaml` has two `to` places. Firing it
+puts a token in `pending_legal` *and* `pending_finance` — an **AND-split**.
+`finalize` has two `from` places — an **AND-join**, enabled only when both
+branches have produced their token. There is no gateway object, no
+goroutine, no join counter: parallelism is just arcs, and synchronization is
+just a transition with two inputs.
+
+This is why the model survives crashes so calmly. "Two things in flight"
+is not two threads to keep alive — it is two tokens in a persisted marking.
+Kill the process; the marking is still there; whoever loads it next sees
+exactly what was in flight.
+
+## Choice: who decides, and where
+
+There are three kinds of "or" and they look different in the net:
+
+- **XOR-split (choose one route out of a place).** Model it as *alternative
+  transitions out of the same place*, each carrying a guard. The place is
+  the decision point; the guards are the policy. The dogfood's `submit` vs
+  `submit_auto` route by `amount`, resolved in one call:
+  `wf.ApplyAny(ctx, "submit_auto", "submit")` fires the first candidate the
+  state and guards allow.
+- **OR-input (accept from either stage).** One transition with
+  `from_any: true` is enabled by *any one* of its inputs and consumes only
+  the marked one. The dogfood's `legal_approve` accepts from
+  `pending_legal` OR `escalated_legal`, so escalation doesn't double the
+  transition count. In diagrams this joins through a `◇×` gateway.
+- **AND-join (wait for all).** Multiple `from` places, all required — the
+  `◇+` gateway. Use it when branches must synchronize, not merely converge.
+
+If you're unsure which you have, ask: *who decides?* Data decides → XOR
+with guards. Whichever branch arrives first decides → OR-input. Nobody
+decides, everyone must arrive → AND-join.
+
+## Cycles are just arcs too
+
+A rejected expense that can be revised and resubmitted is not a special
+"loop" feature — it is a transition from `rejected` back to `draft`
+(`revise` in the dogfood), after which the same submit guards route it
+again, possibly down a different branch than round one. Nets are graphs;
+nothing stops an arc from pointing "backwards".
+
+## Cancellation is declared, not hand-rolled
+
+When one branch's outcome makes the sibling branch moot (a rejection ends
+the whole review), the reject transition declares **reset arcs**:
+`resets: [pending_finance, escalated_finance, ...]`. Firing it clears those
+places atomically with the move — pending tokens die, and any escalation
+timer running on them dies too. Before this existed, the dogfood cleared
+places by hand after firing and it was the friction log's top-ranked
+finding; if you find yourself writing `ClearPlace` after a fire, you want a
+reset arc.
+
+## Time is modeled, never scheduled
+
+A timed transition (`after: 72h`) does not start a timer. The library only
+*records* when each token entered its place and can answer "what is due at
+time T?" (`Due`, `NextDue`, `Manager.ListDue`). The host owns the clock: a
+cron or ticker calls `ListDue` + `FireDue` with *its* `now`. Deadlines live
+in the database, so they survive restarts by construction, and tests pass a
+future `now` instead of sleeping. See
+[`TIMERS_GUIDE.md`](./TIMERS_GUIDE.md).
+
+## Two modeling styles: instance-per-entity vs shared pool
+
+Most processes want **one workflow instance per business entity**: every
+expense is its own instance, its marking is that expense's state, and the
+"fleet" is just rows (`ListWorkflowIDs` + `LoadWorkflow`). Reach for this
+by default — state stays local, contention stays per-entity, and one
+stuck instance can't block the rest.
+
+Sometimes entities genuinely *flow together*: a payment batch settles many
+expenses at once. That is the **shared pool** style — one long-lived
+instance whose places hold **colored tokens**, one per entity, carrying data
+(`{expense_id, amount, submitter}`). The dogfood's `payment.yaml` is the
+worked example: approved expenses become tokens in `payable`, the batch
+fires `pay` per token, a guard holds big amounts for manual `release`. A
+pool net legitimately starts **empty** (an empty marking is a valid
+persisted state), and the cross-instance question "every payable token in
+the system" is one indexed query (`Manager.ListPlaceTokens`).
+
+The trade-offs between the two styles — and why the pool is a singleton
+*by choice*, kept swappable by the token read-model — are worked through in
+[`docs/roadmap/SHARED_POOL_MODELING.md`](../roadmap/SHARED_POOL_MODELING.md).
+Token mechanics are in [`CPN_GUIDE.md`](./CPN_GUIDE.md).
+
+## The engine never acts on its own
+
+This is the boundary that makes everything above composable
+(see [`docs/BOUNDARIES.md`](../BOUNDARIES.md) for the full list): the
+library never fires a transition, never ticks a clock, never retries a side
+effect. State is persisted; *code is not*. Every state change is some
+caller doing `load → fire → save` — usually via `Manager.Execute`, which
+wraps that cycle in optimistic concurrency and atomic side effects. What
+looks like a limitation is the property that makes instances restart-safe,
+replicas coordination-free, and tests deterministic.
+
+## A worked translation
+
+Take a request like: *"an order is picked and invoiced in parallel; both
+must finish before shipping; invoicing over €10k needs a manager, who has
+3 days before it escalates; a failed pick cancels the invoice work."*
+
+- "picked and invoiced in parallel" → AND-split: `start` has `to:
+  [picking, invoicing]`.
+- "both must finish before shipping" → AND-join: `ship` has `from:
+  [picked, invoiced]`.
+- "over €10k needs a manager" → XOR-split out of `invoicing` with amount
+  guards (`invoice_auto` vs `invoice_review`); the host fires
+  `ApplyAny("invoice_auto", "invoice_review")`.
+- "3 days before it escalates" → `after: 72h` on an `escalate` transition
+  out of `pending_manager`; a host tick drives it.
+- "manager approves whether or not it escalated" → OR-input:
+  `manager_approve` with `from_any: true` from `[pending_manager,
+  escalated]`.
+- "a failed pick cancels the invoice work" → `pick_failed` carries
+  `resets: [invoicing, pending_manager, escalated]`.
+
+Six requirements, six constructs, zero custom plumbing. When a requirement
+doesn't map onto a place, a transition, a guard, a reset, or a token — stop
+and check [`docs/BOUNDARIES.md`](../BOUNDARIES.md): it is probably the
+host's job (assignment, notification, cross-instance atomicity), and
+[`PRODUCTION_RECIPES.md`](./PRODUCTION_RECIPES.md) has the pattern for it.

--- a/docs/guides/PRODUCTION_RECIPES.md
+++ b/docs/guides/PRODUCTION_RECIPES.md
@@ -1,0 +1,256 @@
+# Production recipes: crash windows, idempotency, and the seams between transactions
+
+The library's core guarantee is narrow and strong: **one instance's state
+change commits atomically** — marking, context, version, due index, and any
+transactional side effects, in one transaction, under optimistic
+concurrency. Everything *around* that guarantee (webhooks arriving twice,
+processes dying between two saves, listeners re-running) is the host's job,
+and every recipe here comes from building the reference system at
+[`examples/expense_approval`](../../examples/expense_approval) — the file
+and test that prove each one are named as we go.
+
+Read [`MENTAL_MODEL.md`](./MENTAL_MODEL.md) first if the net vocabulary is
+new, and [`docs/BOUNDARIES.md`](../BOUNDARIES.md) for what the library
+deliberately does not do.
+
+## The core loop: `Execute`, and what it re-runs
+
+Every state change is `load → fire → save`. `Manager.Execute` is that cycle
+with the failure handling built in: it loads fresh state, runs your `fn`,
+and saves under the instance's version; if a concurrent writer saved first
+(`ErrConflict`), it reloads and re-runs `fn` — up to `WithMaxRetries` times.
+
+The subtlety that bites (dogfood friction #6): **anything your `fn` closure
+captures must be reset at the top of `fn`**, because a conflict re-runs the
+whole function on fresh state:
+
+```go
+var fired []string
+err := mgr.Execute(ctx, id, def, func(wf *workflow.Workflow) error {
+    fired = nil // ← WITHOUT this, a retry APPENDS to the previous attempt's names
+    if err := wf.ApplyTransition("approve"); err != nil {
+        return err
+    }
+    fired = append(fired, "approve")
+    return nil
+})
+```
+
+Forgetting the reset is silent: single-writer tests never conflict, so the
+bug only appears under real concurrency, as duplicated history records or
+double-counted metrics. The dogfood's `stepRecorder` resets its step list
+at the top of every `fn` (`app.go: fire`), and `FireDue` does the same
+internally with its fired list. Rule of thumb: the first lines of `fn`
+re-initialize every variable `fn` writes.
+
+The same reasoning gives the other two `Execute` rules:
+
+- **`fn` must be re-runnable.** A transition no longer enabled on the
+  reloaded state returns `ErrNotEnabled` out of `fn` — usually exactly what
+  you want a redelivered webhook to see.
+- **External side effects don't belong in `fn`.** `fn` may run more than
+  once, and nothing un-sends an email. Put must-commit-with-state writes in
+  a transactional side effect (next recipe); do fire-and-forget effects
+  after `Execute` returns, keyed idempotently.
+
+## Exactly-once audit trail (interactive and timer fires)
+
+History is opt-in and the library never writes it for you — but it hands
+you the transaction. `WithTxSideEffect` runs your write in the same
+transaction as the save, so state and record commit or roll back together:
+
+```go
+var rec *history.TransitionRecord
+err := mgr.Execute(ctx, id, def,
+    func(wf *workflow.Workflow) error {
+        rec = nil // retry reset, as above
+        if err := wf.ApplyTransition("approve"); err != nil {
+            return err
+        }
+        rec = &history.TransitionRecord{WorkflowID: id, Transition: "approve", Actor: actor, CreatedAt: now}
+        return nil
+    },
+    workflow.WithTxSideEffect(func(ctx context.Context, tx any) error {
+        return hist.SaveTransitionTx(ctx, tx.(*sql.Tx), rec)
+    }))
+```
+
+Timer firings get the same guarantee through `WithFireDueTxSideEffect`,
+which receives the steps the `FireDue` pass fired (transition + from/to
+marking) *inside* the transaction — never write timer history after
+`FireDue` returns, that reopens the crash window. See the worked example in
+[`TIMERS_GUIDE.md`](./TIMERS_GUIDE.md).
+
+The dogfood's `TestCrashConsistency` injects a failing side effect and
+proves neither half lands; `TestFireDueTxSideEffect_EffectErrorRollsBack`
+proves the timer variant re-fires and re-records exactly once.
+
+## Webhooks: idempotency by error mapping
+
+A webhook will be redelivered; design the handler so redelivery is boring.
+The error split does most of the work (`app.go: Approve` and the HTTP
+mapping in `server.go`):
+
+| Result | Meaning | HTTP answer |
+|---|---|---|
+| `nil` | fired | 200/303, do the side effects |
+| `ErrNotEnabled` | already fired earlier (or not yet reachable) | **200 no-op** — redelivery |
+| `ErrGuardRejected` | state fine, policy says no | 403 |
+| `ErrConflict` | lost a race | never seen — `Execute` retried it |
+
+The first fire moves the token; the redelivered fire finds the input place
+empty and gets `ErrNotEnabled`. Mapping that to success-no-op makes the
+endpoint idempotent without a dedup table. (`TestWebhookRedelivery` pins
+this: same request twice, one firing, one audit record.)
+
+## Cross-instance steps: two transactions, a reconciler, and honest windows
+
+The library is atomic *per instance*. A step that touches two instances —
+the dogfood's expense → payment-net enqueue, and pay → `mark_paid` back on
+the expense — is **two transactions**, and a crash between them is not a
+bug you can eliminate; it is a window you must own. The recipe has three
+parts:
+
+**1. Order the writes so the window is detectable.** Commit the record of
+truth first, then the follower. In the dogfood, `pay` moves the payment
+token to `paid_out` (transaction 1) and only then advances the expense to
+`paid` (transaction 2). A crash in between leaves a detectable
+inconsistency: a `paid_out` token whose expense still says `approved` —
+the token IS the outbox entry.
+
+**2. Make both writes idempotent re-runs.** `EnqueueApproved` no-ops if the
+expense's token is already in the payment net (`paymentHasExpense`);
+`markPaid` is a transition that returns `ErrNotEnabled` when already fired.
+Because both halves tolerate re-execution, *repairing* the window is just
+*re-running* it.
+
+**3. Run a periodic reconciler that closes every window you documented.**
+The dogfood's `Reconcile` (`app.go`) is a loop over the fleet with one
+`case` per crash window:
+
+```go
+switch {
+case v.Has("approved") && paidOut[v.ID]:          // pay committed, mark_paid lost
+    a.markPaid(ctx, v.ID)
+case v.Has("approved") && !paymentHasExpense(pay, v.ID): // finalize committed, enqueue lost
+    a.EnqueueApproved(ctx, v.ID)
+case /* creation crash artifact */ :
+    // see the creation-seed recipe below
+}
+```
+
+Wired to a ticker (`-reconcile`, default 1m), it makes the system
+self-healing: `TestReconcileRepairsCrashWindow` simulates each window and
+proves one pass repairs it. If you prefer a classic outbox table over
+state-derived detection, `WithTxSideEffect` is where you'd insert the
+outbox row — same transaction as the state change, drained by the same
+kind of periodic loop.
+
+The general shape: **every multi-instance feature = ordered idempotent
+writes + one reconciler case per seam.** Write the reconciler case in the
+same PR as the feature, or the window ships undocumented.
+
+## Creation seed: the first save's crash window
+
+`CreateWorkflow` persists a bare instance; setting business context and
+firing the first transition is a second save. The dogfood does both
+mutations in ONE `Execute` (`SubmitExpense`: set context + route submit in
+the same `fn`), so there is exactly one window — between create and that
+first `Execute` — and its artifact is precisely characterizable: *a draft
+with no context*.
+
+That makes garbage collection safe and boring, as the third `Reconcile`
+case:
+
+```go
+case v.Has("draft") && v.Amount == 0 && a.now().Sub(*v.DraftedAt) > draftGrace:
+    a.mgr.DeleteWorkflow(ctx, v.ID) // creation crash artifact
+```
+
+Two details carry the safety: a successful creation can never look like
+this (context and first fire commit together), and the grace period —
+keyed off the draft token's `EnteredAt`, which the engine stamps — protects
+a creation in flight right now. If your process must not even tolerate
+that window, seed everything through `CreateWorkflowFromMarking` with the
+initial state you want, then treat the instance as live only after your
+first `Execute` succeeds.
+
+## Listeners: at-least-once, always
+
+Event listeners (`AddEventListener`) run when the transition fires *in
+memory* — which, under `Execute`, can be more than once (retries), and can
+also be once for a change that then fails to save. So listener side effects
+are **at-least-once relative to persisted state**, in both directions.
+Treat them as notifications, not records: counters, cache invalidation,
+logs. The dogfood's metrics listener is the model — incrementing a gauge
+twice is harmless. Anything that must agree with the database goes through
+`WithTxSideEffect` instead.
+
+## Token queries must not re-enter the workflow
+
+`FindTokens`, `CountTokens`, `AggregateTokens`, and `TransformTokens` hold
+the workflow's lock while they run your predicate. A predicate (or
+transform) that calls back into the same workflow — `wf.GetTokens`,
+`wf.ApplyTransition`, anything taking the lock — **deadlocks** (dogfood
+friction #7). Collect first, act after:
+
+```go
+// WRONG: deadlocks — the predicate re-enters wf while the query holds its lock.
+wf.AggregateTokens(func(t workflow.Token) bool {
+    return len(wf.GetTokens("payable")) > 0 // re-entry
+}, "amount")
+
+// RIGHT: pre-collect, then run the query on plain data.
+payable := wf.GetTokens("payable")
+ids := make(map[workflow.TokenID]bool, len(payable))
+for _, t := range payable {
+    ids[t.ID()] = true
+}
+agg := wf.AggregateTokens(func(t workflow.Token) bool {
+    return ids[t.ID()]
+}, "amount")
+```
+
+Keep predicates pure functions of their arguments and this never comes up.
+
+## Definitions evolve: make approval a policy
+
+When a deployed definition changes, persisted instances still carry the old
+fingerprint, and loads route through your `WithDefinitionMigration` hook.
+The mismatch carries a structural `Diff` — places/transitions added,
+removed, changed, by name — so the hook can be a policy instead of a rubber
+stamp (dogfood `app.go`):
+
+```go
+workflow.WithDefinitionMigration(func(ctx context.Context, mm workflow.DefinitionMismatch) error {
+    switch {
+    case mm.Diff == nil: // state saved by an older library: no info — rely on place validation
+        return nil
+    case mm.Diff.Additive(): // new places/transitions only: cannot invalidate a marking
+        return nil
+    default:
+        return fmt.Errorf("non-additive change (%s): needs explicit migration", mm.Diff)
+    }
+})
+```
+
+Non-additive changes then get *real* migration logic per case — the
+dogfood's `migratePaymentAnchor` rewrites stored markings when a place was
+deleted, idempotently and version-guarded, before the manager reloads.
+
+## The checklist
+
+For every feature that touches persistence, ask:
+
+1. Does anything my `Execute` fn captures **reset at the top of fn**?
+2. Does every must-agree-with-state write go through **`WithTxSideEffect`**
+   (or `WithFireDueTxSideEffect` for timers)?
+3. Is the external entry point idempotent under redelivery
+   (**`ErrNotEnabled` → no-op**)?
+4. If this step spans two instances: are the writes **ordered and
+   idempotent**, and did I add the **reconciler case** for the window
+   between them?
+5. Are listener side effects safe to run **at-least-once**?
+6. Do my token-query predicates avoid **re-entering the workflow**?
+7. If the definition changed: is the migration hook's approval a
+   **policy over the diff**, with explicit logic for non-additive cases?

--- a/docs/roadmap/FRICTION.md
+++ b/docs/roadmap/FRICTION.md
@@ -86,29 +86,43 @@ workaround.
    the record). Wanted: a `FireDue` option receiving the fired transitions
    *inside* the transaction.
 
-5. **Cross-instance steps are the host's problem** (expected — but the
-   recipe deserves docs). Expense → payment-net enqueue and pay →
+5. ✅ **DOCUMENTED: cross-instance steps are the host's problem** (expected —
+   the recipe now has docs). Expense → payment-net enqueue and pay →
    `mark_paid` are two transactions each; both crash windows needed an
-   explicit `Reconcile`. An outbox/reconcile recipe belongs in the M6 guides.
+   explicit `Reconcile`. The pattern — ordered idempotent writes + one
+   reconciler case per window — is the cross-instance recipe in
+   [`../guides/PRODUCTION_RECIPES.md`](../guides/PRODUCTION_RECIPES.md)
+   (M6), grounded in this app's `Reconcile`.
 
-6. **`Execute` retry resets are subtle.** Any state captured by the `fn`
-   closure (fired-transition names, before/after markings) must be reset at
-   the top of `fn` because `Execute` re-runs it on `ErrConflict`. Easy to
-   get silently wrong — a `workflowtest` assertion or a doc callout would
-   help (M5.2 candidate).
+6. ✅ **DOCUMENTED: `Execute` retry resets are subtle.** Any state captured
+   by the `fn` closure (fired-transition names, before/after markings) must
+   be reset at the top of `fn` because `Execute` re-runs it on `ErrConflict`.
+   Now a RETRY RESETS callout with an example on `Manager.Execute`'s godoc
+   and the first recipe in
+   [`../guides/PRODUCTION_RECIPES.md`](../guides/PRODUCTION_RECIPES.md).
+   (A `workflowtest` assertion that flags non-reset closures remains a
+   candidate if docs prove insufficient.)
 
-7. **Token-query predicates must not call back into the workflow** (lock
-   re-entrancy). An `AggregateTokens` predicate that calls `wf.GetTokens`
-   risks deadlock; had to pre-collect IDs. Needs a doc warning on the
-   `token_query.go` API.
+7. ✅ **DOCUMENTED: token-query predicates must not call back into the
+   workflow** (lock re-entrancy). An `AggregateTokens` predicate that calls
+   `wf.GetTokens` deadlocks; had to pre-collect IDs. Now a LOCK RE-ENTRANCY
+   warning on `token_query.go` (file header + the predicate-taking APIs)
+   and a wrong-vs-right recipe in
+   [`../guides/PRODUCTION_RECIPES.md`](../guides/PRODUCTION_RECIPES.md).
 
-8. **Instance creation can't seed context or fire in one save.**
-   `CreateWorkflow(ctx, id, def, place)` persists a bare instance; setting
-   the business context and firing `submit` needs a second save (`Execute`).
-   A crash in between leaves a context-less draft the app must garbage-
-   collect (`Reconcile` deletes them after a grace period, keyed off the
-   draft token's `EnteredAt`). Wanted: `CreateWorkflow` variants taking
-   initial context, or an `Execute` that can create-if-missing.
+8. ✅ **DOCUMENTED (pattern): instance creation can't seed context or fire
+   in one save.** `CreateWorkflow(ctx, id, def, place)` persists a bare
+   instance; setting the business context and firing `submit` needs a second
+   save (`Execute`). A crash in between leaves a context-less draft the app
+   garbage-collects (`Reconcile`, grace period keyed off the draft token's
+   `EnteredAt`). The creation-seed recipe — do ALL first-save mutations in
+   one `Execute` so the crash artifact is precisely characterizable, then GC
+   it — is in
+   [`../guides/PRODUCTION_RECIPES.md`](../guides/PRODUCTION_RECIPES.md).
+   The API wish (`CreateWorkflow` variants taking initial context, or a
+   create-if-missing `Execute`) stays parked: the documented pattern makes
+   the window boring, and `CreateWorkflowFromMarking` already covers seeded
+   markings.
 
 ## Bugs found in the library (the dogfood earning its keep)
 
@@ -171,12 +185,16 @@ Priority order for what the library needs next, from what actually hurt:
    hashes, so the host approved blindly and couldn't distinguish "new
    transition added" from "place renamed".
 
-6. **Creation seed** (entry 8) and **cross-instance recipes** (entry 5) —
-   real but tolerable with documented patterns.
+6. ✅ **DOCUMENTED: creation seed** (entry 8) and **cross-instance recipes**
+   (entry 5) — the patterns now live in the M6
+   [`../guides/PRODUCTION_RECIPES.md`](../guides/PRODUCTION_RECIPES.md),
+   grounded in this app's `SubmitExpense` and `Reconcile`.
 
 ## Verdict so far
 
 No bespoke persistence or scheduling layer was needed — the M5 exit
 criterion holds. The library's core loop (load → fire → save atomically) is
-solid; the friction is all at the edges (cancellation, OR-inputs, timer
-audit atomicity, cross-instance recipes).
+solid; the friction was all at the edges (cancellation, OR-inputs, timer
+audit atomicity, cross-instance recipes) — and with the M6 guides, every
+entry in this log is now either shipped as a library feature (1–4 above,
+plus the fingerprint diff) or documented as a host pattern (5–8).

--- a/manager.go
+++ b/manager.go
@@ -453,12 +453,28 @@ func WithFireDueTxSideEffect(effect FireDueTxSideEffect) ExecuteOption {
 // reloaded state; a transition that is no longer enabled on reload returns
 // ErrNotEnabled from within fn, which Execute surfaces to the caller.
 //
+// RETRY RESETS: any variable fn's closure writes (fired-transition names,
+// step records, before/after markings) must be RE-INITIALIZED at the top of
+// fn — a retry otherwise appends to the previous attempt's values, and the
+// bug stays silent until real concurrency triggers a conflict:
+//
+//	var fired []string
+//	err := mgr.Execute(ctx, id, def, func(wf *workflow.Workflow) error {
+//	    fired = nil // reset: Execute may re-run fn on ErrConflict
+//	    if err := wf.ApplyTransition("approve"); err != nil {
+//	        return err
+//	    }
+//	    fired = append(fired, "approve")
+//	    return nil
+//	})
+//
 // Side-effect semantics: fn (and any listeners it triggers) may run more than
 // once across retries, and a listener's external side effects are not rolled
 // back by a later conflict — make them idempotent, or perform them after
 // Execute returns. Writes that must be crash-consistent with the state change
 // (history records, outbox rows) belong in a WithTxSideEffect option, which
-// commits them in the same transaction as the save.
+// commits them in the same transaction as the save. See
+// docs/guides/PRODUCTION_RECIPES.md for the full set of retry/crash recipes.
 func (m *Manager) Execute(ctx context.Context, id string, definition *Definition, fn func(*Workflow) error, opts ...ExecuteOption) error {
 	var cfg executeConfig
 	for _, opt := range opts {

--- a/token_query.go
+++ b/token_query.go
@@ -4,10 +4,21 @@ package workflow
 //
 // These operate on colored (data-carrying) tokens; uncolored presence tokens are
 // skipped, since they carry nothing to query or aggregate.
+//
+// LOCK RE-ENTRANCY: every query in this file holds the workflow's lock while
+// running the caller's predicate (or transform). A predicate that calls back
+// into the same workflow — GetTokens, ApplyTransition, Marking, anything that
+// takes the lock — DEADLOCKS. Keep predicates pure functions of their Token
+// argument; if a query needs other workflow state, collect it into plain
+// values first and close over those (see the token-query recipe in
+// docs/guides/PRODUCTION_RECIPES.md).
 
 // FindTokens returns, grouped by place, the colored tokens across the whole
 // marking that match pred (a nil pred matches every colored token). Places with
 // no match are omitted.
+//
+// pred runs under the workflow's lock and must not call back into the
+// workflow (see the re-entrancy note at the top of this file).
 func (w *Workflow) FindTokens(pred TokenPredicate) map[Place][]Token {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
@@ -87,6 +98,9 @@ func (w *Workflow) AggregateTokens(pred TokenPredicate, field string) TokenAggre
 // TransformTokens replaces the data of each colored token at place that matches
 // pred (a nil pred matches all) with transform(token), keeping each token's
 // identity. It returns the number of tokens transformed.
+//
+// pred and transform run under the workflow's write lock and must not call
+// back into the workflow (see the re-entrancy note at the top of this file).
 func (w *Workflow) TransformTokens(place Place, pred TokenPredicate, transform func(Token) TokenData) int {
 	w.mu.Lock()
 	defer w.mu.Unlock()


### PR DESCRIPTION
## Summary

The **M6 docs milestone**, delivered as ROADMAP defined it — "the deep pass, grounded in the dogfood app (not before)". Stacked on #28 (the recipes reference the migration diff).

### [`docs/guides/MENTAL_MODEL.md`](https://github.com/ehabterra/workflow/blob/m6-guides/docs/guides/MENTAL_MODEL.md) — how to *think* in Petri nets
The narrative guide: unlearning the `status VARCHAR` habit (a marking is a *set*), parallelism as state not threads, the three kinds of "or" and *who decides* each (data → XOR guards, first-arriving branch → OR-input, everyone → AND-join), cycles, reset arcs as declared cancellation, host-driven time, and the instance-per-entity vs shared-pool modeling choice. Ends with a worked six-requirement → six-construct translation. Every idea names its `expense_approval` counterpart.

### [`docs/guides/PRODUCTION_RECIPES.md`](https://github.com/ehabterra/workflow/blob/m6-guides/docs/guides/PRODUCTION_RECIPES.md) — crash windows and idempotency (friction #5–8)
- **`Execute` retry resets** — the silent append-on-retry bug, with the reset rule (friction #6)
- **Exactly-once audit** — `WithTxSideEffect` / `WithFireDueTxSideEffect`, with the tests that prove rollback
- **Webhook idempotency by error mapping** — the `ErrNotEnabled` → 200-no-op table
- **Cross-instance saga** — ordered idempotent writes + one reconciler case per crash window, from the dogfood's `Reconcile` (friction #5)
- **Creation seed** — one-`Execute` seeding makes the crash artifact precisely characterizable, then GC it (friction #8)
- **Listener at-least-once semantics**, **token-query lock re-entrancy** (friction #7, wrong-vs-right example), **migration approval as a policy over the diff**
- Closes with a 7-point checklist for any persistence-touching feature

### [`docs/BOUNDARIES.md`](https://github.com/ehabterra/workflow/blob/m6-guides/docs/BOUNDARIES.md) — what the library deliberately does not do
The ROADMAP's honest statements written out — not a durable-execution engine, no internal clock, listeners at-least-once, history opt-in, org structure in the host, cross-instance atomicity is a seam, no static analyzer yet — each with the host-side pattern and where its worked example lives.

### Godoc polish
Refreshed package doc (Execute write path, transactional effects, token read-model, current flowchart renderer — it still said "state diagram"); **RETRY RESETS** callout with example on `Manager.Execute`; **LOCK RE-ENTRANCY** warning on `token_query.go` (file header + every predicate-taking API).

### Housekeeping
README gains a documentation index table; FRICTION entries 5–8 marked ✅ documented (every entry in the log is now shipped or documented); ROADMAP M6 marked ✅ delivered — the full README rewrite deliberately stays at the v1.0 gate.

## Checklist

- [x] `gofmt -s -l .` prints nothing / `go vet ./...` passes (code changes are comments only)
- [x] `go test ./...` passes (root + examples, run serialized)
- [x] All new docs' relative links verified to resolve
- [x] `CHANGELOG.md` updated under **[Unreleased]**
- [x] Docs/examples only describe behavior the engine can actually execute (test names and API signatures verified against code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
