### PR TITLE
feat: declarative transition effects with a post-commit phase (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Declarative transition effects** (issue #36) — a transition can now declare
+  what happens when it fires, not just that it may. `Transition.SetEffects`
+  (YAML `effects:`) binds named, ordered effects that run **inside the
+  state-save transaction**; `SetAfterCommit` (YAML `after_commit:`) declares the
+  phase that runs only once the transaction has committed, for work that must
+  not be transactional. Implementations are registered once against an
+  **`EffectRegistry`** (`Register` / `RegisterAfterCommit`, plus `Validate` to
+  catch an unimplemented name at startup rather than the first time a rare
+  branch fires) and wired in with `workflow.WithEffectRegistry`.
+  Effects receive an **`EffectEvent`** — instance id, transition, the marking
+  either side of the firing, declared params, and a copy of the instance context.
+  Because effects bind to the transition, two guarded transitions out of one
+  place fire *different* effect sets, so an `ApplyAny` branch no longer needs a
+  host-side switch. A definition that declares effects without a registry is a
+  loud error, never a silent skip. **After-commit effects are at-least-once** —
+  documented on `AfterCommitFunc`; the library provides the phase, not the
+  guarantee.
+  **Fingerprint compatibility:** the effects segment is appended to a
+  transition's structural record only when it declares effects, so a definition
+  written before this feature fingerprints exactly as it did and instances
+  persisted by earlier versions keep loading without a migration. Effect order
+  and params ARE fingerprinted (order is execution order, so two orderings are
+  two different definitions).
+  Measured on `internal/spike/approval`: declarative coverage **30% → 50% by
+  concern**, **10% → 22% by line**; the per-branch effect switch and the
+  post-commit collection are gone. Total Go barely moved — the win is that the
+  sequencing decisions left Go, not that lines vanished.
 - **`internal/spike/approval` — declarative-coverage measurement** (issue #45). A
   realistic value-escalated approval workflow (threshold ladder, approvals
   ledger, separation of duties, admin last-resort, revision supersession,

--- a/definition.go
+++ b/definition.go
@@ -152,7 +152,37 @@ func transitionRecord(t *Transition) string {
 	writeLenPrefixed(&rec, guard)
 	writeLenPrefixedList(&rec, resets)
 	writeLenPrefixed(&rec, inputMode)
+
+	// Declared effects are structure: changing which effects a transition
+	// fires, their order, or their parameters is a definition change and must
+	// move the fingerprint.
+	//
+	// BACKWARD COMPATIBILITY: the segment is appended only when the transition
+	// declares effects. A definition written before effects existed serializes
+	// byte-for-byte as it did, so its fingerprint is unchanged and instances
+	// persisted by earlier versions still load without a migration. Do not
+	// hoist this out of the conditional.
+	effects := t.Effects()
+	afterCommit := t.AfterCommit()
+	if len(effects) > 0 || len(afterCommit) > 0 {
+		writeLenPrefixedList(&rec, effectRecords(effects))
+		writeLenPrefixedList(&rec, effectRecords(afterCommit))
+	}
 	return rec.String()
+}
+
+// effectRecords serializes declarations in DECLARED order — unlike places and
+// arcs, which are sorted, because effect order is semantic: it is the order
+// they execute in, so two orderings are two different definitions.
+func effectRecords(decls []EffectDecl) []string {
+	if len(decls) == 0 {
+		return nil
+	}
+	out := make([]string, len(decls))
+	for i, d := range decls {
+		out[i] = d.record()
+	}
+	return out
 }
 
 // writeLenPrefixed writes s preceded by its byte length ("3:abc"), making the

--- a/effects.go
+++ b/effects.go
@@ -1,0 +1,309 @@
+// Copyright (c) 2026 Ehab Terra
+// SPDX-License-Identifier: MIT
+
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"sync"
+)
+
+// EffectDecl is one effect bound to a transition in the definition: the name of
+// a host-registered implementation plus the parameters it is invoked with.
+//
+// Declaring effects on the transition — rather than passing closures at every
+// call site — is what lets a definition describe not just which state changes
+// are legal but what happens when one occurs. Two transitions out of the same
+// place can carry different effects, so a branch resolved by ApplyAny fires the
+// effects of the branch that actually won.
+type EffectDecl struct {
+	// Name identifies the implementation registered in the EffectRegistry.
+	Name string
+	// Params are handed to the implementation verbatim. They are part of the
+	// definition's structure and are fingerprinted, so changing a parameter is
+	// a definition change (see Definition.Fingerprint).
+	Params map[string]any
+}
+
+// clone returns a deep-enough copy that callers cannot mutate a definition's
+// declared params through the slice they passed in.
+func (e EffectDecl) clone() EffectDecl {
+	if e.Params == nil {
+		return EffectDecl{Name: e.Name}
+	}
+	params := make(map[string]any, len(e.Params))
+	maps.Copy(params, e.Params)
+	return EffectDecl{Name: e.Name, Params: params}
+}
+
+// record serializes the declaration for the definition fingerprint. Params are
+// JSON-encoded, which sorts map keys, so the encoding is stable across runs.
+func (e EffectDecl) record() string {
+	if len(e.Params) == 0 {
+		return e.Name
+	}
+	b, err := json.Marshal(e.Params)
+	if err != nil {
+		// A params map that cannot be JSON-encoded (e.g. a func value) cannot
+		// be fingerprinted meaningfully; fall back to the name so the record
+		// stays deterministic rather than panicking on a definition build.
+		return e.Name
+	}
+	return e.Name + "\x00" + string(b)
+}
+
+// EffectEvent is what an effect implementation is told about the firing it is
+// reacting to. It is a value snapshot, not a live workflow handle: an effect
+// runs while the state transaction is open (or, for an after-commit effect,
+// once it has closed), and must not reach back into the instance.
+type EffectEvent struct {
+	// WorkflowID is the instance the transition fired on.
+	WorkflowID string
+	// Transition is the name of the transition that fired.
+	Transition string
+	// Before and After are the marked places either side of this firing.
+	Before []Place
+	// After is the marking after this firing.
+	After []Place
+	// Params are the declared parameters for this effect, also passed
+	// separately for convenience.
+	Params map[string]any
+	// Context is a copy of the workflow's context map at save time. Reserved
+	// definition keys are already stripped.
+	Context map[string]any
+}
+
+// EffectFunc is a transactional effect implementation. It runs inside the same
+// transaction as the state save, in declared order; returning an error aborts
+// the transaction, so neither the state change nor any sibling effect commits.
+//
+// tx is the backend's own transaction handle — *sql.Tx for the shipped SQL
+// backends, whatever a custom backend hands its side effects. Type-assert it.
+type EffectFunc func(ctx context.Context, tx any, ev EffectEvent) error
+
+// AfterCommitFunc is an effect that runs only after the state transaction has
+// committed successfully — the phase for work that must NOT be in the
+// transaction, such as sending mail or calling a third-party API.
+//
+// AT-LEAST-ONCE. A crash between commit and this call loses the invocation, and
+// a caller-level retry can repeat it. Key these effects idempotently or route
+// them through an outbox written by a transactional effect. This is the same
+// boundary listeners have (see docs/BOUNDARIES.md); the library provides the
+// phase, not the guarantee.
+type AfterCommitFunc func(ctx context.Context, ev EffectEvent) error
+
+// EffectRegistry maps effect names declared in a definition to their host
+// implementations. It is safe for concurrent use; register everything during
+// startup and share one registry across every Manager.
+type EffectRegistry struct {
+	mu          sync.RWMutex
+	tx          map[string]EffectFunc
+	afterCommit map[string]AfterCommitFunc
+}
+
+// NewEffectRegistry returns an empty registry.
+func NewEffectRegistry() *EffectRegistry {
+	return &EffectRegistry{
+		tx:          make(map[string]EffectFunc),
+		afterCommit: make(map[string]AfterCommitFunc),
+	}
+}
+
+// Register binds a transactional effect implementation to a name. Registering
+// the same name twice is an error: a silent overwrite would make which
+// implementation runs depend on startup order.
+func (r *EffectRegistry) Register(name string, fn EffectFunc) error {
+	if name == "" {
+		return fmt.Errorf("effect name cannot be empty")
+	}
+	if fn == nil {
+		return fmt.Errorf("effect %q: implementation cannot be nil", name)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, dup := r.tx[name]; dup {
+		return fmt.Errorf("effect %q is already registered", name)
+	}
+	r.tx[name] = fn
+	return nil
+}
+
+// RegisterAfterCommit binds an after-commit implementation to a name. Names are
+// in a separate namespace from transactional effects, so the same name may mean
+// both — a definition says which phase it wants by where it declares it.
+func (r *EffectRegistry) RegisterAfterCommit(name string, fn AfterCommitFunc) error {
+	if name == "" {
+		return fmt.Errorf("after-commit effect name cannot be empty")
+	}
+	if fn == nil {
+		return fmt.Errorf("after-commit effect %q: implementation cannot be nil", name)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, dup := r.afterCommit[name]; dup {
+		return fmt.Errorf("after-commit effect %q is already registered", name)
+	}
+	r.afterCommit[name] = fn
+	return nil
+}
+
+// MustRegister is Register, panicking on error. For package-level wiring where
+// a duplicate name is a programming mistake, not a runtime condition.
+func (r *EffectRegistry) MustRegister(name string, fn EffectFunc) {
+	if err := r.Register(name, fn); err != nil {
+		panic(err)
+	}
+}
+
+// MustRegisterAfterCommit is RegisterAfterCommit, panicking on error.
+func (r *EffectRegistry) MustRegisterAfterCommit(name string, fn AfterCommitFunc) {
+	if err := r.RegisterAfterCommit(name, fn); err != nil {
+		panic(err)
+	}
+}
+
+func (r *EffectRegistry) lookupTx(name string) (EffectFunc, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	fn, ok := r.tx[name]
+	return fn, ok
+}
+
+func (r *EffectRegistry) lookupAfterCommit(name string) (AfterCommitFunc, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	fn, ok := r.afterCommit[name]
+	return fn, ok
+}
+
+// Validate reports every effect a definition declares that this registry cannot
+// resolve. Call it at startup: without it, an unregistered effect surfaces only
+// when the transition first fires, which for a rare branch can be much later.
+func (r *EffectRegistry) Validate(def *Definition) error {
+	if def == nil {
+		return nil
+	}
+	var missing []string
+	for i := range def.Transitions {
+		t := &def.Transitions[i]
+		for _, e := range t.Effects() {
+			if _, ok := r.lookupTx(e.Name); !ok {
+				missing = append(missing, fmt.Sprintf("%s: effect %q", t.Name(), e.Name))
+			}
+		}
+		for _, e := range t.AfterCommit() {
+			if _, ok := r.lookupAfterCommit(e.Name); !ok {
+				missing = append(missing, fmt.Sprintf("%s: after_commit %q", t.Name(), e.Name))
+			}
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	return fmt.Errorf("unregistered effects: %v", missing)
+}
+
+// pendingAfterCommit is a resolved after-commit effect awaiting a successful
+// commit: the implementation plus the event it will be handed.
+type pendingAfterCommit struct {
+	fn AfterCommitFunc
+	ev EffectEvent
+}
+
+// resolveEffects turns the transitions that fired into concrete effect
+// closures. Both phases are resolved BEFORE the save so an unregistered name
+// fails the whole attempt rather than aborting midway through a transaction
+// with some effects already applied.
+//
+// Effects are returned in firing order, and within a firing in declared order.
+func (m *Manager) resolveEffects(
+	id string,
+	def *Definition,
+	steps []FiredStep,
+	ctxData map[string]any,
+) ([]TxSideEffect, []pendingAfterCommit, error) {
+	if len(steps) == 0 {
+		return nil, nil, nil
+	}
+	var txEffects []TxSideEffect
+	var pending []pendingAfterCommit
+
+	for _, step := range steps {
+		t := def.Transition(step.Transition)
+		if t == nil {
+			// The transition fired, so it exists in this definition; a nil here
+			// would mean the definition changed under us mid-Execute.
+			return nil, nil, fmt.Errorf("effects: transition %q not found in definition", step.Transition)
+		}
+		for _, decl := range t.Effects() {
+			fn, ok := m.effects.lookupTx(decl.Name)
+			if !ok {
+				return nil, nil, fmt.Errorf("effects: transition %q declares unregistered effect %q", step.Transition, decl.Name)
+			}
+			ev := newEffectEvent(id, step, decl, ctxData)
+			txEffects = append(txEffects, func(ctx context.Context, tx any) error {
+				return fn(ctx, tx, ev)
+			})
+		}
+		for _, decl := range t.AfterCommit() {
+			fn, ok := m.effects.lookupAfterCommit(decl.Name)
+			if !ok {
+				return nil, nil, fmt.Errorf("effects: transition %q declares unregistered after_commit effect %q", step.Transition, decl.Name)
+			}
+			pending = append(pending, pendingAfterCommit{fn: fn, ev: newEffectEvent(id, step, decl, ctxData)})
+		}
+	}
+	return txEffects, pending, nil
+}
+
+// newEffectEvent snapshots what an effect implementation is told. Slices and
+// maps are copied so an effect cannot mutate the marking the save is about to
+// persist, or another effect's view of the context.
+func newEffectEvent(id string, step FiredStep, decl EffectDecl, ctxData map[string]any) EffectEvent {
+	ev := EffectEvent{
+		WorkflowID: id,
+		Transition: step.Transition,
+		Before:     slices.Clone(step.Before),
+		After:      slices.Clone(step.After),
+		Params:     decl.clone().Params,
+	}
+	if ctxData != nil {
+		ev.Context = make(map[string]any, len(ctxData))
+		maps.Copy(ev.Context, ctxData)
+	}
+	return ev
+}
+
+// runAfterCommit invokes resolved after-commit effects in order, stopping at
+// the first error. The state change has already committed and is NOT undone —
+// the error only tells the caller an after-commit effect failed.
+func runAfterCommit(ctx context.Context, pending []pendingAfterCommit) error {
+	for _, p := range pending {
+		if err := p.fn(ctx, p.ev); err != nil {
+			return fmt.Errorf("after_commit effect for transition %q: %w", p.ev.Transition, err)
+		}
+	}
+	return nil
+}
+
+// definitionDeclaresEffects reports whether any transition binds an effect. The
+// Manager needs this before running the fire loop, to decide up front whether
+// transactional storage is required — the same check it makes for
+// WithTxSideEffect, but knowable from the definition alone.
+func definitionDeclaresEffects(def *Definition) bool {
+	if def == nil {
+		return false
+	}
+	for i := range def.Transitions {
+		if len(def.Transitions[i].Effects()) > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/effects_test.go
+++ b/effects_test.go
@@ -1,0 +1,453 @@
+// Copyright (c) 2026 Ehab Terra
+// SPDX-License-Identifier: MIT
+
+package workflow_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/ehabterra/workflow"
+)
+
+// txMemStore is an in-memory TransactionalStorage that models the atomicity
+// contract honestly: effects run against a pending buffer, and the state row is
+// published only if every one of them succeeded. An effect that errors leaves
+// both the state and the other effects' writes discarded.
+type txMemStore struct {
+	mu      sync.Mutex
+	rows    map[string]txRow
+	journal []string // committed effect writes, in order
+}
+
+type txRow struct {
+	// state is SERIALIZED, not the live Marking. A fake that stores the object
+	// hands the next load an alias the workflow then mutates in place, so a
+	// failed save appears to have advanced the state. Real backends serialize;
+	// so must this one.
+	state   []byte
+	ctx     map[string]any
+	version int64
+}
+
+// fakeTx is the handle effects receive. Writes land here and are published to
+// the store's journal only on commit.
+type fakeTx struct{ pending []string }
+
+func (t *fakeTx) write(s string) { t.pending = append(t.pending, s) }
+
+func newTxMemStore() *txMemStore { return &txMemStore{rows: make(map[string]txRow)} }
+
+func (s *txMemStore) LoadState(ctx context.Context, id string) (workflow.Marking, map[string]any, int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	row, ok := s.rows[id]
+	if !ok {
+		return nil, nil, 0, workflow.ErrWorkflowNotFound
+	}
+	m, err := workflow.UnmarshalMarkingJSON(row.state)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	return m, row.ctx, row.version, nil
+}
+
+func (s *txMemStore) SaveState(ctx context.Context, id string, m workflow.Marking, c map[string]any, expected int64) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.saveLocked(id, m, c, expected)
+}
+
+func (s *txMemStore) saveLocked(id string, m workflow.Marking, c map[string]any, expected int64) (int64, error) {
+	row, exists := s.rows[id]
+	switch {
+	case !exists && expected != 0:
+		return 0, workflow.ErrConflict
+	case exists && row.version != expected:
+		return 0, workflow.ErrConflict
+	}
+	state, err := json.Marshal(m)
+	if err != nil {
+		return 0, err
+	}
+	next := expected + 1
+	s.rows[id] = txRow{state: state, ctx: c, version: next}
+	return next, nil
+}
+
+// SaveStateInTx runs the effects first, then publishes state and effect writes
+// together — or neither.
+func (s *txMemStore) SaveStateInTx(ctx context.Context, id string, m workflow.Marking, c map[string]any, expected int64, effects ...workflow.TxSideEffect) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx := &fakeTx{}
+	for _, e := range effects {
+		if err := e(ctx, tx); err != nil {
+			return 0, err // roll back: nothing is published
+		}
+	}
+	v, err := s.saveLocked(id, m, c, expected)
+	if err != nil {
+		return 0, err
+	}
+	s.journal = append(s.journal, tx.pending...)
+	return v, nil
+}
+
+func (s *txMemStore) DeleteState(ctx context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.rows, id)
+	return nil
+}
+
+func (s *txMemStore) committed() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.journal...)
+}
+
+func mustGuard(t *testing.T, expr string) workflow.Constraint {
+	t.Helper()
+	c, err := workflow.NewExpressionConstraint(expr)
+	if err != nil {
+		t.Fatalf("guard %q: %v", expr, err)
+	}
+	return c
+}
+
+func decl(name string, params map[string]any) workflow.EffectDecl {
+	return workflow.EffectDecl{Name: name, Params: params}
+}
+
+// effectDef builds a two-branch definition: approve_partial loops back on
+// `open`, approve_final advances to `done`. Each carries different effects, so
+// the branch that fires determines what runs.
+func effectDef(t *testing.T) *workflow.Definition {
+	t.Helper()
+	partial := workflow.MustNewTransition("approve_partial", []workflow.Place{"open"}, []workflow.Place{"open"})
+	partial.AddConstraint(mustGuard(t, "!satisfied"))
+	partial.SetEffects(decl("audit", map[string]any{"detail": "pending"}))
+
+	final := workflow.MustNewTransition("approve_final", []workflow.Place{"open"}, []workflow.Place{"done"})
+	final.AddConstraint(mustGuard(t, "satisfied"))
+	final.SetEffects(
+		decl("audit", map[string]any{"detail": "complete"}),
+		decl("outbox", map[string]any{"event": "approved"}),
+	)
+	final.SetAfterCommit(decl("email", map[string]any{"template": "approved"}))
+
+	def, err := workflow.NewDefinition([]workflow.Place{"open", "done"}, []workflow.Transition{*partial, *final})
+	if err != nil {
+		t.Fatalf("NewDefinition: %v", err)
+	}
+	return def
+}
+
+// recordingRegistry registers audit/outbox/email implementations that append to
+// a shared journal so tests can assert order.
+func recordingRegistry(sent *[]string) *workflow.EffectRegistry {
+	reg := workflow.NewEffectRegistry()
+	reg.MustRegister("audit", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		tx.(*fakeTx).write(fmt.Sprintf("audit:%v:%s", ev.Params["detail"], ev.Transition))
+		return nil
+	})
+	reg.MustRegister("outbox", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		tx.(*fakeTx).write(fmt.Sprintf("outbox:%v", ev.Params["event"]))
+		return nil
+	})
+	reg.MustRegisterAfterCommit("email", func(ctx context.Context, ev workflow.EffectEvent) error {
+		*sent = append(*sent, fmt.Sprintf("email:%v", ev.Params["template"]))
+		return nil
+	})
+	return reg
+}
+
+// TestFingerprintStableWithoutEffects is the compatibility guard: a definition
+// declaring no effects must fingerprint exactly as it did before effects
+// existed, or every instance persisted by an earlier version fails to load.
+// Adding an effect must move it; clearing the effect must restore it.
+func TestFingerprintStableWithoutEffects(t *testing.T) {
+	build := func(effects ...workflow.EffectDecl) string {
+		tr := workflow.MustNewTransition("go", []workflow.Place{"a"}, []workflow.Place{"b"})
+		if len(effects) > 0 {
+			tr.SetEffects(effects...)
+		}
+		def, err := workflow.NewDefinition([]workflow.Place{"a", "b"}, []workflow.Transition{*tr})
+		if err != nil {
+			t.Fatalf("NewDefinition: %v", err)
+		}
+		return def.Fingerprint()
+	}
+
+	plain := build()
+	if plain != build() {
+		t.Fatal("fingerprint is not stable across identical builds")
+	}
+	if withEffect := build(decl("audit", nil)); withEffect == plain {
+		t.Error("declaring an effect must change the fingerprint")
+	}
+	// Clearing effects must produce the ORIGINAL bytes again — this is what
+	// proves the effects segment is absent (not merely empty) when unused.
+	if again := build(); again != plain {
+		t.Errorf("fingerprint drifted for an effect-free definition:\n got %s\nwant %s", again, plain)
+	}
+}
+
+// TestFingerprintEffectOrderAndParams: order is execution order and params are
+// structure, so both must move the fingerprint. (Places and arcs are sorted
+// before hashing; effects deliberately are not.)
+func TestFingerprintEffectOrderAndParams(t *testing.T) {
+	build := func(decls ...workflow.EffectDecl) string {
+		tr := workflow.MustNewTransition("go", []workflow.Place{"a"}, []workflow.Place{"b"})
+		tr.SetEffects(decls...)
+		def, err := workflow.NewDefinition([]workflow.Place{"a", "b"}, []workflow.Transition{*tr})
+		if err != nil {
+			t.Fatalf("NewDefinition: %v", err)
+		}
+		return def.Fingerprint()
+	}
+	a, b := decl("audit", nil), decl("outbox", nil)
+	if build(a, b) == build(b, a) {
+		t.Error("effect order must affect the fingerprint — it is the execution order")
+	}
+	if build(decl("audit", map[string]any{"d": "x"})) == build(decl("audit", map[string]any{"d": "y"})) {
+		t.Error("effect params must affect the fingerprint")
+	}
+}
+
+func TestEffectRegistryRejectsDuplicatesAndEmpty(t *testing.T) {
+	reg := workflow.NewEffectRegistry()
+	noop := func(context.Context, any, workflow.EffectEvent) error { return nil }
+
+	if err := reg.Register("", noop); err == nil {
+		t.Error("empty name should be rejected")
+	}
+	if err := reg.Register("audit", nil); err == nil {
+		t.Error("nil implementation should be rejected")
+	}
+	if err := reg.Register("audit", noop); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	if err := reg.Register("audit", noop); err == nil {
+		t.Error("duplicate registration should be rejected — a silent overwrite " +
+			"would make behaviour depend on startup order")
+	}
+}
+
+// TestEffectRegistryValidate catches unregistered names at startup rather than
+// when a rare branch first fires.
+func TestEffectRegistryValidate(t *testing.T) {
+	def := effectDef(t)
+	reg := workflow.NewEffectRegistry()
+	reg.MustRegister("audit", func(context.Context, any, workflow.EffectEvent) error { return nil })
+
+	err := reg.Validate(def)
+	if err == nil {
+		t.Fatal("expected unregistered effects to be reported")
+	}
+	for _, want := range []string{"outbox", "email"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Validate error %q does not mention %q", err, want)
+		}
+	}
+
+	reg.MustRegister("outbox", func(context.Context, any, workflow.EffectEvent) error { return nil })
+	reg.MustRegisterAfterCommit("email", func(context.Context, workflow.EffectEvent) error { return nil })
+	if err := reg.Validate(def); err != nil {
+		t.Errorf("Validate after registering everything: %v", err)
+	}
+}
+
+// TestPerBranchEffects is the headline behaviour: one action with two outcomes
+// fires the effects of the branch that actually won, with no host-side switch.
+func TestPerBranchEffects(t *testing.T) {
+	ctx := context.Background()
+	def := effectDef(t)
+	store := newTxMemStore()
+	var sent []string
+	mgr := workflow.NewManager(workflow.NewRegistry(), store, workflow.WithEffectRegistry(recordingRegistry(&sent)))
+
+	if _, err := mgr.CreateWorkflow(ctx, "w1", def, "open"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Branch 1: the chain is not yet satisfied — record and stay put.
+	if err := mgr.Execute(ctx, "w1", def, func(wf *workflow.Workflow) error {
+		wf.SetContext("satisfied", false) // chain not yet complete
+		_, err := wf.ApplyAny(ctx, "approve_final", "approve_partial")
+		return err
+	}); err != nil {
+		t.Fatalf("partial: %v", err)
+	}
+	if got := store.committed(); len(got) != 1 || got[0] != "audit:pending:approve_partial" {
+		t.Fatalf("after partial branch, journal = %v", got)
+	}
+	if len(sent) != 0 {
+		t.Errorf("partial branch must not send mail, got %v", sent)
+	}
+
+	// Branch 2: satisfied — advance, with a different effect set plus after-commit.
+	if err := mgr.Execute(ctx, "w1", def, func(wf *workflow.Workflow) error {
+		wf.SetContext("satisfied", true) // the approval that completes the chain
+		_, err := wf.ApplyAny(ctx, "approve_final", "approve_partial")
+		return err
+	}); err != nil {
+		t.Fatalf("final: %v", err)
+	}
+	want := []string{"audit:pending:approve_partial", "audit:complete:approve_final", "outbox:approved"}
+	got := store.committed()
+	if len(got) != len(want) {
+		t.Fatalf("journal = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("journal[%d] = %q, want %q (declared order is execution order)", i, got[i], want[i])
+		}
+	}
+	if len(sent) != 1 || sent[0] != "email:approved" {
+		t.Errorf("after-commit effects = %v, want [email:approved]", sent)
+	}
+}
+
+// TestEffectFailureRollsBackState: an effect that errors aborts the transaction,
+// so neither the state change nor a sibling effect's write survives.
+func TestEffectFailureRollsBackState(t *testing.T) {
+	ctx := context.Background()
+	def := effectDef(t)
+	store := newTxMemStore()
+
+	reg := workflow.NewEffectRegistry()
+	reg.MustRegister("audit", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		tx.(*fakeTx).write("audit")
+		return nil
+	})
+	boom := errors.New("outbox unavailable")
+	reg.MustRegister("outbox", func(context.Context, any, workflow.EffectEvent) error { return boom })
+	reg.MustRegisterAfterCommit("email", func(context.Context, workflow.EffectEvent) error {
+		t.Error("after-commit must not run when the transaction failed")
+		return nil
+	})
+	mgr := workflow.NewManager(workflow.NewRegistry(), store, workflow.WithEffectRegistry(reg))
+
+	if _, err := mgr.CreateWorkflow(ctx, "w2", def, "open"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	err := mgr.Execute(ctx, "w2", def, func(wf *workflow.Workflow) error {
+		wf.SetContext("satisfied", true)
+		return wf.ApplyTransitionWithContext(ctx, "approve_final")
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want %v", err, boom)
+	}
+	if got := store.committed(); len(got) != 0 {
+		t.Errorf("sibling effect writes survived a failed transaction: %v", got)
+	}
+	marking, _, _, lerr := store.LoadState(ctx, "w2")
+	if lerr != nil {
+		t.Fatalf("load: %v", lerr)
+	}
+	if !marking.HasPlace("open") {
+		t.Errorf("state advanced despite the effect failing: %v", marking.Places())
+	}
+}
+
+// TestExecuteRequiresRegistry: a definition that declares effects must not run
+// against a Manager with no registry — silently skipping writes the definition
+// promised is worse than failing.
+func TestExecuteRequiresRegistry(t *testing.T) {
+	ctx := context.Background()
+	def := effectDef(t)
+	mgr := workflow.NewManager(workflow.NewRegistry(), newTxMemStore())
+	if _, err := mgr.CreateWorkflow(ctx, "w3", def, "open"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	err := mgr.Execute(ctx, "w3", def, func(wf *workflow.Workflow) error {
+		wf.SetContext("satisfied", true)
+		return wf.ApplyTransitionWithContext(ctx, "approve_final")
+	})
+	if !errors.Is(err, errors.ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !strings.Contains(err.Error(), "WithEffectRegistry") {
+		t.Errorf("error should point at the fix, got: %v", err)
+	}
+}
+
+// TestUnregisteredEffectFailsBeforeSave: resolution happens before the save, so
+// a missing implementation aborts the attempt rather than tearing down a
+// transaction with some effects already applied.
+func TestUnregisteredEffectFailsBeforeSave(t *testing.T) {
+	ctx := context.Background()
+	def := effectDef(t)
+	store := newTxMemStore()
+	reg := workflow.NewEffectRegistry()
+	reg.MustRegister("audit", func(context.Context, any, workflow.EffectEvent) error { return nil })
+	// outbox deliberately not registered.
+	mgr := workflow.NewManager(workflow.NewRegistry(), store, workflow.WithEffectRegistry(reg))
+
+	if _, err := mgr.CreateWorkflow(ctx, "w4", def, "open"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	err := mgr.Execute(ctx, "w4", def, func(wf *workflow.Workflow) error {
+		wf.SetContext("satisfied", true)
+		return wf.ApplyTransitionWithContext(ctx, "approve_final")
+	})
+	if err == nil || !strings.Contains(err.Error(), "unregistered effect") {
+		t.Fatalf("err = %v, want an unregistered-effect error", err)
+	}
+	if got := store.committed(); len(got) != 0 {
+		t.Errorf("effects ran despite an unresolvable sibling: %v", got)
+	}
+}
+
+// TestEffectEventCarriesMarkingAndContext: an effect is told which transition
+// fired, the marking either side of it, and the instance context.
+func TestEffectEventCarriesMarkingAndContext(t *testing.T) {
+	ctx := context.Background()
+	def := effectDef(t)
+	store := newTxMemStore()
+
+	var seen workflow.EffectEvent
+	reg := workflow.NewEffectRegistry()
+	reg.MustRegister("audit", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		seen = ev
+		return nil
+	})
+	reg.MustRegister("outbox", func(context.Context, any, workflow.EffectEvent) error { return nil })
+	reg.MustRegisterAfterCommit("email", func(context.Context, workflow.EffectEvent) error { return nil })
+	mgr := workflow.NewManager(workflow.NewRegistry(), store, workflow.WithEffectRegistry(reg))
+
+	if _, err := mgr.CreateWorkflow(ctx, "w5", def, "open"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := mgr.Execute(ctx, "w5", def, func(wf *workflow.Workflow) error {
+		wf.SetContext("actor", "sam")
+		wf.SetContext("satisfied", true)
+		return wf.ApplyTransitionWithContext(ctx, "approve_final")
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if seen.WorkflowID != "w5" || seen.Transition != "approve_final" {
+		t.Errorf("event identity = %q/%q", seen.WorkflowID, seen.Transition)
+	}
+	if len(seen.Before) != 1 || seen.Before[0] != "open" {
+		t.Errorf("Before = %v, want [open]", seen.Before)
+	}
+	if len(seen.After) != 1 || seen.After[0] != "done" {
+		t.Errorf("After = %v, want [done]", seen.After)
+	}
+	if seen.Context["actor"] != "sam" {
+		t.Errorf("Context[actor] = %v, want sam", seen.Context["actor"])
+	}
+	if seen.Params["detail"] != "complete" {
+		t.Errorf("Params[detail] = %v, want complete", seen.Params["detail"])
+	}
+}

--- a/internal/spike/approval/COVERAGE.md
+++ b/internal/spike/approval/COVERAGE.md
@@ -32,13 +32,32 @@ what guards them, what effects they fire, and what state results. Schema, record
 CRUD, the role ladder config, and the user directory are domain code that would
 exist with or without the library, and are excluded from both sides.
 
-| | non-comment lines |
-|---|---|
-| **Declarative** (`workflow.yaml`) | **36** |
-| **Go** (workflow logic the definition could not absorb) | **337** |
-| *(excluded: domain schema, CRUD, role/directory config)* | *(206)* |
+> **Re-measured after #36 (declarative effects) landed.** The pre-#36 baseline is
+> kept alongside every figure, because the point of this document is the delta.
 
-### **Declarative coverage: 10% by line**
+| | before #36 | after #36 |
+|---|---|---|
+| **Declarative** (`workflow.yaml`) | 36 | **85** |
+| **Go — orchestration** (binding, ordering, branch dispatch) | 303 | **167** |
+| **Go — effect implementations** (the SQL itself) | 34 | **142** |
+| *(excluded: domain schema, CRUD, role/directory config)* | *(206)* | *(206)* |
+
+### **Declarative coverage: 22% by line** (was 10%)
+
+Counting orchestration only — the sequencing decisions, excluding the SQL that
+would exist under any design — it is **34%**, up from 11%.
+
+**Total Go barely moved** (337 → 309), and that is the honest headline: #36 did
+not delete code so much as *relocate the decisions*. 49 lines of "which effects,
+in what order, on which branch" moved out of Go and into the definition, and the
+per-branch `switch` disappeared entirely.
+
+The effect implementations got **more verbose** (34 → 142 lines), which is a real
+cost worth recording: a registry entry extracts its parameters from the event and
+type-asserts the transaction, where the old closure captured typed values
+directly. That is the price of the indirection, and it is paid once per effect
+kind rather than once per transition — so it amortizes as a workflow grows, and
+would not amortize for a workflow with two transitions.
 
 Line-counting YAML against Go flatters neither side — YAML is denser per line — so
 here is the same question asked by **concern**, which is the fairer measure:
@@ -57,20 +76,24 @@ here is the same question asked by **concern**, which is the fairer measure:
 | 10 | Chain satisfaction (dynamic AND-join) | ❌ Go |
 | 11 | Separation of duties | ⚠️ half — guard declarative, input Go |
 | 12 | Last-resort override | ❌ Go |
-| 13 | Branch selection (partial vs final) | ⚠️ half — `ApplyAny` routes, effects don't follow |
-| 14 | Per-transition effect binding | ❌ Go |
-| 15 | Effect ordering | ❌ Go |
-| 16 | Post-commit phase | ❌ Go |
-| 17 | Status projection | ❌ Go |
+| 13 | Branch selection (partial vs final) | ✅ **declarative since #36** |
+| 14 | Per-transition effect binding | ✅ **declarative since #36** |
+| 15 | Effect ordering | ✅ **declarative since #36** |
+| 16 | Post-commit phase | ✅ **declarative since #36** |
+| 17 | Status projection | ⚠️ half since #36 — *when* it runs is declared, the place→status map is still host code (#39) |
 | 18 | Multi-instance cascade | ❌ Go — **and incorrect**, see friction 5 |
 | 19 | Guard rejection → error mapping | ❌ Go |
 | 20 | Actor authorization (is this actor even in the chain?) | ❌ Go — added in review, see below |
 
-### **Declarative coverage: 30% by concern** (5 full + 2 half of 20)
+### **Declarative coverage: 50% by concern** (9 full + 2 half of 20) — was 30%
 
-Both are far below the ~50% floor at which adoption starts paying for itself. The
-issue-#45 estimate of 15-20% was about right for concerns and **optimistic** on
-lines: the real line figure is 10%.
+That crosses the ~50% floor at which adoption starts paying for itself, on one
+feature. The prediction when #36 was filed was "near 50% after #36 **and** #39";
+#36 reached it alone, so the estimate was pessimistic by about one feature.
+
+What is left below the line is the part that was always the hard part: the
+dynamic approval join, the guard inputs it depends on, and the multi-instance
+cascade. Those are #34, #35, and #37 — no amount of effect plumbing reaches them.
 
 The shape of the result matters more than either number. What the library covers
 is the **status graph** — real, correct, and the part a host can hand-roll in a
@@ -121,23 +144,37 @@ concurrent *save* on the same instance, but not a stale *decision input* read
 before the cycle began. Real systems close this with an in-transaction re-check;
 here there is nowhere to put one.
 
-### 3 — Effects are opaque closures ([#36](https://github.com/ehabterra/workflow/issues/36)) · ~150 lines
+### 3 — Effects are opaque closures ([#36](https://github.com/ehabterra/workflow/issues/36)) — ✅ **RESOLVED**
 
-`WithTxSideEffect` takes one function. Everything else — which effects a transition
-fires, in what order, and which of them differ per branch — is assembled by hand.
-The `fire` wrapper, the `effect` type, the four effect constructors, the
-per-transition effect lists, and the post-commit collection all exist for this
-reason. It is the single largest block of Go in the spike.
+*Was: ~150 lines, the single largest block of Go in the spike.*
 
-The per-branch case is the sharpest: `Approve` fires `approve_partial` or
-`approve_final`, and the branch is known only inside a Go closure, so the differing
-effects are a `switch` rather than two transition declarations.
+`WithTxSideEffect` took one function, so which effects a transition fired, in what
+order, and which differed per branch was all assembled by hand: a `fire` wrapper
+threading effect-builders through `Execute`, an `effect` type, four effect
+constructors, a per-transition effect list in every service method, and a `switch`
+on which branch `ApplyAny` picked.
 
-### 4 — No post-commit phase ([#36](https://github.com/ehabterra/workflow/issues/36)) · ~15 lines
+All of that is now declared. `workflow.yaml` names the effects per transition;
+`effects.go` registers the implementations once at startup; `App.fire` is eight
+lines that seed context and apply. The per-branch switch is gone — `approve_partial`
+and `approve_final` carry their own effect lists, so the branch that wins fires its
+own effects with no host involvement.
 
-The email must not be in the transaction. There is no phase for it, so the host
-collects emails during the fire and flushes them after `Execute` returns —
-re-implementing per action what a declared `after_commit` would do once.
+What remains is the implementations themselves, which are host SQL and always were.
+They grew (34 → 142 lines) because a registry entry must extract its params from the
+event and assert the tx type where a closure captured typed values — see the note
+under the headline figures.
+
+### 4 — No post-commit phase ([#36](https://github.com/ehabterra/workflow/issues/36)) — ✅ **RESOLVED**
+
+*Was: ~15 lines.*
+
+The email must not be in the transaction. `after_commit:` is now a declared phase;
+the host registers one `email` implementation and the definition says which
+transitions send which template. The per-action collect-and-flush is gone.
+
+The at-least-once boundary is documented on `AfterCommitFunc` rather than left for
+the adopter to discover.
 
 ### 5 — No atomic multi-instance transition ([#37](https://github.com/ehabterra/workflow/issues/37)) · ~10 lines, **and a correctness bug**
 

--- a/internal/spike/approval/app.go
+++ b/internal/spike/approval/app.go
@@ -6,7 +6,6 @@ package approval
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -30,9 +29,8 @@ var (
 	ErrNotReady          = errors.New("approval: requisition not ready") // -> 422
 )
 
-// Email is a post-commit notification. The library has no post-commit effect
-// phase, so the host collects these during the transaction and flushes them
-// after Execute returns.
+// Email is a post-commit notification, produced by the declared `email`
+// after-commit effect.
 type Email struct {
 	To       string
 	Template string
@@ -72,13 +70,19 @@ func New(ctx context.Context, db *sql.DB, hier Hierarchy, dir *Directory) (*App,
 	if _, err := db.ExecContext(ctx, Schema); err != nil {
 		return nil, fmt.Errorf("host schema: %w", err)
 	}
-	return &App{
-		db:   db,
-		mgr:  workflow.NewManager(workflow.NewRegistry(), store),
-		def:  def,
-		hier: hier,
-		dir:  dir,
-	}, nil
+
+	a := &App{db: db, def: def, hier: hier, dir: dir}
+	reg, err := a.registerEffects()
+	if err != nil {
+		return nil, fmt.Errorf("register effects: %w", err)
+	}
+	// Fail at startup on an effect the definition names but nothing implements,
+	// rather than the first time a rare branch fires.
+	if err := reg.Validate(def); err != nil {
+		return nil, fmt.Errorf("effect wiring: %w", err)
+	}
+	a.mgr = workflow.NewManager(workflow.NewRegistry(), store, workflow.WithEffectRegistry(reg))
+	return a, nil
 }
 
 // Definition exposes the net for diagramming and tests.
@@ -104,112 +108,22 @@ func (a *App) Create(ctx context.Context, id, ref, submitter string, amount floa
 	return err
 }
 
-// effect is one write that must land in the state-change transaction. The
-// library takes a single opaque TxSideEffect, so the host builds and sequences
-// this list itself. See COVERAGE.md, friction 3.
-type effect func(ctx context.Context, tx *sql.Tx) error
-
-// fire is the shared load-fire-save wrapper every action goes through. It
-// exists only because effects, the status projection, and the post-commit
-// phase all have to be assembled by hand for every transition.
-func (a *App) fire(
-	ctx context.Context,
-	id string,
-	setup func(wf *workflow.Workflow),
-	apply func(wf *workflow.Workflow) (string, error),
-	effects func(fired string) []effect,
-	postCommit func(fired string) []Email,
-) (string, error) {
-	var fired string
-	err := a.mgr.Execute(ctx, id, a.def, func(wf *workflow.Workflow) error {
-		// Execute retries the whole cycle on ErrConflict, so setup must be
-		// re-applied on every attempt and must be idempotent.
-		setup(wf)
-		name, err := apply(wf)
-		if err != nil {
-			return err
+// fire applies one transition under Execute.
+//
+// Compare with the pre-#36 version: it took a setup func, an apply func, an
+// effects-builder keyed on which branch fired, and a post-commit builder —
+// because every one of those was the host's job. Effects and the post-commit
+// phase are declared now, so all that remains is seeding the context the guards
+// and effects read.
+func (a *App) fire(ctx context.Context, id string, seed map[string]any, apply func(*workflow.Workflow) error) error {
+	return a.mgr.Execute(ctx, id, a.def, func(wf *workflow.Workflow) error {
+		// Execute retries the whole cycle on ErrConflict, so seeding must be
+		// idempotent — it is, being a plain overwrite per attempt.
+		for k, v := range seed {
+			wf.SetContext(k, v)
 		}
-		fired = name
-		// The status projection is derived here and written in the effect
-		// below, because the library has no projection binding.
-		return nil
-	}, workflow.WithTxSideEffect(func(ctx context.Context, tx any) error {
-		sqlTx, ok := tx.(*sql.Tx)
-		if !ok {
-			return fmt.Errorf("unexpected tx type %T", tx)
-		}
-		for _, e := range effects(fired) {
-			if err := e(ctx, sqlTx); err != nil {
-				return err
-			}
-		}
-		return nil
-	}))
-	if err != nil {
-		return "", err
-	}
-	a.Sent = append(a.Sent, postCommit(fired)...)
-	return fired, nil
-}
-
-// statusOf maps the instance's marking back to the record's status column.
-// Place metadata carries the label; a marking with more than one marked place
-// would make this lossy, which is why the net stays single-token.
-func (a *App) statusOf(wf *workflow.Workflow) string {
-	for _, p := range wf.CurrentPlaces() {
-		if v, ok := a.def.PlaceMetadata(p, "status"); ok {
-			if s, ok := v.(string); ok {
-				return s
-			}
-		}
-	}
-	return ""
-}
-
-// project writes the derived status onto the record row inside the tx.
-func project(reqID, status string) effect {
-	return func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `UPDATE requisitions SET status = ? WHERE id = ?`, status, reqID)
-		return err
-	}
-}
-
-func auditEffect(reqID, action, detail, actor string) effect {
-	return func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx,
-			`INSERT INTO audit_log (req_id, action, detail, actor) VALUES (?, ?, ?, ?)`,
-			reqID, action, detail, actor)
-		return err
-	}
-}
-
-func notifyEffect(reqID, target, kind string) effect {
-	return func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx,
-			`INSERT INTO notifications (req_id, target, kind) VALUES (?, ?, ?)`, reqID, target, kind)
-		return err
-	}
-}
-
-func outboxEffect(reqID, event, payload string) effect {
-	return func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx,
-			`INSERT INTO outbox (req_id, event, payload) VALUES (?, ?, ?)`, reqID, event, payload)
-		return err
-	}
-}
-
-func ledgerEffect(reqID, actor, role string, lastResort bool) effect {
-	return func(ctx context.Context, tx *sql.Tx) error {
-		lr := 0
-		if lastResort {
-			lr = 1
-		}
-		_, err := tx.ExecContext(ctx,
-			`INSERT INTO approvals (req_id, actor, role, last_resort) VALUES (?, ?, ?, ?)`,
-			reqID, actor, role, lr)
-		return err
-	}
+		return apply(wf)
+	})
 }
 
 // Submit fires the submit transition after evaluating the ready-gate.
@@ -219,25 +133,14 @@ func (a *App) Submit(ctx context.Context, id, actor string) error {
 		return err
 	}
 	ready := readyGate(req)
-	status := ""
-	_, err = a.fire(ctx, id,
-		func(wf *workflow.Workflow) { wf.SetContext("ready", ready) },
-		func(wf *workflow.Workflow) (string, error) {
-			if err := wf.ApplyTransitionWithContext(ctx, "submit"); err != nil {
-				return "", err
-			}
-			status = a.statusOf(wf)
-			return "submit", nil
-		},
-		func(string) []effect {
-			return []effect{
-				project(id, status),
-				auditEffect(id, "requisition.submit", req.Ref, actor),
-				notifyEffect(id, "approvers", "submitted"),
-			}
-		},
-		func(string) []Email { return []Email{{To: "approvers", Template: "submitted", ReqID: id}} },
-	)
+	err = a.fire(ctx, id, map[string]any{
+		"ready":     ready,
+		"actor":     actor,
+		"submitter": req.Submitter,
+		"amount":    req.Amount,
+	}, func(wf *workflow.Workflow) error {
+		return wf.ApplyTransitionWithContext(ctx, "submit")
+	})
 	if err != nil {
 		// The library cannot say WHICH guard rejected, so the host recomputes
 		// the gate to produce the right error. See COVERAGE.md, friction 6.
@@ -249,11 +152,10 @@ func (a *App) Submit(ctx context.Context, id, actor string) error {
 	return nil
 }
 
-// Approve is the core of the spike. It shows every friction at once.
+// Approve is the core of the spike. Everything before the fire is friction 1
+// and 2: the chain, the ledger read, and the authorization check all happen
+// OUTSIDE the transaction, because guards cannot query.
 func (a *App) Approve(ctx context.Context, id, actor string) error {
-	// ---- Phase 1: everything below happens OUTSIDE the transaction, because
-	// guards cannot query. The values computed here are already potentially
-	// stale by the time the guard reads them. See COVERAGE.md, friction 2.
 	req, err := loadRequisition(ctx, a.db, id)
 	if err != nil {
 		return err
@@ -263,11 +165,8 @@ func (a *App) Approve(ctx context.Context, id, actor string) error {
 	sodOk := actor != req.Submitter || lastResort
 
 	role := a.dir.RoleOf(actor)
-	// Is this actor even a required approver? The chain is a runtime value, so
-	// this cannot be a guard — and without the check any non-submitter writes a
-	// row into the append-only ledger. It cannot forge an approval (an
-	// out-of-chain role never satisfies the join), but the junk entry is
-	// permanent. See COVERAGE.md, friction 1.
+	// Is this actor even a required approver? Chain membership is a runtime
+	// value, so it cannot be a guard. See COVERAGE.md, friction 1.
 	if !lastResort && (role == "" || !roleInChain(role, chain)) {
 		return ErrForbidden
 	}
@@ -276,96 +175,28 @@ func (a *App) Approve(ctx context.Context, id, actor string) error {
 		return err
 	}
 
-	status := ""
-	fired, err := a.fire(ctx, id,
-		func(wf *workflow.Workflow) {
-			wf.SetContext("sod_ok", sodOk)
-			wf.SetContext("chain_satisfied", satisfied)
-		},
-		func(wf *workflow.Workflow) (string, error) {
-			name, err := wf.ApplyAny(ctx, "approve_final", "approve_partial")
-			if err != nil {
-				return "", err
-			}
-			status = a.statusOf(wf)
-			return name, nil
-		},
-		func(fired string) []effect {
-			// ---- Effects differ per branch, and the branch is only known
-			// here, in Go. This switch is what a per-transition effect binding
-			// would replace. See COVERAGE.md, friction 3.
-			base := []effect{
-				ledgerEffect(id, actor, role, lastResort),
-				project(id, status),
-			}
-			if fired == "approve_partial" {
-				return append(base,
-					auditEffect(id, "requisition.approve", "pending", actor),
-					notifyEffect(id, "approvers", "approval_pending"),
-				)
-			}
-			return append(base,
-				supersedePriorEffect(id),
-				auditEffect(id, "requisition.approve", detailFor(lastResort), actor),
-				notifyEffect(id, req.Submitter, "approved"),
-				outboxEffect(id, "requisition.approved", approvedPayload(req.Amount)),
-				func(ctx context.Context, tx *sql.Tx) error {
-					_, err := tx.ExecContext(ctx, `UPDATE requisitions SET approved_by = ? WHERE id = ?`, actor, id)
-					return err
-				},
-			)
-		},
-		func(fired string) []Email {
-			if fired == "approve_final" {
-				return []Email{{To: req.Submitter, Template: "approved", ReqID: id}}
-			}
-			return nil
-		},
-	)
+	err = a.fire(ctx, id, map[string]any{
+		"sod_ok":          sodOk,
+		"chain_satisfied": satisfied,
+		"actor":           actor,
+		"role":            role,
+		"submitter":       req.Submitter,
+		"amount":          req.Amount,
+		"last_resort":     lastResort,
+		"audit_detail":    detailFor(lastResort, satisfied),
+	}, func(wf *workflow.Workflow) error {
+		// The branch is chosen by the guards, and its effects follow from the
+		// definition — no host-side switch on which one won.
+		_, err := wf.ApplyAny(ctx, "approve_final", "approve_partial")
+		return err
+	})
 	if err != nil {
 		if !sodOk {
 			return ErrForbidden
 		}
 		return classify(err)
 	}
-	_ = fired
 	return nil
-}
-
-// supersedePriorEffect marks every OTHER approved requisition superseded.
-//
-// This is a raw SQL write, and that is the point: the library has no atomic
-// multi-instance transition, so the prior requisitions' STATUS changes while
-// their workflow MARKINGS stay on `approved`. State and marking diverge, and
-// nothing in the library detects it. TestSupersedeCascade_DivergesMarking
-// proves the divergence. See COVERAGE.md, friction 5.
-func supersedePriorEffect(newID string) effect {
-	return func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx,
-			`UPDATE requisitions SET status = 'Superseded' WHERE status = 'Approved' AND id != ?`, newID)
-		return err
-	}
-}
-
-// approvedPayload builds the outbox payload. Marshalled rather than formatted:
-// %v on a float64 switches to scientific notation at the extremes, and any
-// field added later would risk unescaped JSON.
-func approvedPayload(amount float64) string {
-	b, err := json.Marshal(struct {
-		Amount float64 `json:"amount"`
-	}{amount})
-	if err != nil {
-		// A float64 field cannot fail to marshal; keep the effect total.
-		return `{}`
-	}
-	return string(b)
-}
-
-func detailFor(lastResort bool) string {
-	if lastResort {
-		return "last-resort"
-	}
-	return "chain-satisfied"
 }
 
 // Reject fires reject.
@@ -374,70 +205,46 @@ func (a *App) Reject(ctx context.Context, id, actor string) error {
 	if err != nil {
 		return err
 	}
-	status := ""
-	_, err = a.fire(ctx, id,
-		func(*workflow.Workflow) {},
-		func(wf *workflow.Workflow) (string, error) {
-			if err := wf.ApplyTransitionWithContext(ctx, "reject"); err != nil {
-				return "", err
-			}
-			status = a.statusOf(wf)
-			return "reject", nil
-		},
-		func(string) []effect {
-			return []effect{
-				project(id, status),
-				auditEffect(id, "requisition.reject", req.Ref, actor),
-				notifyEffect(id, req.Submitter, "rejected"),
-			}
-		},
-		func(string) []Email { return []Email{{To: req.Submitter, Template: "rejected", ReqID: id}} },
-	)
-	return classify(err)
+	return classify(a.fire(ctx, id, map[string]any{
+		"actor": actor, "submitter": req.Submitter, "amount": req.Amount,
+	}, func(wf *workflow.Workflow) error {
+		return wf.ApplyTransitionWithContext(ctx, "reject")
+	}))
 }
 
 // Resubmit returns a rejected requisition to draft.
 func (a *App) Resubmit(ctx context.Context, id, actor string) error {
-	status := ""
-	_, err := a.fire(ctx, id,
-		func(*workflow.Workflow) {},
-		func(wf *workflow.Workflow) (string, error) {
-			if err := wf.ApplyTransitionWithContext(ctx, "resubmit"); err != nil {
-				return "", err
-			}
-			status = a.statusOf(wf)
-			return "resubmit", nil
-		},
-		func(string) []effect {
-			return []effect{project(id, status), auditEffect(id, "requisition.resubmit", "", actor)}
-		},
-		func(string) []Email { return nil },
-	)
-	return classify(err)
+	return classify(a.fire(ctx, id, map[string]any{"actor": actor},
+		func(wf *workflow.Workflow) error {
+			return wf.ApplyTransitionWithContext(ctx, "resubmit")
+		}))
 }
 
 // Revoke supersedes an approved requisition deliberately.
 func (a *App) Revoke(ctx context.Context, id, actor string) error {
-	status := ""
-	_, err := a.fire(ctx, id,
-		func(*workflow.Workflow) {},
-		func(wf *workflow.Workflow) (string, error) {
-			if err := wf.ApplyTransitionWithContext(ctx, "revoke"); err != nil {
-				return "", err
-			}
-			status = a.statusOf(wf)
-			return "revoke", nil
-		},
-		func(string) []effect {
-			return []effect{
-				project(id, status),
-				auditEffect(id, "requisition.revoke", "", actor),
-				outboxEffect(id, "requisition.revoked", `{"reversal":true}`),
-			}
-		},
-		func(string) []Email { return nil },
-	)
-	return classify(err)
+	req, err := loadRequisition(ctx, a.db, id)
+	if err != nil {
+		return err
+	}
+	return classify(a.fire(ctx, id, map[string]any{
+		"actor": actor, "amount": req.Amount,
+	}, func(wf *workflow.Workflow) error {
+		return wf.ApplyTransitionWithContext(ctx, "revoke")
+	}))
+}
+
+// detailFor is the audit marker distinguishing a last-resort completion from a
+// normally-satisfied chain. It travels in context because it depends on runtime
+// facts the definition cannot know.
+func detailFor(lastResort, satisfied bool) string {
+	switch {
+	case lastResort:
+		return "last-resort"
+	case satisfied:
+		return "chain-satisfied"
+	default:
+		return "pending"
+	}
 }
 
 // classify maps a library error onto the host's sentinels. Everything that is

--- a/internal/spike/approval/app_test.go
+++ b/internal/spike/approval/app_test.go
@@ -214,18 +214,72 @@ func TestOutOfChainActorCannotApprove(t *testing.T) {
 	mustStatus(t, a, ctx, "rb", "Approved")
 }
 
-// TestApprovedPayloadIsValidJSON pins the outbox payload as marshalled rather
-// than formatted, including at a magnitude where %v would go exponential.
-func TestApprovedPayloadIsValidJSON(t *testing.T) {
+// TestOutboxPayloadIsValidJSON pins the payload written by the declared
+// `outbox` effect as marshalled rather than formatted, at a magnitude where %v
+// would go exponential.
+func TestOutboxPayloadIsValidJSON(t *testing.T) {
+	a, ctx := newApp(t)
+	const amount = 1.5e21 // needs the full chain, so approve as last-resort admin
+	if err := a.Create(ctx, "rj", "REQ-RJ", "dana", amount, []Line{costed("l1", "CC-100", amount)}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := a.Submit(ctx, "rj", "dana"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if err := a.Approve(ctx, "rj", "admin"); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+
+	var payload string
+	if err := a.db.QueryRowContext(ctx,
+		`SELECT payload FROM outbox WHERE req_id = 'rj'`).Scan(&payload); err != nil {
+		t.Fatalf("outbox: %v", err)
+	}
 	var got struct {
 		Amount float64 `json:"amount"`
 	}
-	if err := json.Unmarshal([]byte(approvedPayload(1.5e21)), &got); err != nil {
-		t.Fatalf("payload is not valid JSON: %v", err)
+	if err := json.Unmarshal([]byte(payload), &got); err != nil {
+		t.Fatalf("payload %q is not valid JSON: %v", payload, err)
 	}
-	if got.Amount != 1.5e21 {
-		t.Errorf("amount = %v, want 1.5e21", got.Amount)
+	if got.Amount != amount {
+		t.Errorf("amount = %v, want %v", got.Amount, amount)
 	}
+}
+
+// TestDeclaredEffectsFireInOrder pins that the effects a transition declares
+// all run, in one transaction, for the branch that actually fired. Before #36
+// this ordering lived in a hand-assembled Go slice per action.
+func TestDeclaredEffectsFireInOrder(t *testing.T) {
+	a, ctx := newApp(t)
+	if err := a.Create(ctx, "rk", "REQ-RK", "dana", 1_000, []Line{costed("l1", "CC-100", 1_000)}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := a.Submit(ctx, "rk", "dana"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if err := a.Approve(ctx, "rk", "sam"); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+
+	// approve_final declares: record_approval, project_status, supersede_prior,
+	// stamp_approver, audit, notify, outbox — all of which must have landed.
+	if n := countRows(t, a, ctx, `SELECT COUNT(*) FROM approvals WHERE req_id = 'rk'`); n != 1 {
+		t.Errorf("ledger rows = %d, want 1", n)
+	}
+	if n := countRows(t, a, ctx, `SELECT COUNT(*) FROM outbox WHERE req_id = 'rk'`); n != 1 {
+		t.Errorf("outbox rows = %d, want 1", n)
+	}
+	if n := countRows(t, a, ctx, `SELECT COUNT(*) FROM notifications WHERE req_id = 'rk'`); n != 2 {
+		t.Errorf("notification rows = %d, want 2 (submitted + approved)", n)
+	}
+	var approvedBy string
+	if err := a.db.QueryRowContext(ctx, `SELECT approved_by FROM requisitions WHERE id = 'rk'`).Scan(&approvedBy); err != nil {
+		t.Fatalf("approved_by: %v", err)
+	}
+	if approvedBy != "sam" {
+		t.Errorf("approved_by = %q, want sam", approvedBy)
+	}
+	mustStatus(t, a, ctx, "rk", "Approved")
 }
 
 // TestAdminLastResort: a chain containing an unheld role (director) is

--- a/internal/spike/approval/effects.go
+++ b/internal/spike/approval/effects.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Ehab Terra
+// SPDX-License-Identifier: MIT
+
+package approval
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ehabterra/workflow"
+)
+
+// registerEffects wires the host implementations the definition names.
+//
+// This is what #36 moved: the implementations stay (they are host code and
+// always were), but which effects a transition fires, in what order, and which
+// differ per branch is now DECLARED in workflow.yaml. Before, every one of
+// those decisions was Go — a per-action effect list assembled by hand in each
+// service method, plus a switch on which branch ApplyAny picked.
+//
+// Note what these signatures no longer need: no per-call closure capture, no
+// `fire` wrapper threading effects through Execute, no post-commit collection.
+// The registry is built once at startup and shared.
+func (a *App) registerEffects() (*workflow.EffectRegistry, error) {
+	reg := workflow.NewEffectRegistry()
+
+	// project_status writes the marking-derived status onto the record row, in
+	// the same transaction. Still host code — see #39, which would make this a
+	// declared binding rather than an effect the definition has to remember.
+	if err := reg.Register("project_status", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		sqlTx, err := asTx(tx)
+		if err != nil {
+			return err
+		}
+		_, err = sqlTx.ExecContext(ctx, `UPDATE requisitions SET status = ? WHERE id = ?`,
+			a.statusFor(ev.After), ev.WorkflowID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := reg.Register("audit", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		sqlTx, err := asTx(tx)
+		if err != nil {
+			return err
+		}
+		// A declared param wins; otherwise fall back to what the firing knows.
+		// detailFor is the last-resort marker, which only the context carries.
+		detail := str(ev.Params["detail"])
+		if detail == "" {
+			detail = str(ev.Context["audit_detail"])
+		}
+		_, err = sqlTx.ExecContext(ctx,
+			`INSERT INTO audit_log (req_id, action, detail, actor) VALUES (?, ?, ?, ?)`,
+			ev.WorkflowID, str(ev.Params["action"]), detail, str(ev.Context["actor"]))
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := reg.Register("notify", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		sqlTx, err := asTx(tx)
+		if err != nil {
+			return err
+		}
+		_, err = sqlTx.ExecContext(ctx,
+			`INSERT INTO notifications (req_id, target, kind) VALUES (?, ?, ?)`,
+			ev.WorkflowID, a.resolveTarget(ev), str(ev.Params["kind"]))
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := reg.Register("outbox", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		sqlTx, err := asTx(tx)
+		if err != nil {
+			return err
+		}
+		payload, err := json.Marshal(map[string]any{
+			"amount":   ev.Context["amount"],
+			"reversal": ev.Params["reversal"] == true,
+		})
+		if err != nil {
+			return err
+		}
+		_, err = sqlTx.ExecContext(ctx,
+			`INSERT INTO outbox (req_id, event, payload) VALUES (?, ?, ?)`,
+			ev.WorkflowID, str(ev.Params["event"]), string(payload))
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	// record_approval appends to the ledger. Still host code: the net cannot
+	// hold the ledger until a dynamic-cardinality join exists (#34), which
+	// would make the approval a token and this effect disappear.
+	if err := reg.Register("record_approval", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		sqlTx, err := asTx(tx)
+		if err != nil {
+			return err
+		}
+		lastResort := 0
+		if ev.Context["last_resort"] == true {
+			lastResort = 1
+		}
+		_, err = sqlTx.ExecContext(ctx,
+			`INSERT INTO approvals (req_id, actor, role, last_resort) VALUES (?, ?, ?, ?)`,
+			ev.WorkflowID, str(ev.Context["actor"]), str(ev.Context["role"]), lastResort)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := reg.Register("stamp_approver", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		sqlTx, err := asTx(tx)
+		if err != nil {
+			return err
+		}
+		_, err = sqlTx.ExecContext(ctx, `UPDATE requisitions SET approved_by = ? WHERE id = ?`,
+			str(ev.Context["actor"]), ev.WorkflowID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	// supersede_prior is STILL a raw SQL cascade, and still wrong: the prior
+	// requisitions' status changes while their markings stay on `approved`.
+	// #36 declared WHEN it runs; only #37 can make it a real transition.
+	// TestSupersedeCascade_DivergesMarking still documents the divergence.
+	if err := reg.Register("supersede_prior", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		sqlTx, err := asTx(tx)
+		if err != nil {
+			return err
+		}
+		_, err = sqlTx.ExecContext(ctx,
+			`UPDATE requisitions SET status = 'Superseded' WHERE status = 'Approved' AND id != ?`,
+			ev.WorkflowID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	// email is the post-commit phase — deliberately outside the transaction,
+	// and at-least-once. Before #36 the host collected these during the fire
+	// and flushed them after Execute returned, per action.
+	if err := reg.RegisterAfterCommit("email", func(ctx context.Context, ev workflow.EffectEvent) error {
+		a.Sent = append(a.Sent, Email{
+			To:       a.resolveTarget(ev),
+			Template: str(ev.Params["template"]),
+			ReqID:    ev.WorkflowID,
+		})
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return reg, nil
+}
+
+// resolveTarget maps the declared audience to an address. "submitter" is
+// per-instance, so it comes from context; anything else is a literal.
+func (a *App) resolveTarget(ev workflow.EffectEvent) string {
+	target := str(ev.Params["target"])
+	if target == "" {
+		target = str(ev.Params["to"])
+	}
+	if target == "submitter" {
+		return str(ev.Context["submitter"])
+	}
+	return target
+}
+
+// statusFor maps a marking to the record's status column via place metadata.
+func (a *App) statusFor(places []workflow.Place) string {
+	for _, p := range places {
+		if v, ok := a.def.PlaceMetadata(p, "status"); ok {
+			if s, ok := v.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func asTx(tx any) (*sql.Tx, error) {
+	sqlTx, ok := tx.(*sql.Tx)
+	if !ok {
+		return nil, fmt.Errorf("unexpected tx type %T", tx)
+	}
+	return sqlTx, nil
+}
+
+func str(v any) string {
+	s, _ := v.(string)
+	return s
+}

--- a/internal/spike/approval/workflow.yaml
+++ b/internal/spike/approval/workflow.yaml
@@ -37,26 +37,73 @@ workflow:
       from: [draft]
       to: [submitted]
       guard: "ready"
+      effects:
+        - name: project_status
+        - name: audit
+          params: {action: "requisition.submit"}
+        - name: notify
+          params: {target: "approvers", kind: "submitted"}
+      after_commit:
+        - name: email
+          params: {to: "approvers", template: "submitted"}
 
     # Both approve branches share the separation-of-duties guard. sod_ok is
     # host-computed as (actor != submitter) || last_resort.
+    #
+    # The two branches carry DIFFERENT effects — the whole point of binding
+    # effects per transition. Before #36 this was a Go switch on which branch
+    # ApplyAny picked; now the definition says it.
     - name: approve_partial
       from: [submitted]
       to: [submitted]
       guard: "sod_ok && !chain_satisfied"
+      effects:
+        - name: record_approval
+        - name: project_status
+        - name: audit
+          params: {action: "requisition.approve", detail: "pending"}
+        - name: notify
+          params: {target: "approvers", kind: "approval_pending"}
 
     - name: approve_final
       from: [submitted]
       to: [approved]
       guard: "sod_ok && chain_satisfied"
+      effects:
+        - name: record_approval
+        - name: project_status
+        - name: supersede_prior
+        - name: stamp_approver
+        - name: audit
+          params: {action: "requisition.approve"}
+        - name: notify
+          params: {target: "submitter", kind: "approved"}
+        - name: outbox
+          params: {event: "requisition.approved"}
+      after_commit:
+        - name: email
+          params: {to: "submitter", template: "approved"}
 
     - name: reject
       from: [submitted]
       to: [rejected]
+      effects:
+        - name: project_status
+        - name: audit
+          params: {action: "requisition.reject"}
+        - name: notify
+          params: {target: "submitter", kind: "rejected"}
+      after_commit:
+        - name: email
+          params: {to: "submitter", template: "rejected"}
 
     - name: resubmit
       from: [rejected]
       to: [draft]
+      effects:
+        - name: project_status
+        - name: audit
+          params: {action: "requisition.resubmit"}
 
     # revoke is the deliberate act of retiring an approved requisition.
     #
@@ -69,3 +116,9 @@ workflow:
     - name: revoke
       from: [approved]
       to: [superseded]
+      effects:
+        - name: project_status
+        - name: audit
+          params: {action: "requisition.revoke"}
+        - name: outbox
+          params: {event: "requisition.revoked", reversal: true}

--- a/manager.go
+++ b/manager.go
@@ -78,6 +78,10 @@ type Manager struct {
 	// onDefinitionMismatch, if set, is consulted when a loaded instance's stored
 	// fingerprint differs from the definition's; nil means mismatches are errors.
 	onDefinitionMismatch DefinitionMigrationFunc
+
+	// effects resolves the effect names transitions declare. Nil when the host
+	// never called WithEffectRegistry.
+	effects *EffectRegistry
 }
 
 // ManagerOption configures a Manager.
@@ -98,6 +102,18 @@ func WithRegistryCache() ManagerOption {
 // it. Without it, such a load fails with ErrDefinitionMismatch.
 func WithDefinitionMigration(fn DefinitionMigrationFunc) ManagerOption {
 	return func(m *Manager) { m.onDefinitionMismatch = fn }
+}
+
+// WithEffectRegistry installs the registry that resolves the effects a
+// definition's transitions declare (see Transition.SetEffects). Without it,
+// declared effects are inert: Execute reports them as unresolvable rather than
+// silently skipping writes the definition promised.
+//
+// Effects declared on the transitions that fired run inside the state-save
+// transaction, in declared order, after any effect passed via WithTxSideEffect.
+// After-commit effects run once the transaction has committed.
+func WithEffectRegistry(reg *EffectRegistry) ManagerOption {
+	return func(m *Manager) { m.effects = reg }
 }
 
 // NewManager creates a new workflow manager.
@@ -506,12 +522,22 @@ func (m *Manager) Execute(ctx context.Context, id string, definition *Definition
 
 	// Atomic side effects need transactional support; fail loudly rather than
 	// silently dropping the atomicity guarantee.
+	// Declared effects need the same transactional storage as WithTxSideEffect.
+	// Whether the definition declares any is knowable up front, before anything
+	// fires, so the requirement is checked here rather than mid-transaction.
+	declaresEffects := definitionDeclaresEffects(definition)
+	if declaresEffects && m.effects == nil {
+		return fmt.Errorf("definition declares transition effects but the Manager has no registry: %w "+
+			"(build it with workflow.WithEffectRegistry)", errors.ErrUnsupported)
+	}
+
 	var ts TransactionalStorage
 	var tds TransactionalDueStorage
-	if len(cfg.effects) > 0 {
+	if len(cfg.effects) > 0 || declaresEffects {
 		var ok bool
 		if ts, ok = m.storage.(TransactionalStorage); !ok {
-			return fmt.Errorf("WithTxSideEffect requires a TransactionalStorage backend: %w", errors.ErrUnsupported)
+			return fmt.Errorf("atomic side effects (WithTxSideEffect or declared transition effects) "+
+				"require a TransactionalStorage backend: %w", errors.ErrUnsupported)
 		}
 		// A backend that maintains a due index but cannot update it inside the
 		// state+effect transaction would leave the index silently corrupt for a
@@ -555,6 +581,22 @@ func (m *Manager) Execute(ctx context.Context, id string, definition *Definition
 		ctxData = contextForSave(ctxData, definition)
 		due := m.dueForSave(definition, marking)
 
+		// Resolve the effects declared by whatever actually fired this attempt.
+		// Draining after fn (and after the snapshot) means a retried attempt
+		// starts from an empty log, so an abandoned attempt's effects can never
+		// leak into the one that commits.
+		var afterCommit []pendingAfterCommit
+		effects := cfg.effects
+		if declaresEffects {
+			steps := wf.drainFired()
+			txEffects, pending, rerr := m.resolveEffects(id, definition, steps, ctxData)
+			if rerr != nil {
+				return rerr
+			}
+			effects = append(append([]TxSideEffect(nil), cfg.effects...), txEffects...)
+			afterCommit = pending
+		}
+
 		switch {
 		case ts != nil:
 			// Keep the due index current even on the transactional path (state +
@@ -562,9 +604,9 @@ func (m *Manager) Execute(ctx context.Context, id string, definition *Definition
 			// due backend (DueStorage but not TransactionalDueStorage) with a timed
 			// definition was already rejected before the loop.
 			if tds != nil {
-				_, err = tds.SaveStateInTxWithDue(ctx, id, marking, ctxData, wf.Version(), due, cfg.effects...)
+				_, err = tds.SaveStateInTxWithDue(ctx, id, marking, ctxData, wf.Version(), due, effects...)
 			} else {
-				_, err = ts.SaveStateInTx(ctx, id, marking, ctxData, wf.Version(), cfg.effects...)
+				_, err = ts.SaveStateInTx(ctx, id, marking, ctxData, wf.Version(), effects...)
 			}
 		default:
 			_, err = m.persistState(ctx, id, marking, ctxData, wf.Version(), due)
@@ -581,7 +623,10 @@ func (m *Manager) Execute(ctx context.Context, id string, definition *Definition
 		if m.useCache {
 			_ = m.registry.RemoveWorkflow(id)
 		}
-		return nil
+		// The state transaction has committed. After-commit effects run now,
+		// deliberately outside it — and so AT-LEAST-ONCE: a crash here loses
+		// them, and an error from one is returned without undoing the commit.
+		return runAfterCommit(ctx, afterCommit)
 	}
 	return fmt.Errorf("%w: giving up after %d attempts", lastErr, maxAttempts)
 }

--- a/token_firing.go
+++ b/token_firing.go
@@ -240,6 +240,7 @@ func (w *Workflow) ApplyTransitionForToken(ctx context.Context, transitionName s
 		_ = w.marking.RemovePlace(p)
 	}
 	w.produce(to, []Token{tok})
+	w.recordFired(targetTransition.Name(), from, w.currentPlacesLocked())
 	w.mu.Unlock()
 
 	// Fire after-transition listeners.

--- a/transition.go
+++ b/transition.go
@@ -47,6 +47,15 @@ type Transition struct {
 	// pending work — and any timer running on those tokens — in the same
 	// atomic firing.
 	resets []Place
+
+	// effects holds the transactional effects this transition declares, in
+	// execution order, resolved against the Manager's EffectRegistry when the
+	// transition fires. They commit with the state change.
+	effects []EffectDecl
+
+	// afterCommit holds effects that run only once the state transaction has
+	// committed — at-least-once, for work that must not be transactional.
+	afterCommit []EffectDecl
 }
 
 // Constraint represents a validation constraint for a transition
@@ -202,6 +211,43 @@ func (t *Transition) Resets() []Place {
 // AddConstraint adds a constraint to the transition
 func (t *Transition) AddConstraint(constraint Constraint) {
 	t.constraints = append(t.constraints, constraint)
+}
+
+// SetEffects declares the transactional effects this transition fires, in
+// execution order. They run inside the state-save transaction (see EffectFunc);
+// resolving them needs a Manager built WithEffectRegistry.
+//
+// Declaring effects here rather than passing closures per call is what lets two
+// transitions out of the same place carry different effects, so an ApplyAny
+// branch fires exactly the effects of the branch that won.
+func (t *Transition) SetEffects(effects ...EffectDecl) {
+	t.effects = cloneEffectDecls(effects)
+}
+
+// Effects returns the declared transactional effects, in declared order.
+func (t *Transition) Effects() []EffectDecl { return cloneEffectDecls(t.effects) }
+
+// SetAfterCommit declares effects that run only after the state transaction has
+// committed — the phase for work that must not be transactional. They are
+// AT-LEAST-ONCE; see AfterCommitFunc.
+func (t *Transition) SetAfterCommit(effects ...EffectDecl) {
+	t.afterCommit = cloneEffectDecls(effects)
+}
+
+// AfterCommit returns the declared after-commit effects, in declared order.
+func (t *Transition) AfterCommit() []EffectDecl { return cloneEffectDecls(t.afterCommit) }
+
+// cloneEffectDecls copies a declaration slice so neither the caller nor a
+// reader can mutate a definition's declared effects in place.
+func cloneEffectDecls(in []EffectDecl) []EffectDecl {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]EffectDecl, len(in))
+	for i, e := range in {
+		out[i] = e.clone()
+	}
+	return out
 }
 
 // SetMetadata sets metadata for the transition

--- a/workflow.go
+++ b/workflow.go
@@ -37,6 +37,32 @@ type Workflow struct {
 	// a VersionedStorage backend. It is 0 for a workflow that has never been
 	// persisted, and ignored by non-versioned backends.
 	version int64
+
+	// fired logs the transitions applied to this instance, in order, with the
+	// marking either side of each. Manager.Execute drains it after the caller's
+	// function returns to resolve the effects those transitions declare.
+	//
+	// It is per-instance and Execute loads a fresh instance on every conflict
+	// retry, so a retried attempt starts with an empty log — the effects of an
+	// abandoned attempt can never leak into the one that commits.
+	fired []FiredStep
+}
+
+// recordFired appends a firing to the log. Callers MUST already hold w.mu:
+// it is called from the firing paths between moveMarking and the after-event,
+// while the lock is held (the lock is NOT reentrant — see the caution in
+// CLAUDE.md).
+func (w *Workflow) recordFired(transition string, before, after []Place) {
+	w.fired = append(w.fired, FiredStep{Transition: transition, Before: before, After: after})
+}
+
+// drainFired returns the firings logged since the last drain and clears the log.
+func (w *Workflow) drainFired() []FiredStep {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := w.fired
+	w.fired = nil
+	return out
 }
 
 // Version returns the workflow's current optimistic-concurrency version. It is 0
@@ -667,6 +693,10 @@ func (w *Workflow) ApplyTransitionWithContext(ctx context.Context, transitionNam
 	// reset places), preserving colored token data and leaving unrelated
 	// places untouched.
 	w.moveMarking(from, to, targetTransition.Resets())
+	// Log the firing while still holding the lock, before the after-event runs
+	// listeners: a listener that errors aborts the caller's function, so
+	// Execute never reaches the drain and the log is discarded with the attempt.
+	w.recordFired(targetTransition.Name(), from, w.currentPlacesLocked())
 
 	// Fire after transition event (unlock before calling listeners)
 	w.mu.Unlock()
@@ -761,6 +791,7 @@ func (w *Workflow) ApplyWithContext(ctx context.Context, targetPlaces []Place) e
 	// reset places), preserving colored token data and leaving unrelated
 	// places untouched.
 	w.moveMarking(from, targetPlaces, transition.Resets())
+	w.recordFired(transition.Name(), from, w.currentPlacesLocked())
 
 	// Fire after transition event (unlock before calling listeners)
 	w.mu.Unlock()
@@ -831,6 +862,13 @@ func (w *Workflow) EnabledTransitions() ([]Transition, error) {
 func (w *Workflow) CurrentPlaces() []Place {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
+	return w.marking.Places()
+}
+
+// currentPlacesLocked is CurrentPlaces for callers that already hold w.mu. The
+// lock is a non-reentrant sync.RWMutex, so a firing path — which holds the
+// write lock across the marking move — must use this, never CurrentPlaces.
+func (w *Workflow) currentPlacesLocked() []Place {
 	return w.marking.Places()
 }
 

--- a/yaml/config.go
+++ b/yaml/config.go
@@ -94,6 +94,25 @@ type TransitionConfig struct {
 	Notes        string         `yaml:"notes,omitempty"`         // Default notes for history
 	Actor        string         `yaml:"actor,omitempty"`         // Default actor for history
 	CustomFields map[string]any `yaml:"custom_fields,omitempty"` // Default custom fields for history
+
+	// Effects are the transactional effects this transition fires, in
+	// execution order, resolved against the Manager's EffectRegistry. They
+	// commit with the state change.
+	Effects []EffectConfig `yaml:"effects,omitempty"`
+	// AfterCommit are effects that run only once the state transaction has
+	// committed — at-least-once, for work that must not be transactional.
+	AfterCommit []EffectConfig `yaml:"after_commit,omitempty"`
+}
+
+// EffectConfig declares one effect bound to a transition.
+//
+// The explicit {name, params} form is deliberate over the terser single-key
+// mapping (`- audit: {…}`): the config is strict-decoded, so a typo in a key
+// must be a load error rather than an arbitrary effect name, and only a named
+// field can give that.
+type EffectConfig struct {
+	Name   string         `yaml:"name"`
+	Params map[string]any `yaml:"params,omitempty"`
 }
 
 // StorageConfig defines generic storage configuration.

--- a/yaml/effects_test.go
+++ b/yaml/effects_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Ehab Terra
+// SPDX-License-Identifier: MIT
+
+package yaml_test
+
+import (
+	"strings"
+	"testing"
+
+	wfyaml "github.com/ehabterra/workflow/yaml"
+)
+
+const effectsYAML = `
+workflow:
+  name: approval
+  initial_marking: open
+  places:
+    - name: open
+    - name: done
+  transitions:
+    - name: approve
+      from: [open]
+      to: [done]
+      effects:
+        - name: audit
+          params: {action: "approve"}
+        - name: outbox
+          params: {event: "approved"}
+      after_commit:
+        - name: email
+          params: {template: "approved"}
+`
+
+func TestLoadDeclaredEffects(t *testing.T) {
+	cfg, err := wfyaml.LoadConfigFromBytes([]byte(effectsYAML))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	def, err := wfyaml.NewLoader().LoadDefinition(cfg)
+	if err != nil {
+		t.Fatalf("load definition: %v", err)
+	}
+	tr := def.Transition("approve")
+	if tr == nil {
+		t.Fatal("transition not found")
+	}
+
+	effects := tr.Effects()
+	if len(effects) != 2 {
+		t.Fatalf("effects = %d, want 2", len(effects))
+	}
+	// Declared order is execution order and must survive the load unsorted.
+	if effects[0].Name != "audit" || effects[1].Name != "outbox" {
+		t.Errorf("effect order not preserved: %v, %v", effects[0].Name, effects[1].Name)
+	}
+	if effects[0].Params["action"] != "approve" {
+		t.Errorf("params[action] = %v", effects[0].Params["action"])
+	}
+
+	after := tr.AfterCommit()
+	if len(after) != 1 || after[0].Name != "email" {
+		t.Fatalf("after_commit = %v, want [email]", after)
+	}
+	if after[0].Params["template"] != "approved" {
+		t.Errorf("params[template] = %v", after[0].Params["template"])
+	}
+}
+
+// TestEffectsAreIsolatedFromCallerMutation: Effects() returns a copy, so a
+// caller cannot rewrite a loaded definition's declared effects in place.
+func TestEffectsAreIsolatedFromCallerMutation(t *testing.T) {
+	cfg, err := wfyaml.LoadConfigFromBytes([]byte(effectsYAML))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	def, err := wfyaml.NewLoader().LoadDefinition(cfg)
+	if err != nil {
+		t.Fatalf("load definition: %v", err)
+	}
+	tr := def.Transition("approve")
+	got := tr.Effects()
+	got[0].Name = "tampered"
+	got[0].Params["action"] = "tampered"
+
+	fresh := tr.Effects()
+	if fresh[0].Name != "audit" || fresh[0].Params["action"] != "approve" {
+		t.Errorf("declared effects were mutated through the returned slice: %+v", fresh[0])
+	}
+}
+
+// TestEmptyEffectNameRejected: an unnamed effect can never resolve, so it must
+// fail at load rather than the first time that transition fires.
+func TestEmptyEffectNameRejected(t *testing.T) {
+	bad := strings.Replace(effectsYAML, `        - name: audit`, `        - name: ""`, 1)
+	cfg, err := wfyaml.LoadConfigFromBytes([]byte(bad))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if _, err := wfyaml.NewLoader().LoadDefinition(cfg); err == nil {
+		t.Fatal("expected an empty effect name to be rejected at load")
+	}
+}

--- a/yaml/loader.go
+++ b/yaml/loader.go
@@ -5,6 +5,7 @@ package yaml
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ehabterra/workflow"
@@ -133,6 +134,23 @@ func (l *Loader) LoadDefinition(config *Config) (*workflow.Definition, error) {
 			}
 		}
 
+		// Declared effects. Order is semantic — it is the execution order — so
+		// the slices are carried through as written, never sorted.
+		if len(transConfig.Effects) > 0 {
+			decls, err := effectDecls(transConfig.Name, "effects", transConfig.Effects)
+			if err != nil {
+				return nil, err
+			}
+			transition.SetEffects(decls...)
+		}
+		if len(transConfig.AfterCommit) > 0 {
+			decls, err := effectDecls(transConfig.Name, "after_commit", transConfig.AfterCommit)
+			if err != nil {
+				return nil, err
+			}
+			transition.SetAfterCommit(decls...)
+		}
+
 		// Store history-related metadata (notes, actor, custom_fields) in metadata
 		// These will be used when saving history records
 		if transConfig.Notes != "" {
@@ -212,4 +230,18 @@ func (l *Loader) LoadWorkflow(config *Config, workflowID string) (*workflow.Work
 	}
 
 	return wf, nil
+}
+
+// effectDecls converts declared effects, rejecting an empty name: an effect
+// with no name can never resolve, and failing at load beats failing the first
+// time that transition fires.
+func effectDecls(transition, field string, cfgs []EffectConfig) ([]workflow.EffectDecl, error) {
+	decls := make([]workflow.EffectDecl, len(cfgs))
+	for i, c := range cfgs {
+		if strings.TrimSpace(c.Name) == "" {
+			return nil, fmt.Errorf("transition '%s': %s[%d] has an empty name", transition, field, i)
+		}
+		decls[i] = workflow.EffectDecl{Name: c.Name, Params: c.Params}
+	}
+	return decls, nil
 }


### PR DESCRIPTION
Closes #36. First feature from the #46 roadmap, chosen because the spike measured it as 44% of all the friction Go.

## What this adds

A transition can now declare **what happens when it fires**, not just that it may.

```yaml
- name: approve_final
  from: [submitted]
  to: [approved]
  guard: "sod_ok && chain_satisfied"
  effects:
    - name: record_approval
    - name: audit
      params: {action: "requisition.approve"}
    - name: outbox
      params: {event: "requisition.approved"}
  after_commit:
    - name: email
      params: {to: "submitter", template: "approved"}
```

- `effects:` run **inside the state-save transaction**, in declared order. An error aborts the transaction, so neither the state change nor a sibling effect commits.
- `after_commit:` runs only once the transaction has committed — the phase for work that must not be transactional.
- Implementations register once against an **`EffectRegistry`**; `WithEffectRegistry` wires it into the `Manager`. `Registry.Validate(def)` catches an unimplemented name at startup rather than the first time a rare branch fires.
- Effects receive an **`EffectEvent`**: instance id, transition, the marking either side of the firing, declared params, and a copy of the instance context.

**The headline consequence:** because effects bind to the *transition*, two guarded transitions out of one place fire different effect sets — so an `ApplyAny` branch no longer needs a host-side switch to decide what runs.

## Design decisions worth reviewing

**Fingerprint compatibility.** The effects segment is appended to a transition's structural record **only when it declares effects**. A definition written before this feature serializes byte-for-byte as it did, so its fingerprint is unchanged and instances persisted by earlier versions keep loading without a migration. `TestFingerprintStableWithoutEffects` pins this — including that *clearing* effects restores the original bytes, which is what proves the segment is absent rather than merely empty. Effect order and params **are** hashed: order is execution order, so two orderings are two different definitions.

**Resolution before the save.** An unregistered effect name aborts the whole attempt rather than tearing down a transaction with some effects already applied.

**No silent skips.** A definition that declares effects against a Manager with no registry is a loud `ErrUnsupported`. Quietly omitting writes the definition promised is the one outcome worse than failing.

**Firing log.** `Workflow` now records its firings so `Execute` knows which transitions to resolve effects for. It drains after `fn` returns, and `Execute` reloads a fresh instance per conflict retry, so an abandoned attempt's effects can never leak into the one that commits.

**`currentPlacesLocked`.** Added because the firing paths hold the non-reentrant write lock when they log; calling `CurrentPlaces` there would deadlock (the caution in CLAUDE.md).

**At-least-once.** Documented on `AfterCommitFunc`. The library provides the phase, not the guarantee.

## Measured effect

`internal/spike/approval` is migrated to the feature, so the claim is measured rather than asserted:

| | before | after |
|---|---|---|
| Declarative (`workflow.yaml`) | 36 | **85** |
| Go — orchestration | 303 | **167** |
| Go — effect implementations | 34 | **142** |
| **by concern** | 30% | **50%** |
| **by line** | 10% | **22%** |

Concerns 13–16 (branch selection, effect binding, effect ordering, post-commit) moved from ❌ Go to ✅ declarative; 17 (status projection) moved to half — *when* it runs is declared, the place→status map is still host code, which is #39.

**Two honest caveats**, both recorded in `COVERAGE.md`:

1. **Total Go barely moved** (337 → 309). #36 did not delete code so much as *relocate the decisions*: 49 lines of "which effects, in what order, on which branch" left Go for the definition, and the per-branch switch disappeared. The win is where the logic lives, not the line count.
2. **The implementations got more verbose** (34 → 142 lines). A registry entry extracts params from the event and asserts the tx type where a closure captured typed values directly. That cost is paid once per effect *kind* rather than once per transition, so it amortizes as a workflow grows — and would not amortize for a workflow with two transitions.

The prediction when #36 was filed was "near 50% after #36 **and** #39". #36 reached it alone, so that estimate was pessimistic by about a feature.

## What this does NOT reach

The remaining ❌ concerns are the ones that were always the hard part: the dynamic approval join (#34), the guard inputs it depends on (#35), and the multi-instance cascade (#37 — still a raw SQL cascade, and `TestSupersedeCascade_DivergesMarking` still documents the divergence). No amount of effect plumbing reaches those.

## Verification

- `go test -p 1 ./...` — green, 7 packages
- `go test -race` on the root and spike packages — green (the new firing log is lock-protected)
- `golangci-lint run ./...` — 0 issues
- New tests: per-branch effect binding, effect-failure rollback, fingerprint stability/order/params, registry validation, missing-registry and unregistered-effect errors, `EffectEvent` contents, YAML load + order preservation + caller-mutation isolation + empty-name rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
