### PR TITLE
feat: dynamic-cardinality joins — enablement on a runtime-resolved token count (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   requirements segment is written only when a transition declares one, so
   definitions written before this feature fingerprint exactly as they did.
   Re-measured on `internal/spike/approval`: declarative coverage **50% → 68% by
-  concern**, **18% → 26% by line**, and this time **Go shrank by 73 lines** —
+  concern**, **18% → 25% by line**, and this time **Go shrank by 67 lines** —
   the ledger read, the chain-satisfaction test (including the parameter that
   forced the host to simulate the write it was about to make), the
   chain-membership check, and the effect that appended to the ledger table are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Dynamic-cardinality joins** (issue #34) — a transition can now be enabled by
+  a token **count resolved at fire time**, not fixed by the arc structure. The
+  classic AND-join asks only "is this place marked?", so the number of things a
+  transition waits for is a property of the drawing; the recurring business
+  shape — an approval chain whose length comes from the record's value — is not.
+  `Transition.SetRequirements` (YAML `require:`) declares, per input place, a
+  `count` expression, an optional `where` predicate selecting which tokens
+  count, and an optional `distinct` field so two tokens carrying the same value
+  count once. Both expressions are compiled at definition-build time (a
+  malformed one fails the load, not the first firing of a rare branch) and are
+  evaluated against the workflow context plus the place's tokens.
+  A requirement is both an enablement condition **and a token selector**: firing
+  consumes exactly the tokens it selected and **leaves the remainder in the
+  place**, where an ordinary input place is drained. Selection is deterministic
+  (the place's own order) and is re-resolved under the write lock, so concurrent
+  firings split a pool instead of double-consuming it. An unmet requirement is
+  `ErrNotEnabled` — so an `ApplyAny` candidate simply loses to its sibling —
+  while a requirement that cannot be *evaluated* is a loud error rather than a
+  silent skip.
+  Two combinations are rejected at `NewDefinition`, because each would put two
+  competing token selectors on one transition: `require` with `from_any`, and
+  two requirements on the same place. A requirement's place must be one of the
+  transition's own inputs. Per-token firing (`ApplyTransitionForToken`) is
+  likewise rejected on a transition with requirements — the requirement *is* the
+  selection. Reset arcs are unchanged and still clear whole places.
+  Requirements are part of `Definition.Fingerprint()` and appear in
+  `Diagram()` on the transition node (the arity is an expression, not a number
+  of arcs, so a diagram that omitted it would misstate when the transition can
+  fire). **Fingerprint compatibility:** like the effects segment, the
+  requirements segment is written only when a transition declares one, so
+  definitions written before this feature fingerprint exactly as they did.
+  Re-measured on `internal/spike/approval`: declarative coverage **50% → 68% by
+  concern**, **18% → 26% by line**, and this time **Go shrank by 73 lines** —
+  the ledger read, the chain-satisfaction test (including the parameter that
+  forced the host to simulate the write it was about to make), the
+  chain-membership check, and the effect that appended to the ledger table are
+  all deleted, not relocated.
 - **Declarative transition effects** (issue #36) — a transition can now declare
   what happens when it fires, not just that it may. `Transition.SetEffects`
   (YAML `effects:`) binds named, ordered effects that run **inside the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,13 +116,25 @@ use: operate on a **closed `*sql.DB`** to exercise query-error branches; seed a
 - **OR-input / XOR routing.** `from_any: true` enables a transition when *any* one input
   is marked and consumes only that one. `Workflow.ApplyAny(names...)` fires the first
   allowed candidate. Reset arcs (`resets:`) clear whole places when a transition fires.
+- **A required place is NOT drained.** Ordinary input places lose every token when a
+  transition fires; a place carrying a `require:` (dynamic-cardinality join) loses only
+  the tokens the requirement selected, and the remainder stays in declaration order.
+  That asymmetry is deliberate — it is what makes "take N out of a pool" expressible —
+  and it is why `require` cannot be combined with `from_any` or with per-token firing
+  (two selectors, one transition). `NewDefinition` rejects those combinations.
 
 ## Cautions / gotchas (learned the hard way)
 
 - **The workflow lock is a `sync.RWMutex` and is NOT reentrant.** A method already
-  holding the lock must call the lock-free `…Locked` variant (e.g. `coloredTokensAtLocked`),
-  never the public method — re-entering deadlocks or races. When you refresh a token
-  snapshot after re-resolving a consume-set, use the locked variant.
+  holding the lock must call the lock-free `…Locked` variant (e.g. `coloredTokensAtLocked`,
+  `selectRequirementsLocked`), never the public method — re-entering deadlocks or races.
+  The firing paths hold the write lock across the marking move, so anything they consult
+  in that window (token snapshots, requirement selection) must be the locked variant.
+- **A requirement's indexes are only valid under the lock that produced them.**
+  `selectRequirementsLocked` returns token INDEXES into the place's current token slice,
+  and `moveMarking` acts on them. They must be resolved and used inside one write-lock
+  hold — a pre-lock selection re-used after the lock would consume the wrong tokens under
+  concurrency. The firing paths re-resolve; do not "optimize" that away.
 - **Mermaid label escaping uses `#nnn;`, not `&#nnn;`.** `escapeMermaidLabel` emits
   Mermaid's own numeric-entity convention (`#39;` for `'`, `#58;` for `:`, `#34;` for `"`,
   `#60;`/`#62;` for `<`/`>`) — a `#` with **no** ampersand. This is correct and renders as

--- a/README.md
+++ b/README.md
@@ -201,6 +201,28 @@ declared **reset arcs** (`resets: [...]`: firing atomically clears sibling
 branches — and any timers running on them). Cycles are just arcs. Pure
 token-pool nets are valid too: an **empty marking persists and reloads**.
 
+**Joins whose arity is a runtime value.** A plain AND-join asks "is this place
+marked?", so the number of things a transition waits for is fixed by the
+drawing. `require:` resolves it at fire time instead — the shape every approval
+chain has, where how many sign-offs are needed comes from the record:
+
+```yaml
+- name: approve_final
+  from: [submitted, approvals]
+  to: [approved]
+  require:
+    - place: approvals
+      where: "token.role in chain"   # only chain members count
+      distinct: role                 # two approvals from one role are one
+      count: "len(chain)"            # resolved now, from the instance context
+```
+
+The transition is simply not enabled until the pool satisfies it, so there is no
+host-side "is the chain complete?" check — and firing consumes exactly the
+tokens it selected, leaving the rest of the pool in place (that is also how you
+take a batch of N out of a queue of many). Requirements are fingerprinted and
+rendered on the diagram.
+
 **Colored tokens.** A place can hold multiple data-carrying tokens
 (`{order_id: "001", amount: 240.75}`); fire per token
 (`ApplyTransitionForToken`), guard on token data (`token.amount <= 5000`),

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -257,10 +257,14 @@ feature, not a doc item.)
 
 Formerly M3–M8. None is deleted; none proceeds without a dogfood-proven need.
 
-- **Weighted transitions & advanced sync** (N-token thresholds, OR/XOR-join,
-  discriminator, cancellation regions). Note: per-token AND-join is impossible today
-  (`ApplyTransitionForToken` is single-input) — promote this specific gap if the dogfood
-  batch component hits it.
+- **Weighted transitions & advanced sync** (OR/XOR-join, discriminator,
+  cancellation regions). **N-token thresholds are no longer parked** — they
+  shipped as dynamic-cardinality joins (`require:`, issue #34), which resolve the
+  count at fire time from an expression rather than fixing it in the arcs, and
+  consume exactly the tokens they select. Note: per-token AND-join is still
+  impossible (`ApplyTransitionForToken` is single-input, and is rejected outright
+  on a transition that declares `require`, since the requirement already selects
+  the tokens).
 - **Static validation / `workflow lint`** (reachability, deadlock detection) — also the
   precondition for ever claiming "deadlock-free" in marketing.
 - **HCPN / nested workflows**; **compensation/saga**; **message correlation** beyond

--- a/definition.go
+++ b/definition.go
@@ -79,12 +79,45 @@ func NewDefinition(places []Place, transitions []Transition) (*Definition, error
 				return nil, fmt.Errorf("reset place '%s' in transition '%s' is not defined in workflow places", place, trans.Name())
 			}
 		}
+
+		if err := validateRequirements(&trans); err != nil {
+			return nil, err
+		}
 	}
 
 	return &Definition{
 		Places:      places,
 		Transitions: transitions,
 	}, nil
+}
+
+// validateRequirements enforces the structural rules a dynamic-cardinality
+// join has to obey to have one unambiguous token selector per input place (see
+// Transition.SetRequirements).
+func validateRequirements(t *Transition) error {
+	reqs := t.Requirements()
+	if len(reqs) == 0 {
+		return nil
+	}
+	if t.FromAny() {
+		return fmt.Errorf("transition '%s': from_any cannot be combined with require (both resolve the input to consume)", t.Name())
+	}
+	inputs := make(map[Place]bool, len(t.from))
+	for _, p := range t.From() {
+		inputs[p] = true
+	}
+	seen := make(map[Place]bool, len(reqs))
+	for _, r := range reqs {
+		p := r.Place()
+		if !inputs[p] {
+			return fmt.Errorf("transition '%s': require place '%s' is not one of its 'from' places", t.Name(), p)
+		}
+		if seen[p] {
+			return fmt.Errorf("transition '%s': duplicate require for place '%s'", t.Name(), p)
+		}
+		seen[p] = true
+	}
+	return nil
 }
 
 // Fingerprint returns a stable SHA-256 hash of the definition's structure: its
@@ -162,13 +195,34 @@ func transitionRecord(t *Transition) string {
 	// byte-for-byte as it did, so its fingerprint is unchanged and instances
 	// persisted by earlier versions still load without a migration. Do not
 	// hoist this out of the conditional.
+	//
+	// Requirements ride in the same conditional and are written LAST, again only
+	// when present, so a definition that declares effects but no requirements
+	// still serializes exactly as it did before requirements existed.
 	effects := t.Effects()
 	afterCommit := t.AfterCommit()
-	if len(effects) > 0 || len(afterCommit) > 0 {
+	requires := t.Requirements()
+	if len(effects) > 0 || len(afterCommit) > 0 || len(requires) > 0 {
 		writeLenPrefixedList(&rec, effectRecords(effects))
 		writeLenPrefixedList(&rec, effectRecords(afterCommit))
+		if len(requires) > 0 {
+			writeLenPrefixedList(&rec, requirementRecords(requires))
+		}
 	}
 	return rec.String()
+}
+
+// requirementRecords serializes requirements SORTED: requirements are a
+// conjunction over distinct places, so the order they are declared in carries no
+// meaning and must not change the fingerprint (unlike effects, whose order is
+// their execution order).
+func requirementRecords(reqs []Requirement) []string {
+	out := make([]string, len(reqs))
+	for i, r := range reqs {
+		out[i] = r.record()
+	}
+	slices.Sort(out)
+	return out
 }
 
 // effectRecords serializes declarations in DECLARED order — unlike places and

--- a/docs/BOUNDARIES.md
+++ b/docs/BOUNDARIES.md
@@ -63,6 +63,15 @@ context you supply (`hasRole(...)` and friends), and *who is asked* is your
 notification layer's job. Every org chart is different; a workflow engine
 that ships one is wrong for everyone but its author.
 
+**Where this boundary is NOT.** "Wait until a runtime-resolved set of
+participants has acted" is net semantics, not org modelling, and the library
+does express it: a dynamic-cardinality join (`require:`) counts tokens in a
+place against an expression evaluated at fire time, so an approval chain whose
+length comes from the record needs no host-side satisfaction check. What stays
+out is still everything about *who those participants are* — the chain itself
+is a value you resolve and hand in, and the roles a token carries mean nothing
+to the engine beyond being data it can count and de-duplicate.
+
 ## 6. Cross-instance atomicity is a seam, not a feature
 
 Saves are atomic per instance. A step spanning two instances is two

--- a/docs/guides/CPN_GUIDE.md
+++ b/docs/guides/CPN_GUIDE.md
@@ -75,6 +75,80 @@ Movement rules:
 - **No colored tokens involved**: falls back to boolean presence, so existing
   boolean workflows behave exactly as before.
 
+## Dynamic-cardinality joins: waiting for a runtime-resolved set
+
+The rules above answer "the transition is enabled, now move the tokens". They do
+not answer **"wait until enough tokens are here"** — and how many is *enough* is
+usually not a constant. An approval chain's length comes from the record's
+value; a shipping batch's size comes from configuration.
+
+`require:` puts that condition in the definition. Per input place it declares how
+many tokens are needed (an expression, evaluated at fire time), optionally which
+tokens count, and optionally a field they must be distinct by:
+
+```yaml
+transitions:
+  - name: approve_final
+    from: [submitted, approvals]
+    to: [approved]
+    resets: [approvals]                  # discard what the join did not take
+    require:
+      - place: approvals
+        where: "token.role in chain"     # only chain members count
+        distinct: role                   # two approvals from one role are one
+        count: "len(chain)"              # `chain` comes from the instance context
+```
+
+```go
+// The same thing in Go.
+final := workflow.MustNewTransition("approve_final",
+    []workflow.Place{"submitted", "approvals"}, []workflow.Place{"approved"})
+final.SetRequirements(workflow.MustNewRequirement(workflow.RequirementSpec{
+    Place: "approvals", Where: "token.role in chain", Distinct: "role", Count: "len(chain)",
+}))
+```
+
+Both expressions see the workflow context; `where` also sees the token's data as
+`token`, and `count` sees every token at the place as `tokens`. `count` must
+yield a non-negative integer (a `float64` that came back from JSON storage is
+fine — a fractional one is an error).
+
+**Consumption is the part to internalize.** An ordinary input place is drained
+when a transition fires. A *required* place is not: firing consumes exactly the
+tokens the requirement selected — in the place's own order, so it is
+deterministic — and leaves the remainder behind. That is what makes "take a
+batch of 10 out of a pool of 50" a definition rather than a loop:
+
+```yaml
+  - name: ship_batch
+    from: [pool]
+    to: [shipped]
+    require:
+      - place: pool
+        count: 10
+```
+
+Notes worth knowing before you reach for it:
+
+- An unmet requirement is `ErrNotEnabled`, so `ApplyAny` skips that candidate and
+  tries the next — which is how "record progress" and "complete the chain"
+  become two transitions with no host-side branch. A requirement that cannot be
+  *evaluated* (a broken expression, a count that is not a number) is a hard
+  error instead, so a broken definition is never silently skipped.
+- The selection is re-resolved under the write lock immediately before the move,
+  so concurrent firings split a pool rather than double-consuming it.
+- `require` cannot be combined with `from_any`, two requirements cannot target
+  the same place, and a requirement's place must be one of the transition's own
+  inputs. Each rule keeps exactly one selector per input; `NewDefinition`
+  enforces them.
+- `ApplyTransitionForToken` is rejected on a transition with requirements — the
+  requirement already chooses the tokens.
+- Reset arcs still clear **whole** places, so a place that is both required and
+  reset ends up empty regardless of what the join took.
+- Requirements are part of `Definition.Fingerprint()` and are rendered on the
+  transition in `Diagram()`. They are *not* evaluated by the `Due` API, exactly
+  like guards: a due transition still has to be enabled when it fires.
+
 Use `SelectTokens(place, pred)` to choose which token(s) to advance:
 
 ```go

--- a/internal/spike/approval/COVERAGE.md
+++ b/internal/spike/approval/COVERAGE.md
@@ -42,16 +42,16 @@ exist with or without the library, and are excluded from both sides.
 | | after #36 | after #34 |
 |---|---|---|
 | **Declarative** (`workflow.yaml`) | 85 | **109** |
-| **Go — orchestration** (branching, ledger, satisfaction, binding) | 208 | **151** |
+| **Go — orchestration** (branching, ledger, satisfaction, binding) | 208 | **157** |
 | **Go — effect implementations** (the SQL itself) | 180 | **164** |
-| **Total Go** | 388 | **315** |
+| **Total Go** | 388 | **321** |
 
-### **Declarative coverage: 26% by line** (was 18%)
+### **Declarative coverage: 25% by line** (was 18%)
 
 Counting orchestration only — the sequencing decisions, excluding the SQL that
-would exist under any design — it is **42%**, up from 29%.
+would exist under any design — it is **41%**, up from 29%.
 
-The headline this time is that **Go went down**, by 73 lines. #36 relocated
+The headline this time is that **Go went down**, by 67 lines. #36 relocated
 decisions from Go into the definition without deleting much; #34 deleted code
 outright. Three functions and an entire effect are simply gone:
 
@@ -292,6 +292,29 @@ The transition is removed; declarative lines went 39 → 36.
 and ~11 more lines of Go.
 
 Net effect on the pre-#36 baseline: **11% → 10% by line, 32% → 30% by concern.**
+
+### Round two, on #34: separation of duties had a hole
+
+Review found that an **admin could approve a requisition they had submitted
+themselves**. Two things said yes independently: the host computed `sod_ok` as
+`actor != submitter || lastResort`, exempting the escape hatch, and
+`approve_last_resort` carried no `sod_ok` guard at all, because "last resort"
+felt like its own justification. Being able to break a chain nobody can satisfy
+is not a licence to sign off on your own record.
+
+Both halves are fixed. `sod_ok` is now plainly `actor != req.Submitter`, and all
+three approve branches carry it — so the rule is uniform and stated in the
+definition rather than assembled from a boolean the host computes.
+`TestAdminSubmitterCannotSelfApprove` pins it, including that a *different* admin
+can still use the hatch.
+
+Worth recording for the same reason as the first round: this **predates #34** —
+the `|| lastResort` term is in the original spike — and neither the tests nor the
+earlier review caught it. That is the second real defect found by review in a net
+small enough to read in one sitting, which argues for
+[#42](https://github.com/ehabterra/workflow/issues/42) better than any argument
+about it does. Orchestration went 151 → 157 lines, because the fix is worth
+explaining in place.
 
 ## What worked well
 

--- a/internal/spike/approval/COVERAGE.md
+++ b/internal/spike/approval/COVERAGE.md
@@ -15,7 +15,8 @@ systems:
 
 - a **threshold ladder** — the set of roles that must approve grows with the
   requisition's value, so the required approval count is not known until fire time
-- an append-only **approvals ledger**
+- an append-only **approvals ledger** — since #34 this is a pool of colored
+  tokens in the net itself, not a host table
 - **separation of duties** — the submitter may not approve their own record
 - an **admin last-resort** for chains containing a role nobody holds
 - **revision supersession** — approving a requisition supersedes prior approved ones
@@ -32,35 +33,47 @@ what guards them, what effects they fire, and what state results. Schema, record
 CRUD, the role ladder config, and the user directory are domain code that would
 exist with or without the library, and are excluded from both sides.
 
-> **Re-measured after #36 (declarative effects) landed.** The pre-#36 baseline is
-> kept alongside every figure, because the point of this document is the delta.
+> **Re-measured after #34 (dynamic-cardinality join) landed.** Both columns below
+> come from the same reproducible rule (see *Re-running the measurement*), so the
+> delta is apples-to-apples. The absolute numbers differ slightly from those
+> reported in the #36 PR, which applied the same rule by hand and did not count
+> each function's doc comment; the earlier figures are kept in the footnote.
 
-| | before #36 | after #36 |
+| | after #36 | after #34 |
 |---|---|---|
-| **Declarative** (`workflow.yaml`) | 36 | **85** |
-| **Go — orchestration** (binding, ordering, branch dispatch) | 303 | **167** |
-| **Go — effect implementations** (the SQL itself) | 34 | **142** |
-| *(excluded: domain schema, CRUD, role/directory config)* | *(206)* | *(206)* |
+| **Declarative** (`workflow.yaml`) | 85 | **109** |
+| **Go — orchestration** (branching, ledger, satisfaction, binding) | 208 | **151** |
+| **Go — effect implementations** (the SQL itself) | 180 | **164** |
+| **Total Go** | 388 | **315** |
 
-### **Declarative coverage: 22% by line** (was 10%)
+### **Declarative coverage: 26% by line** (was 18%)
 
 Counting orchestration only — the sequencing decisions, excluding the SQL that
-would exist under any design — it is **34%**, up from 11%.
+would exist under any design — it is **42%**, up from 29%.
 
-**Total Go barely moved** (337 → 309), and that is the honest headline: #36 did
-not delete code so much as *relocate the decisions*. 49 lines of "which effects,
-in what order, on which branch" moved out of Go and into the definition, and the
-per-branch `switch` disappeared entirely.
+The headline this time is that **Go went down**, by 73 lines. #36 relocated
+decisions from Go into the definition without deleting much; #34 deleted code
+outright. Three functions and an entire effect are simply gone:
 
-The effect implementations got **more verbose** (34 → 142 lines), which is a real
-cost worth recording: a registry entry extracts its parameters from the event and
-type-asserts the transaction, where the old closure captured typed values
-directly. That is the price of the indirection, and it is paid once per effect
-kind rather than once per transition — so it amortizes as a workflow grows, and
-would not amortize for a workflow with two transitions.
+- `chainSatisfied` (26 lines) — the AND-join whose arity was `len(chain)`,
+  including the `pending` parameter that forced the host to *simulate the write
+  it was about to make*
+- `approvedRoles` (17 lines) — the ledger read that fed it
+- `roleInChain` (9 lines) — the authorization check the net could not express
+- the `record_approval` effect and the `approvals` table it wrote (16 lines net)
 
-Line-counting YAML against Go flatters neither side — YAML is denser per line — so
-here is the same question asked by **concern**, which is the fairer measure:
+What replaced them is four lines of YAML:
+
+```yaml
+require:
+  - place: approvals
+    where: "token.role in chain"
+    distinct: role
+    count: "len(chain)"
+```
+
+Line-counting YAML against Go flatters neither side — YAML is denser per line —
+so here is the same question asked by **concern**, which is the fairer measure:
 
 | # | Workflow concern | Where it lives |
 |---|---|---|
@@ -69,80 +82,123 @@ here is the same question asked by **concern**, which is the fairer measure:
 | 3 | Initial marking | ✅ declarative |
 | 4 | Terminal detection | ✅ declarative |
 | 5 | Guard expressions | ✅ declarative |
-| 6 | Guard *inputs* (`ready`, `sod_ok`, `chain_satisfied`) | ❌ Go |
-| 7 | Ready-gate evaluation | ❌ Go |
-| 8 | Approval chain resolution | ❌ Go |
-| 9 | Approvals ledger | ❌ Go |
-| 10 | Chain satisfaction (dynamic AND-join) | ❌ Go |
+| 6 | Guard *inputs* (`ready`, `sod_ok`, ~~`chain_satisfied`~~) | ⚠️ half since #34 — one of the three is gone; the rest need #35 |
+| 7 | Ready-gate evaluation | ❌ Go (#35) |
+| 8 | Approval chain resolution | ❌ Go — the ladder is domain policy, but the net now consumes it as a *value* rather than an answer |
+| 9 | Approvals ledger | ✅ **declarative since #34** — the pool of colored tokens IS the ledger |
+| 10 | Chain satisfaction (dynamic AND-join) | ✅ **declarative since #34** |
 | 11 | Separation of duties | ⚠️ half — guard declarative, input Go |
-| 12 | Last-resort override | ❌ Go |
-| 13 | Branch selection (partial vs final) | ✅ **declarative since #36** |
-| 14 | Per-transition effect binding | ✅ **declarative since #36** |
-| 15 | Effect ordering | ✅ **declarative since #36** |
-| 16 | Post-commit phase | ✅ **declarative since #36** |
+| 12 | Last-resort override | ⚠️ half since #34 — a declared transition with its own guard and effects; the input is Go |
+| 13 | Branch selection (partial vs final) | ✅ declarative since #36 |
+| 14 | Per-transition effect binding | ✅ declarative since #36 |
+| 15 | Effect ordering | ✅ declarative since #36 |
+| 16 | Post-commit phase | ✅ declarative since #36 |
 | 17 | Status projection | ⚠️ half since #36 — *when* it runs is declared, the place→status map is still host code (#39) |
 | 18 | Multi-instance cascade | ❌ Go — **and incorrect**, see friction 5 |
-| 19 | Guard rejection → error mapping | ❌ Go |
-| 20 | Actor authorization (is this actor even in the chain?) | ❌ Go — added in review, see below |
+| 19 | Guard rejection → error mapping | ❌ Go (#38) |
+| 20 | Actor authorization (is this actor even in the chain?) | ⚠️ half since #34 — `role in chain` is the guard; the directory lookup is Go |
 
-### **Declarative coverage: 50% by concern** (9 full + 2 half of 20) — was 30%
+### **Declarative coverage: 68% by concern** (11 full + 5 half of 20) — was 50%
 
-That crosses the ~50% floor at which adoption starts paying for itself, on one
-feature. The prediction when #36 was filed was "near 50% after #36 **and** #39";
-#36 reached it alone, so the estimate was pessimistic by about one feature.
+The target this document set after #36 was "**above 70%** by concern once #34,
+#35 and #36 have all landed". Two of the three are in and it stands at 68%, so
+the estimate is holding: #35 is what carries concerns 6, 7, 11 and 20, and it is
+the only one of the three still open.
 
-What is left below the line is the part that was always the hard part: the
-dynamic approval join, the guard inputs it depends on, and the multi-instance
-cascade. Those are #34, #35, and #37 — no amount of effect plumbing reaches them.
+Read the shape rather than the number. What #34 moved is not plumbing — it is
+the part that made this workflow hard. The net now holds the ledger, counts it,
+de-duplicates it by role, and refuses an approver the chain does not require.
+What is left below the line is the *inputs* to guards (#35), the multi-instance
+cascade (#37), and error identity (#38).
 
-The shape of the result matters more than either number. What the library covers
-is the **status graph** — real, correct, and the part a host can hand-roll in a
-two-level map. What stays in Go is every concern that made this workflow hard.
+### An unplanned result: the authorization hole closed itself
+
+The first draft of this spike let any non-submitter write a permanent row into
+the append-only ledger; a reviewer caught it and the fix was a hand-written check
+the host had to remember (`roleInChain`, plus a branch in `Approve`).
+
+That class of bug is now **unreachable in this shape**, and not because of the
+check. The approval is a token created *inside* the `Execute` cycle, so appending
+it and firing the transition are one atomic unit: if the net refuses the firing,
+`Execute` returns before saving and the token never existed.
+`TestRolelessActorCannotApprove` and `TestOutOfChainActorCannotApprove` now
+assert an empty pool rather than an empty table, and they pass without the host
+check being load-bearing — it survives only to choose between 403 and 409, which
+is #38's job.
+
+### What #34 cost
+
+Recorded so the entry is not one-sided:
+
+- **The pool is a place, and places are visible.** `approvals` appears in the net
+  and in every diagram, and it has to be excluded from status projection by
+  carrying no `status` metadata. A modeller has to understand that a place can
+  be a pool rather than a state.
+- **A third approve transition.** The last-resort path became its own transition
+  (`approve_last_resort`) rather than a flag inside a satisfaction function. That
+  is more declaration for less Go, but it is more declaration — the +24
+  declarative lines are mostly it.
+- **`require` is the third way a transition can be conditional**, after guards
+  and `from_any` — and `require` cannot be combined with `from_any`, because both
+  resolve which input a firing consumes. That is a rule an author has to learn,
+  and the engine rejects the combination at `NewDefinition` rather than at run
+  time.
 
 ## Friction log
 
 Ranked by how much hand-written Go each one forces.
 
-### 1 — Dynamic-cardinality join ([#34](https://github.com/ehabterra/workflow/issues/34)) · ~43 lines
+### 1 — Dynamic-cardinality join ([#34](https://github.com/ehabterra/workflow/issues/34)) — ✅ **RESOLVED**
 
-`chainSatisfied` in `domain.go` is an AND-join whose arity is `len(chain)`, and
-`chain` is not known until the requisition's value is read. The library joins over
-statically declared input places, so the ledger, the required-set, and the
-satisfaction test all live in Go.
+*Was: ~43 lines, and the single reason the approval brain stayed hand-written.*
 
-The tell is `chainSatisfied`'s `pending` parameter: the caller must ask *"would the
-chain be satisfied if this approval were recorded?"*, because the transition that
-records it is the one whose guard needs the answer. The host simulates the write it
-is about to make.
+`chainSatisfied` was an AND-join whose arity was `len(chain)`, and `chain` was
+not known until the requisition's value was read. The library joined over
+statically declared input places, so the ledger, the required-set and the
+satisfaction test all lived in Go.
 
-**The authorization half.** Because chain membership is a runtime value, *"is this
-actor even a required approver?"* also cannot be a guard. The first draft of this
-spike omitted the check and a reviewer caught it: any non-submitter — including an
-actor holding no role at all, or one whose role is outside the required chain —
-could write a permanent row into the append-only ledger and audit log. It could not
-forge an approval (an out-of-chain role never satisfies the join, so no
-unauthorized requisition can be approved), but the junk entry is permanent in an
-append-only table.
+All three are now in the definition. `approvals` is a place holding one colored
+token per approval; `approve_final` declares:
 
-`roleInChain` plus the check in `Approve` fixes it, and
-`TestRolelessActorCannotApprove` / `TestOutOfChainActorCannotApprove` pin it. A
-join over **role-tagged tokens** would subsume both halves: only a token carrying a
-required role could enter the place, so membership would be structural rather than
-a check the host has to remember to write.
+```yaml
+require:
+  - place: approvals
+    where: "token.role in chain"     # only chain members count
+    distinct: role                   # two approvals from one role are one
+    count: "len(chain)"              # resolved at fire time
+```
 
-### 2 — Guards cannot query ([#35](https://github.com/ehabterra/workflow/issues/35)) · ~40 lines, plus a race
+The tell is gone with it. `chainSatisfied` took a `pending` parameter because the
+caller had to ask *"would the chain be satisfied IF this approval were
+recorded?"* — the transition that records the approval was the one whose guard
+needed the answer. Now the approval is a token, the host appends it, and the net
+answers a question about the state that actually exists.
 
-Every guard in `workflow.yaml` reads a boolean the host pre-computed: `ready`,
-`sod_ok`, `chain_satisfied`. None of them can be computed by the guard, because
-`envBuilder` receives an `Event` and an `Event` has no transaction.
+**The authorization half** is subsumed as predicted: `where` means an
+out-of-chain approval can never count toward the join, and `approve_partial`'s
+`role in chain` guard refuses to record one at all. See *An unplanned result*
+above for why this is now structural rather than a check.
 
-The consequence is not just volume. `Approve` does its entire phase-1 computation
-**outside** the transaction, then fires. Between the read and the fire, another
-approver can record an approval — and the guard will happily evaluate a
-`chain_satisfied` that was true a moment ago. Optimistic concurrency catches a
-concurrent *save* on the same instance, but not a stale *decision input* read
-before the cycle began. Real systems close this with an in-transaction re-check;
-here there is nowhere to put one.
+**What it did not solve.** `chain` still arrives from the host via `SetContext`,
+read before the transaction opens — so the *value* the join counts against can
+still be stale. That is #35, and #34 does not touch it.
+
+### 2 — Guards cannot query ([#35](https://github.com/ehabterra/workflow/issues/35)) · ~37 lines, plus a race — **now the top item**
+
+Every guard in `workflow.yaml` still reads a boolean or a value the host
+pre-computed: `ready`, `sod_ok`, `chain`. None can be computed by the guard,
+because `envBuilder` receives an `Event` and an `Event` has no transaction.
+
+#34 changed the *shape* of this problem without solving it. The satisfaction
+test is no longer a pre-computed answer — the net works it out from tokens it
+holds, under the same lock as the firing, so the ledger half of the race is
+closed. What remains is the *inputs*: `chain` is derived from `req.Amount`, read
+outside the transaction. If the requisition's value changes between the read and
+the fire, the join counts against a chain that is no longer the right one.
+
+That is a narrower race than before (it needs the record to change, not merely a
+concurrent approval), but it is the same defect, and there is still nowhere to
+put an in-transaction re-check.
 
 ### 3 — Effects are opaque closures ([#36](https://github.com/ehabterra/workflow/issues/36)) — ✅ **RESOLVED**
 
@@ -161,9 +217,10 @@ and `approve_final` carry their own effect lists, so the branch that wins fires 
 own effects with no host involvement.
 
 What remains is the implementations themselves, which are host SQL and always were.
-They grew (34 → 142 lines) because a registry entry must extract its params from the
-event and assert the tx type where a closure captured typed values — see the note
-under the headline figures.
+They grew because a registry entry must extract its params from the event and
+assert the tx type where a closure captured typed values. (The 34 → 142 figure
+reported at the time predates the mechanical counting rule; see *Re-running the
+measurement*.)
 
 ### 4 — No post-commit phase ([#36](https://github.com/ehabterra/workflow/issues/36)) — ✅ **RESOLVED**
 
@@ -234,7 +291,7 @@ The transition is removed; declarative lines went 39 → 36.
 **A missing authorization check.** See friction 1 above — concern 20 in the table,
 and ~11 more lines of Go.
 
-Net effect: **11% → 10% by line, 32% → 30% by concern.**
+Net effect on the pre-#36 baseline: **11% → 10% by line, 32% → 30% by concern.**
 
 ## What worked well
 
@@ -244,8 +301,18 @@ Worth recording, because the spike is not an argument that the library is bad:
   state change rolls back with it. The marking stays on `submitted` even though the
   transition fired in memory. This guarantee is real and it is the reason to build
   on this library rather than a bare FSM.
-- **`ApplyAny` for branch routing** is the right primitive for "one action, two
-  outcomes". It is only let down by effects not binding to the chosen transition.
+- **A token created inside `Execute` commits with the firing.** This is what makes
+  the ledger safe: append the approval, fire, and either both land or neither
+  does. It needed no new feature — it falls out of "a fire mutates memory only;
+  persistence is a separate, version-guarded step".
+- **`require` + `ApplyAny` compose exactly as hoped.** Three approve branches in
+  declaration order, each enabled by its own condition, and the host asks for the
+  first that fires. No branch table, no satisfaction test, no switch.
+- **`distinct`** turned out to matter more than the count. Without it the join is
+  satisfiable by one enthusiastic approver, and that is the kind of rule a host
+  forgets to write. `TestPartialApprovalIsNotEnoughEvenTwice` pins it.
+- **`ApplyAny` for branch routing** is the right primitive for "one action, several
+  outcomes".
 - **The self-loop** (`approve_partial`: `submitted -> submitted`) models
   "record progress without advancing" cleanly and needed no special support.
 - **Optimistic concurrency** is on by default and cost nothing to adopt.
@@ -254,19 +321,32 @@ Worth recording, because the spike is not an argument that the library is bad:
 
 ## Re-running the measurement
 
-The counts above are reproducible:
+Declarative lines:
 
 ```bash
 cd internal/spike/approval
-grep -vE '^\s*(#|$)' workflow.yaml | wc -l          # declarative lines
+grep -vE '^\s*(#|$)' workflow.yaml | wc -l
 ```
 
-Go workflow-logic lines are the sum of the function spans listed in the table,
-excluding `App`/`New`/`Create`/`Status`/`Marking` in `app.go` and the
-role/directory/record/schema block in `domain.go`.
+Go workflow-logic lines are the sum of **function spans including each
+function's doc comment**, from `func` line to the closing brace at column 0:
+
+- **orchestration** — `fire`, `Submit`, `Approve`, `Reject`, `Resubmit`,
+  `Revoke`, `classify` in `app.go`, plus `readyGate` in `domain.go`
+- **effect implementations** — `registerEffects`, `resolveTarget`, `statusFor`,
+  `asTx`, `str` in `effects.go`
+- **excluded** — `App`/`New`/`Create`/`Status`/`Marking`/`Ledger` in `app.go`, and
+  the role/directory/record/schema block in `domain.go`
+
+Comparing across releases means measuring both revisions with this rule, not
+comparing against a number quoted in an older PR. The figures reported when #36
+landed (declarative 85, orchestration 167, effects 142) came from the same rule
+applied by hand without counting doc comments; re-measured mechanically the same
+tree gives 85 / 208 / 180.
 
 **Target after [#34](https://github.com/ehabterra/workflow/issues/34),
 [#35](https://github.com/ehabterra/workflow/issues/35), and
 [#36](https://github.com/ehabterra/workflow/issues/36):** the same workflow above
-**70%** by concern. If three features do not get it there, that is the signal to
-stop investing and keep the library scoped to nets that are genuinely parallel.
+**70%** by concern. Two of the three have landed and it stands at **68%**, so the
+target is intact and #35 decides it. If it does not get there, that is the signal
+to stop investing and keep the library scoped to nets that are genuinely parallel.

--- a/internal/spike/approval/app.go
+++ b/internal/spike/approval/app.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	_ "embed"
@@ -152,9 +153,15 @@ func (a *App) Submit(ctx context.Context, id, actor string) error {
 	return nil
 }
 
-// Approve is the core of the spike. Everything before the fire is friction 1
-// and 2: the chain, the ledger read, and the authorization check all happen
-// OUTSIDE the transaction, because guards cannot query.
+// Approve is the core of the spike, and since #34 it is mostly the ladder.
+//
+// What it no longer does: read the ledger, work out whether the chain would be
+// satisfied if this approval were recorded, or check that the actor is a
+// required approver. The net answers all three — the approvals are tokens, and
+// the join counts them.
+//
+// What it still does is #35: `sod_ok` is a boolean computed OUTSIDE the
+// transaction, because a guard cannot query the record.
 func (a *App) Approve(ctx context.Context, id, actor string) error {
 	req, err := loadRequisition(ctx, a.db, id)
 	if err != nil {
@@ -163,35 +170,37 @@ func (a *App) Approve(ctx context.Context, id, actor string) error {
 	chain := a.hier.ChainFor(req.Amount)
 	lastResort := lastResortAllowed(a.dir, actor, chain)
 	sodOk := actor != req.Submitter || lastResort
-
 	role := a.dir.RoleOf(actor)
-	// Is this actor even a required approver? Chain membership is a runtime
-	// value, so it cannot be a guard. See COVERAGE.md, friction 1.
-	if !lastResort && (role == "" || !roleInChain(role, chain)) {
-		return ErrForbidden
-	}
-	satisfied, err := chainSatisfied(ctx, a.db, id, chain, role, lastResort)
-	if err != nil {
-		return err
-	}
 
 	err = a.fire(ctx, id, map[string]any{
-		"sod_ok":          sodOk,
-		"chain_satisfied": satisfied,
-		"actor":           actor,
-		"role":            role,
-		"submitter":       req.Submitter,
-		"amount":          req.Amount,
-		"last_resort":     lastResort,
-		"audit_detail":    detailFor(lastResort, satisfied),
+		"sod_ok":      sodOk,
+		"chain":       chain,
+		"actor":       actor,
+		"role":        role,
+		"submitter":   req.Submitter,
+		"amount":      req.Amount,
+		"last_resort": lastResort,
 	}, func(wf *workflow.Workflow) error {
-		// The branch is chosen by the guards, and its effects follow from the
-		// definition — no host-side switch on which one won.
-		_, err := wf.ApplyAny(ctx, "approve_final", "approve_partial")
+		// The approval IS a token. Appending it and firing happen in one atomic
+		// cycle, so an approval the net refuses is never persisted — the
+		// authorization hole a reviewer found in the first draft of this spike
+		// cannot exist in this shape.
+		if _, err := wf.CreateToken("approvals", workflow.TokenData{
+			"role": role, "by": actor, "last_resort": lastResort,
+		}); err != nil {
+			return err
+		}
+		// The branch is chosen by enablement and guards; its effects follow from
+		// the definition. No host-side switch, and no host-side satisfaction test.
+		_, err := wf.ApplyAny(ctx, "approve_last_resort", "approve_final", "approve_partial")
 		return err
 	})
 	if err != nil {
-		if !sodOk {
+		// The library reports only THAT the net refused, so the host re-derives
+		// which rule it was to choose a status code. That is #38 — and it is now
+		// the only reason these values are recomputed here; nothing about the
+		// decision itself depends on them any more.
+		if !sodOk || (!lastResort && !slices.Contains(chain, role)) {
 			return ErrForbidden
 		}
 		return classify(err)
@@ -233,20 +242,6 @@ func (a *App) Revoke(ctx context.Context, id, actor string) error {
 	}))
 }
 
-// detailFor is the audit marker distinguishing a last-resort completion from a
-// normally-satisfied chain. It travels in context because it depends on runtime
-// facts the definition cannot know.
-func detailFor(lastResort, satisfied bool) string {
-	switch {
-	case lastResort:
-		return "last-resort"
-	case satisfied:
-		return "chain-satisfied"
-	default:
-		return "pending"
-	}
-}
-
 // classify maps a library error onto the host's sentinels. Everything that is
 // not a recognised library condition collapses to ErrIllegalTransition,
 // because the library does not report which guard rejected.
@@ -275,4 +270,15 @@ func (a *App) Marking(ctx context.Context, id string) ([]workflow.Place, error) 
 		return nil, err
 	}
 	return wf.CurrentPlaces(), nil
+}
+
+// Ledger returns the approvals recorded so far. Since #34 the ledger is the
+// marking — one colored token per approval in the `approvals` pool — so there
+// is no ledger table to read and no effect that writes one.
+func (a *App) Ledger(ctx context.Context, id string) ([]workflow.Token, error) {
+	wf, err := a.mgr.LoadWorkflow(ctx, id, a.def)
+	if err != nil {
+		return nil, err
+	}
+	return wf.GetTokens("approvals"), nil
 }

--- a/internal/spike/approval/app.go
+++ b/internal/spike/approval/app.go
@@ -169,7 +169,13 @@ func (a *App) Approve(ctx context.Context, id, actor string) error {
 	}
 	chain := a.hier.ChainFor(req.Amount)
 	lastResort := lastResortAllowed(a.dir, actor, chain)
-	sodOk := actor != req.Submitter || lastResort
+	// Separation of duties applies to EVERY approve branch, last-resort included.
+	// This used to read `actor != req.Submitter || lastResort`, exempting the
+	// hatch — which let an admin approve a requisition they had submitted
+	// themselves, since `approve_last_resort` needs no role. The hatch exists for
+	// a chain nobody can satisfy; that is not a reason to let someone sign off on
+	// their own record. TestAdminSubmitterCannotSelfApprove pins it.
+	sodOk := actor != req.Submitter
 	role := a.dir.RoleOf(actor)
 
 	err = a.fire(ctx, id, map[string]any{

--- a/internal/spike/approval/app_test.go
+++ b/internal/spike/approval/app_test.go
@@ -354,6 +354,38 @@ func TestAdminLastResort(t *testing.T) {
 	}
 }
 
+// TestAdminSubmitterCannotSelfApprove: the last-resort hatch is not a way around
+// separation of duties.
+//
+// `admin` submits a 200k requisition, whose chain needs a `director` nobody
+// holds — so the hatch IS available to them. It must still be refused, because
+// they are the submitter. Caught by review on #49: the host used to compute
+// `sod_ok` as `actor != submitter || lastResort` and `approve_last_resort`
+// carried no `sod_ok` guard, so both halves said yes.
+func TestAdminSubmitterCannotSelfApprove(t *testing.T) {
+	a, ctx := newApp(t)
+	if err := a.Create(ctx, "sa", "REQ-SA", "admin", 200_000, []Line{costed("l1", "CC-900", 200_000)}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := a.Submit(ctx, "sa", "admin"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if err := a.Approve(ctx, "sa", "admin"); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("approve err = %v, want ErrForbidden", err)
+	}
+	mustStatus(t, a, ctx, "sa", "Submitted")
+	if n := ledgerSize(t, a, ctx, "sa"); n != 0 {
+		t.Errorf("pool = %d tokens, want 0 — a refused approval left a trace", n)
+	}
+
+	// A different admin, same requisition, still works: the hatch is intact.
+	a.dir.admins["auditor"] = true
+	if err := a.Approve(ctx, "sa", "auditor"); err != nil {
+		t.Fatalf("last-resort by a non-submitting admin: %v", err)
+	}
+	mustStatus(t, a, ctx, "sa", "Approved")
+}
+
 // TestRejectResubmitCycle exercises the loop back to draft.
 func TestRejectResubmitCycle(t *testing.T) {
 	a, ctx := newApp(t)

--- a/internal/spike/approval/app_test.go
+++ b/internal/spike/approval/app_test.go
@@ -67,6 +67,18 @@ func countRows(t *testing.T, a *App, ctx context.Context, query string, args ...
 	return n
 }
 
+// ledgerSize counts the approvals recorded so far. Since #34 the ledger is the
+// marking, so this reads the net rather than a table — there is no approvals
+// table any more.
+func ledgerSize(t *testing.T, a *App, ctx context.Context, id string) int {
+	t.Helper()
+	toks, err := a.Ledger(ctx, id)
+	if err != nil {
+		t.Fatalf("ledger: %v", err)
+	}
+	return len(toks)
+}
+
 // TestChainForThresholds pins the ladder: the chain grows with value, which is
 // exactly why the number of required approvals is not knowable at definition
 // time.
@@ -127,17 +139,48 @@ func TestTwoStepChain(t *testing.T) {
 		t.Fatalf("first approve: %v", err)
 	}
 	mustStatus(t, a, ctx, "r2", "Submitted") // still pending
-	if n := countRows(t, a, ctx, `SELECT COUNT(*) FROM approvals WHERE req_id = 'r2'`); n != 1 {
-		t.Errorf("ledger rows after first approval = %d, want 1", n)
+	if n := ledgerSize(t, a, ctx, "r2"); n != 1 {
+		t.Errorf("pool after first approval = %d tokens, want 1", n)
 	}
 
 	if err := a.Approve(ctx, "r2", "casey"); err != nil {
 		t.Fatalf("second approve: %v", err)
 	}
 	mustStatus(t, a, ctx, "r2", "Approved")
-	if n := countRows(t, a, ctx, `SELECT COUNT(*) FROM approvals WHERE req_id = 'r2'`); n != 2 {
-		t.Errorf("ledger rows after second approval = %d, want 2", n)
+	// The join consumed both approvals into `approved` and the reset arc cleared
+	// what was left, so the pool is empty — the ledger did its job and closed.
+	if n := ledgerSize(t, a, ctx, "r2"); n != 0 {
+		t.Errorf("pool after the chain closed = %d tokens, want 0", n)
 	}
+}
+
+// TestPartialApprovalIsNotEnoughEvenTwice: the join counts DISTINCT roles, so
+// the same approver signing twice does not advance the requisition. Before #34
+// this was a de-duplication the host had to implement over its own ledger.
+func TestPartialApprovalIsNotEnoughEvenTwice(t *testing.T) {
+	a, ctx := newApp(t)
+	if err := a.Create(ctx, "rd", "REQ-RD", "dana", 20_000, []Line{costed("l1", "CC-200", 20_000)}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := a.Submit(ctx, "rd", "dana"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	// sam and rae both hold site_manager — two approvals, one role.
+	if err := a.Approve(ctx, "rd", "sam"); err != nil {
+		t.Fatalf("first approve: %v", err)
+	}
+	if err := a.Approve(ctx, "rd", "rae"); err != nil {
+		t.Fatalf("second approve: %v", err)
+	}
+	mustStatus(t, a, ctx, "rd", "Submitted")
+	if n := ledgerSize(t, a, ctx, "rd"); n != 2 {
+		t.Errorf("pool = %d tokens, want 2 (both recorded, one role)", n)
+	}
+
+	if err := a.Approve(ctx, "rd", "casey"); err != nil {
+		t.Fatalf("third approve: %v", err)
+	}
+	mustStatus(t, a, ctx, "rd", "Approved")
 }
 
 // TestReadyGateBlocksSubmit: a line without a cost code blocks submission, and
@@ -171,8 +214,12 @@ func TestSeparationOfDuties(t *testing.T) {
 }
 
 // TestRolelessActorCannotApprove: an actor holding no role at all must not be
-// able to write into the append-only ledger. The net cannot make this check —
-// chain membership is a runtime value — so the host makes it.
+// able to write into the ledger.
+//
+// Since #34 the NET refuses this — `role in chain` is a guard over a runtime
+// value the definition can now reason about — and because the approval token is
+// created inside the same atomic cycle as the firing, a refused approval leaves
+// nothing behind at all. The host check that remains only picks the status code.
 func TestRolelessActorCannotApprove(t *testing.T) {
 	a, ctx := newApp(t)
 	if err := a.Create(ctx, "ra", "REQ-RA", "dana", 1_000, []Line{costed("l1", "CC-100", 1_000)}); err != nil {
@@ -184,8 +231,8 @@ func TestRolelessActorCannotApprove(t *testing.T) {
 	if err := a.Approve(ctx, "ra", "nobody"); !errors.Is(err, ErrForbidden) {
 		t.Fatalf("approve err = %v, want ErrForbidden", err)
 	}
-	if n := countRows(t, a, ctx, `SELECT COUNT(*) FROM approvals WHERE req_id = 'ra'`); n != 0 {
-		t.Errorf("ledger rows = %d, want 0 — a roleless actor wrote to the ledger", n)
+	if n := ledgerSize(t, a, ctx, "ra"); n != 0 {
+		t.Errorf("pool = %d tokens, want 0 — a roleless actor left a trace", n)
 	}
 	mustStatus(t, a, ctx, "ra", "Submitted")
 }
@@ -204,8 +251,8 @@ func TestOutOfChainActorCannotApprove(t *testing.T) {
 	if err := a.Approve(ctx, "rb", "ollie"); !errors.Is(err, ErrForbidden) { // ollie is ceo
 		t.Fatalf("approve err = %v, want ErrForbidden", err)
 	}
-	if n := countRows(t, a, ctx, `SELECT COUNT(*) FROM approvals WHERE req_id = 'rb'`); n != 0 {
-		t.Errorf("ledger rows = %d, want 0", n)
+	if n := ledgerSize(t, a, ctx, "rb"); n != 0 {
+		t.Errorf("pool = %d tokens, want 0", n)
 	}
 	// The legitimate approver still works.
 	if err := a.Approve(ctx, "rb", "sam"); err != nil {
@@ -261,10 +308,10 @@ func TestDeclaredEffectsFireInOrder(t *testing.T) {
 		t.Fatalf("approve: %v", err)
 	}
 
-	// approve_final declares: record_approval, project_status, supersede_prior,
-	// stamp_approver, audit, notify, outbox — all of which must have landed.
-	if n := countRows(t, a, ctx, `SELECT COUNT(*) FROM approvals WHERE req_id = 'rk'`); n != 1 {
-		t.Errorf("ledger rows = %d, want 1", n)
+	// approve_final declares: project_status, supersede_prior, stamp_approver,
+	// audit, notify, outbox — all of which must have landed.
+	if n := countRows(t, a, ctx, `SELECT COUNT(*) FROM audit_log WHERE req_id = 'rk'`); n != 2 {
+		t.Errorf("audit rows = %d, want 2 (submit + approve)", n)
 	}
 	if n := countRows(t, a, ctx, `SELECT COUNT(*) FROM outbox WHERE req_id = 'rk'`); n != 1 {
 		t.Errorf("outbox rows = %d, want 1", n)
@@ -348,8 +395,8 @@ func TestEffectsAreAtomic(t *testing.T) {
 	if err := a.Submit(ctx, "r8", "dana"); err != nil {
 		t.Fatalf("submit: %v", err)
 	}
-	// Drop the ledger table so the approval effect fails mid-transaction.
-	if _, err := a.db.ExecContext(ctx, `DROP TABLE approvals`); err != nil {
+	// Drop the audit table so a declared effect fails mid-transaction.
+	if _, err := a.db.ExecContext(ctx, `DROP TABLE audit_log`); err != nil {
 		t.Fatalf("drop: %v", err)
 	}
 	if err := a.Approve(ctx, "r8", "sam"); err == nil {

--- a/internal/spike/approval/domain.go
+++ b/internal/spike/approval/domain.go
@@ -22,7 +22,6 @@ import (
 	"database/sql"
 	"fmt"
 	"maps"
-	"slices"
 	"sort"
 )
 
@@ -141,13 +140,6 @@ CREATE TABLE IF NOT EXISTS requisition_lines (
 	cost_code TEXT NOT NULL DEFAULT '',
 	amount    REAL NOT NULL
 );
-CREATE TABLE IF NOT EXISTS approvals (
-	seq         INTEGER PRIMARY KEY AUTOINCREMENT,
-	req_id      TEXT NOT NULL,
-	actor       TEXT NOT NULL,
-	role        TEXT NOT NULL,
-	last_resort INTEGER NOT NULL DEFAULT 0
-);
 CREATE TABLE IF NOT EXISTS audit_log (
 	seq    INTEGER PRIMARY KEY AUTOINCREMENT,
 	req_id TEXT NOT NULL,
@@ -206,60 +198,23 @@ func readyGate(r Requisition) bool {
 	return true
 }
 
-// approvedRoles returns the set of roles that have already approved req.
-func approvedRoles(ctx context.Context, q queryer, reqID string) (map[string]bool, error) {
-	rows, err := q.QueryContext(ctx, `SELECT role FROM approvals WHERE req_id = ?`, reqID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-	got := map[string]bool{}
-	for rows.Next() {
-		var role string
-		if err := rows.Scan(&role); err != nil {
-			return nil, err
-		}
-		got[role] = true
-	}
-	return got, rows.Err()
-}
-
-// chainSatisfied reports whether every role in chain has approved once the
-// pending role is counted, treating a last-resort approval as satisfying the
-// whole remainder. This is the dynamic-cardinality AND-join the net cannot
-// express: the number of tokens that must arrive is len(chain), and len(chain)
-// is not known until the requisition's value is read.
+// The approvals ledger, the "have all required roles approved?" test, and the
+// "is this actor even a required approver?" check all used to live here — some
+// 55 lines of Go, including a function that had to SIMULATE the write it was
+// about to make, because the transition that records an approval is the one
+// whose guard needed the answer.
 //
-// The `pending` parameter is the tell. The caller has to ask "would the chain
-// be satisfied IF this approval were recorded?", because the transition that
-// records it is the one whose guard needs the answer — and the guard cannot
-// query. So the host simulates the write it is about to make.
-func chainSatisfied(ctx context.Context, q queryer, reqID string, chain []string, pending string, lastResort bool) (bool, error) {
-	if lastResort {
-		return true, nil
-	}
-	got, err := approvedRoles(ctx, q, reqID)
-	if err != nil {
-		return false, err
-	}
-	got[pending] = true
-	for _, role := range chain {
-		if !got[role] {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-// roleInChain reports whether role is one of the roles the chain requires.
+// All of it is gone. Since #34 the approvals are colored tokens in the net's
+// `approvals` pool and the definition counts them itself:
 //
-// This is an authorization check the net cannot make. The chain is a runtime
-// value, so "is this actor even a required approver?" cannot be a guard — and
-// without it any non-submitter can write a row into the append-only ledger.
-// A dynamic-cardinality join over role-tagged tokens (#34) would subsume it.
-func roleInChain(role string, chain []string) bool {
-	return slices.Contains(chain, role)
-}
+//	require:
+//	  - place: approvals
+//	    where: "token.role in chain"
+//	    distinct: role
+//	    count: "len(chain)"
+//
+// What remains below is genuine domain code — the ladder that produces the
+// chain, and the escape hatch for a chain nobody can satisfy.
 
 // lastResortAllowed reports whether actor may complete the chain alone. It is
 // the escape hatch for a chain containing a role nobody holds — without it

--- a/internal/spike/approval/effects.go
+++ b/internal/spike/approval/effects.go
@@ -46,15 +46,12 @@ func (a *App) registerEffects() (*workflow.EffectRegistry, error) {
 		if err != nil {
 			return err
 		}
-		// A declared param wins; otherwise fall back to what the firing knows.
-		// detailFor is the last-resort marker, which only the context carries.
-		detail := str(ev.Params["detail"])
-		if detail == "" {
-			detail = str(ev.Context["audit_detail"])
-		}
+		// The detail is a declared param throughout — including the last-resort
+		// marker, which used to travel in context because the host had to work
+		// out which branch it was about to take. The branch declares its own now.
 		_, err = sqlTx.ExecContext(ctx,
 			`INSERT INTO audit_log (req_id, action, detail, actor) VALUES (?, ?, ?, ?)`,
-			ev.WorkflowID, str(ev.Params["action"]), detail, str(ev.Context["actor"]))
+			ev.WorkflowID, str(ev.Params["action"]), str(ev.Params["detail"]), str(ev.Context["actor"]))
 		return err
 	}); err != nil {
 		return nil, err
@@ -93,25 +90,12 @@ func (a *App) registerEffects() (*workflow.EffectRegistry, error) {
 		return nil, err
 	}
 
-	// record_approval appends to the ledger. Still host code: the net cannot
-	// hold the ledger until a dynamic-cardinality join exists (#34), which
-	// would make the approval a token and this effect disappear.
-	if err := reg.Register("record_approval", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
-		sqlTx, err := asTx(tx)
-		if err != nil {
-			return err
-		}
-		lastResort := 0
-		if ev.Context["last_resort"] == true {
-			lastResort = 1
-		}
-		_, err = sqlTx.ExecContext(ctx,
-			`INSERT INTO approvals (req_id, actor, role, last_resort) VALUES (?, ?, ?, ?)`,
-			ev.WorkflowID, str(ev.Context["actor"]), str(ev.Context["role"]), lastResort)
-		return err
-	}); err != nil {
-		return nil, err
-	}
+	// There was a `record_approval` effect here, appending a row to an approvals
+	// table. #34 deleted it: an approval is a colored token in the net's pool
+	// now, written by the same atomic save as the marking, and the join counts
+	// the tokens directly. The prediction under friction 1 was that a
+	// dynamic-cardinality join "would make the approval a token and this effect
+	// disappear" — it did.
 
 	if err := reg.Register("stamp_approver", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
 		sqlTx, err := asTx(tx)

--- a/internal/spike/approval/workflow.yaml
+++ b/internal/spike/approval/workflow.yaml
@@ -2,19 +2,21 @@
 # (see COVERAGE.md). This is everything about the workflow that the library
 # can express today.
 #
-# What it deliberately does NOT contain, because the library cannot express
-# it, is the interesting part: the approval chain is resolved by the host and
-# arrives here as three pre-computed booleans (ready, sod_ok, chain_satisfied)
-# that the guards can only read. The guards cannot compute them, because a
-# guard has no transaction and cannot query the ledger — so every one of them
-# is a value the host had to work out first and inject via SetContext.
+# What it still does NOT contain is the guard INPUTS: `ready` and `sod_ok` are
+# booleans the host computes and injects with SetContext, because a guard has
+# no transaction and cannot query (#35). `chain` is injected for the same
+# reason — but note that it is now a VALUE the net reasons about rather than a
+# pre-computed answer, which is the whole difference #34 made.
 #
-# approve is split into two transitions with complementary guards precisely
-# because one action has two outcomes: recording an approval that does not yet
-# satisfy the chain (approve_partial, a self-loop) versus the one that does
-# (approve_final). ApplyAny picks between them. That split is the right shape
-# and it works — what does not work is that the effects each branch needs
-# cannot be attached here, so they live in a Go switch instead.
+# approve is three transitions with complementary conditions because one action
+# has three outcomes, and ApplyAny picks between them in declaration order:
+#
+#   approve_last_resort  an admin completing a chain nobody can satisfy
+#   approve_final        this approval satisfies the chain
+#   approve_partial      it does not (yet)
+#
+# Nothing in the host decides which: approve_final is simply not ENABLED until
+# the approvals pool holds one token per required role.
 workflow:
   name: requisition_approval
   initial_marking: draft
@@ -23,6 +25,11 @@ workflow:
       metadata: {status: Draft, editable: true}
     - name: submitted
       metadata: {status: Submitted}
+    # approvals is a token POOL, not a state: one colored token per approval,
+    # carrying the approver's role. It is the ledger, and it is what the
+    # dynamic-cardinality join counts. It carries no status metadata precisely
+    # because it is not a state the record is "in".
+    - name: approvals
     - name: approved
       metadata: {status: Approved}
     - name: rejected
@@ -32,7 +39,7 @@ workflow:
   transitions:
     # `ready` is the ready-gate: every costed line carries a cost code. The
     # host computes it by querying the lines and injects the answer; the guard
-    # only reads the boolean.
+    # only reads the boolean. That is #35, still open.
     - name: submit
       from: [draft]
       to: [submitted]
@@ -47,30 +54,52 @@ workflow:
         - name: email
           params: {to: "approvers", template: "submitted"}
 
-    # Both approve branches share the separation-of-duties guard. sod_ok is
-    # host-computed as (actor != submitter) || last_resort.
-    #
-    # The two branches carry DIFFERENT effects — the whole point of binding
-    # effects per transition. Before #36 this was a Go switch on which branch
-    # ApplyAny picked; now the definition says it.
-    - name: approve_partial
-      from: [submitted]
-      to: [submitted]
-      guard: "sod_ok && !chain_satisfied"
-      effects:
-        - name: record_approval
-        - name: project_status
-        - name: audit
-          params: {action: "requisition.approve", detail: "pending"}
-        - name: notify
-          params: {target: "approvers", kind: "approval_pending"}
-
-    - name: approve_final
-      from: [submitted]
+    # An admin may complete a chain that contains a role nobody holds — without
+    # it such a requisition is unapprovable. It is tried FIRST because it is the
+    # narrowest condition.
+    - name: approve_last_resort
+      from: [submitted, approvals]
       to: [approved]
-      guard: "sod_ok && chain_satisfied"
+      guard: "last_resort"
+      resets: [approvals]
       effects:
-        - name: record_approval
+        - name: project_status
+        - name: supersede_prior
+        - name: stamp_approver
+        - name: audit
+          params: {action: "requisition.approve", detail: "last-resort"}
+        - name: notify
+          params: {target: "submitter", kind: "approved"}
+        - name: outbox
+          params: {event: "requisition.approved"}
+      after_commit:
+        - name: email
+          params: {to: "submitter", template: "approved"}
+
+    # THE DYNAMIC-CARDINALITY JOIN (#34).
+    #
+    # Wait until the approvals pool holds one token per role the chain requires
+    # — where the chain's LENGTH is len(chain), a runtime value. Before #34 this
+    # was `chain_satisfied`, a boolean the host computed by reading its own
+    # ledger table and simulating the approval it was about to write.
+    #
+    # `distinct: role` is what makes two approvals from one role count once, and
+    # `where` is what makes an out-of-chain approval count never — so chain
+    # membership is structural instead of a check the host must remember.
+    #
+    # The reset arc discards the pool with the same firing; the tokens the join
+    # selected have already flowed to `approved`.
+    - name: approve_final
+      from: [submitted, approvals]
+      to: [approved]
+      guard: "sod_ok"
+      resets: [approvals]
+      require:
+        - place: approvals
+          where: "token.role in chain"
+          distinct: role
+          count: "len(chain)"
+      effects:
         - name: project_status
         - name: supersede_prior
         - name: stamp_approver
@@ -84,9 +113,30 @@ workflow:
         - name: email
           params: {to: "submitter", template: "approved"}
 
+    # The approval landed but the chain is not satisfied yet. The self-loop
+    # records progress without advancing; the approval token itself is already
+    # in the pool, added inside the same atomic cycle.
+    #
+    # `role in chain` is the authorization check. It rejects an actor the chain
+    # does not require — and because the token was added inside the fire, a
+    # rejected approval is never persisted at all.
+    - name: approve_partial
+      from: [submitted]
+      to: [submitted]
+      guard: "sod_ok && role in chain"
+      effects:
+        - name: project_status
+        - name: audit
+          params: {action: "requisition.approve", detail: "pending"}
+        - name: notify
+          params: {target: "approvers", kind: "approval_pending"}
+
+    # Rejecting clears the pool: the approvals collected so far do not survive
+    # a rejection, and the reset arc says so in one place.
     - name: reject
       from: [submitted]
       to: [rejected]
+      resets: [approvals]
       effects:
         - name: project_status
         - name: audit

--- a/internal/spike/approval/workflow.yaml
+++ b/internal/spike/approval/workflow.yaml
@@ -57,10 +57,17 @@ workflow:
     # An admin may complete a chain that contains a role nobody holds — without
     # it such a requisition is unapprovable. It is tried FIRST because it is the
     # narrowest condition.
+    #
+    # It carries `sod_ok` like every other approve branch. An earlier version did
+    # not, and the host exempted last-resort from separation of duties on top of
+    # that, so an admin could approve their own requisition. Being able to break a
+    # deadlocked chain is not a licence to sign off on your own record — and with
+    # the rule on all three branches, the definition says so rather than leaving
+    # it to a boolean the host computes.
     - name: approve_last_resort
       from: [submitted, approvals]
       to: [approved]
-      guard: "last_resort"
+      guard: "last_resort && sod_ok"
       resets: [approvals]
       effects:
         - name: project_status

--- a/mermaid.go
+++ b/mermaid.go
@@ -283,6 +283,12 @@ func renderDiagram(def *Definition, initial []Place, current map[Place]bool, tok
 		if d, ok := t.TimeoutAfter(); ok {
 			label = "⏱ " + label + "<br/>after " + escapeMermaidLabel(d.String())
 		}
+		// A dynamic-cardinality join is invisible in the arc structure — the
+		// arity is an expression, not a number of arcs — so it has to be on the
+		// node or the diagram lies about when the transition can fire.
+		for _, r := range t.Requirements() {
+			label += "<br/>❰ " + escapeMermaidLabel(r.String()) + " ❱"
+		}
 		fmt.Fprintf(&b, "    %s[\"%s\"]\n    class %s %s\n", id, label, id, class)
 
 		// Fork/join gateway diamonds with the BPMN symbols: + marks the

--- a/requirement.go
+++ b/requirement.go
@@ -1,0 +1,349 @@
+// Copyright (c) 2026 Ehab Terra
+// SPDX-License-Identifier: MIT
+
+package workflow
+
+import (
+	"fmt"
+	"maps"
+	"math"
+	"strings"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
+)
+
+// RequirementSpec declares a dynamic-cardinality join: a transition input whose
+// arity is resolved at fire time from an expression rather than fixed by the
+// definition.
+//
+// The classic AND-join is structural — "every declared input place is marked" —
+// so the number of things a transition waits for is a property of the drawing.
+// The recurring business-workflow shape is not: an approval chain's length comes
+// from the record's value, so the transition must wait for a set whose size is
+// only known at runtime. A requirement expresses exactly that, over the tokens
+// resting in one input place.
+//
+//	require:
+//	  - place: submitted
+//	    where: "token.role in required_roles"   # which tokens count
+//	    distinct: role                          # two tokens of one role are one approval
+//	    count: "len(required_roles)"            # how many are needed, resolved now
+//
+// A requirement is BOTH an enablement condition and a token selector: the
+// transition is enabled only when its place holds enough matching tokens, and
+// firing consumes exactly the tokens it selected, leaving the remainder in
+// place. See Transition.SetRequirements for the full firing rules.
+type RequirementSpec struct {
+	// Place is the input place whose tokens are counted. It must be one of the
+	// transition's own 'from' places (NewDefinition validates this), and at most
+	// one requirement may target a given place.
+	Place Place
+
+	// Count is an expression yielding the number of tokens required. It is
+	// evaluated at fire time against the workflow context, plus `tokens` — the
+	// data of every token currently at Place. It must yield a non-negative
+	// integer (a JSON-decoded float64 with no fractional part is accepted, since
+	// context values round-trip through storage).
+	Count string
+
+	// Where, when set, is an expression evaluated once per token at Place to
+	// decide whether that token counts toward Count. The token's data is exposed
+	// as `token`; the workflow context is in scope. An empty Where counts every
+	// token in the place.
+	Where string
+
+	// Distinct, when set, names a token-data field that must be UNIQUE among the
+	// counted tokens: one token per distinct value, first occurrence wins. It is
+	// what makes "two approvals from the same role are one approval" structural
+	// rather than a check the host has to remember to write. Tokens that do not
+	// carry the field are never counted.
+	Distinct string
+}
+
+// Requirement is a compiled RequirementSpec. Build one with NewRequirement; it
+// is immutable and safe to share across workflow instances.
+type Requirement struct {
+	spec     RequirementSpec
+	countPrg *vm.Program
+	wherePrg *vm.Program
+}
+
+// NewRequirement compiles a requirement declaration, reporting an expression
+// that does not parse. Compiling at definition-build time rather than at fire
+// time means a malformed count expression fails at startup, not on the first
+// firing of a rare branch.
+func NewRequirement(spec RequirementSpec) (Requirement, error) {
+	if spec.Place == "" {
+		return Requirement{}, fmt.Errorf("%w: requirement place cannot be empty", ErrInvalidTransition)
+	}
+	if strings.TrimSpace(spec.Count) == "" {
+		return Requirement{}, fmt.Errorf("%w: requirement on place %q has no count expression", ErrInvalidTransition, spec.Place)
+	}
+
+	r := Requirement{spec: spec}
+	var err error
+	if r.countPrg, err = expr.Compile(spec.Count); err != nil {
+		return Requirement{}, fmt.Errorf("%w: requirement on place %q: count %q: %w",
+			ErrInvalidExpression, spec.Place, spec.Count, err)
+	}
+	if spec.Where != "" {
+		if r.wherePrg, err = expr.Compile(spec.Where); err != nil {
+			return Requirement{}, fmt.Errorf("%w: requirement on place %q: where %q: %w",
+				ErrInvalidExpression, spec.Place, spec.Where, err)
+		}
+	}
+	return r, nil
+}
+
+// MustNewRequirement is NewRequirement, panicking on error. For declaring
+// definitions in Go, where a malformed expression is a programming mistake.
+func MustNewRequirement(spec RequirementSpec) Requirement {
+	r, err := NewRequirement(spec)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// Spec returns the declaration this requirement was compiled from.
+func (r Requirement) Spec() RequirementSpec { return r.spec }
+
+// Place returns the input place whose tokens this requirement counts.
+func (r Requirement) Place() Place { return r.spec.Place }
+
+// String renders the requirement in the canonical form used by diagrams and by
+// the ErrNotEnabled message, e.g.
+// `submitted >= len(required_roles) distinct by role where token.role in required_roles`.
+func (r Requirement) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s >= %s", r.spec.Place, r.spec.Count)
+	if r.spec.Distinct != "" {
+		fmt.Fprintf(&b, " distinct by %s", r.spec.Distinct)
+	}
+	if r.spec.Where != "" {
+		fmt.Fprintf(&b, " where %s", r.spec.Where)
+	}
+	return b.String()
+}
+
+// record serializes the requirement for the definition fingerprint. Every field
+// is structural: changing which tokens count, how many, or how they are
+// de-duplicated changes when the net can fire.
+func (r Requirement) record() string {
+	var b strings.Builder
+	writeLenPrefixed(&b, string(r.spec.Place))
+	writeLenPrefixed(&b, r.spec.Count)
+	writeLenPrefixed(&b, r.spec.Where)
+	writeLenPrefixed(&b, r.spec.Distinct)
+	return b.String()
+}
+
+// selectTokens evaluates the requirement against the tokens currently at its
+// place and returns the INDEXES (into tokens, in the given order) of those a
+// firing would consume. met reports whether the place holds enough matching
+// tokens; an error means the declaration could not be evaluated at all — a
+// broken expression or a count that is not a non-negative integer — which is a
+// definition/environment fault, not a "not yet" condition.
+//
+// Selection is deterministic: matching tokens are taken in the order the place
+// holds them, so two evaluations of the same marking consume the same tokens.
+func (r Requirement) selectTokens(tokens []Token, ctxData map[string]any) (picked []int, met bool, err error) {
+	need, err := r.requiredCount(tokens, ctxData)
+	if err != nil {
+		return nil, false, err
+	}
+
+	env := requirementEnv(tokens, ctxData)
+	seen := make(map[string]bool)
+	for i := range tokens {
+		if len(picked) == need {
+			break
+		}
+		ok, err := r.matches(tokens[i], env)
+		if err != nil {
+			return nil, false, err
+		}
+		if !ok {
+			continue
+		}
+		if r.spec.Distinct != "" {
+			v, has := tokens[i].Get(r.spec.Distinct)
+			if !has {
+				continue // cannot be told apart; never counts
+			}
+			key := distinctKey(v)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+		}
+		picked = append(picked, i)
+	}
+
+	if len(picked) < need {
+		return nil, false, nil
+	}
+	return picked, true, nil
+}
+
+// matches evaluates the where expression for one token. A requirement without a
+// where clause counts every token.
+func (r Requirement) matches(tok Token, env map[string]any) (bool, error) {
+	if r.wherePrg == nil {
+		return true, nil
+	}
+	data := tok.Data()
+	if data == nil {
+		// An uncolored presence token carries no data. Expose an empty map so
+		// `token.field` evaluates to nil rather than faulting on a nil map.
+		data = TokenData{}
+	}
+	env["token"] = data
+	out, err := expr.Run(r.wherePrg, env)
+	if err != nil {
+		return false, fmt.Errorf("%w: requirement on place %q: where %q: %w",
+			ErrInvalidExpression, r.spec.Place, r.spec.Where, err)
+	}
+	b, ok := out.(bool)
+	if !ok {
+		return false, fmt.Errorf("%w: requirement on place %q: where %q must return boolean, got %T",
+			ErrInvalidExpression, r.spec.Place, r.spec.Where, out)
+	}
+	return b, nil
+}
+
+// requiredCount evaluates the count expression to a non-negative integer.
+func (r Requirement) requiredCount(tokens []Token, ctxData map[string]any) (int, error) {
+	out, err := expr.Run(r.countPrg, requirementEnv(tokens, ctxData))
+	if err != nil {
+		return 0, fmt.Errorf("%w: requirement on place %q: count %q: %w",
+			ErrInvalidExpression, r.spec.Place, r.spec.Count, err)
+	}
+	n, ok := toInt(out)
+	if !ok {
+		return 0, fmt.Errorf("%w: requirement on place %q: count %q must return an integer, got %T",
+			ErrInvalidExpression, r.spec.Place, r.spec.Count, out)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("%w: requirement on place %q: count %q must not be negative, got %d",
+			ErrInvalidExpression, r.spec.Place, r.spec.Count, n)
+	}
+	return n, nil
+}
+
+// requirementEnv builds the evaluation environment: the workflow context, plus
+// `tokens` — the data of every token currently at the requirement's place. The
+// reserved names `tokens` and `token` shadow context keys of the same name, as
+// they do in guard expressions.
+func requirementEnv(tokens []Token, ctxData map[string]any) map[string]any {
+	env := make(map[string]any, len(ctxData)+2)
+	maps.Copy(env, ctxData)
+	datas := make([]TokenData, len(tokens))
+	for i, t := range tokens {
+		datas[i] = t.Data()
+	}
+	env["tokens"] = datas
+	return env
+}
+
+// toInt coerces an expression result to an int. Whole float64 values are
+// accepted because context values that have round-tripped through JSON storage
+// come back as float64 — rejecting them would make a requirement work before a
+// save and fail after one.
+func toInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int8:
+		return int(n), true
+	case int16:
+		return int(n), true
+	case int32:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case uint:
+		return fromUint(uint64(n))
+	case uint8:
+		return int(n), true
+	case uint16:
+		return int(n), true
+	case uint32:
+		return fromUint(uint64(n))
+	case uint64:
+		return fromUint(n)
+	case float32:
+		return wholeFloat(float64(n))
+	case float64:
+		return wholeFloat(n)
+	default:
+		return 0, false
+	}
+}
+
+// fromUint converts an unsigned value that fits in an int. A count larger than
+// the platform's int is not a count anyone meant to write.
+func fromUint(n uint64) (int, bool) {
+	if n > math.MaxInt {
+		return 0, false
+	}
+	return int(n), true
+}
+
+// wholeFloat converts a float to an int only when it has no fractional part: a
+// count of 2.5 is a mistake worth reporting, not something to round.
+func wholeFloat(f float64) (int, bool) {
+	n := int(f)
+	if float64(n) != f {
+		return 0, false
+	}
+	return n, true
+}
+
+// selectRequirementsLocked evaluates every requirement of t against the current
+// marking, returning for each requirement's place the indexes of the tokens a
+// firing would consume (nil when t declares no requirements).
+//
+// It is the single decision point for both halves of the feature: an unmet
+// requirement is reported as ErrNotEnabled, and the indexes it returns are the
+// consume set moveMarking will act on. Callers MUST hold w.mu — the returned
+// indexes are only valid for the marking as it stands under that same hold.
+func (w *Workflow) selectRequirementsLocked(t *Transition) (map[Place][]int, error) {
+	if len(t.requires) == 0 {
+		return nil, nil
+	}
+	picked := make(map[Place][]int, len(t.requires))
+	for i := range t.requires {
+		r := t.requires[i]
+		idx, met, err := r.selectTokens(w.marking.TokensAt(r.spec.Place), w.context)
+		if err != nil {
+			return nil, fmt.Errorf("transition %q: %w", t.name, err)
+		}
+		if !met {
+			return nil, fmt.Errorf("%w: transition %q requires %s", ErrNotEnabled, t.name, r)
+		}
+		picked[r.spec.Place] = idx
+	}
+	return picked, nil
+}
+
+// requirementsMet is the enablement half of selectRequirementsLocked for
+// callers that do NOT already hold w.mu. The answer is a snapshot: a firing
+// re-evaluates under the write lock before it consumes anything.
+func (w *Workflow) requirementsMet(t *Transition) error {
+	if len(t.requires) == 0 {
+		return nil
+	}
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	_, err := w.selectRequirementsLocked(t)
+	return err
+}
+
+// distinctKey renders a token-data value as a de-duplication key. The type is
+// part of the key so that values of different types (the string "1" and the
+// number 1) are never conflated.
+func distinctKey(v any) string {
+	return fmt.Sprintf("%T\x00%v", v, v)
+}

--- a/requirement.go
+++ b/requirement.go
@@ -149,12 +149,16 @@ func (r Requirement) record() string {
 // Selection is deterministic: matching tokens are taken in the order the place
 // holds them, so two evaluations of the same marking consume the same tokens.
 func (r Requirement) selectTokens(tokens []Token, ctxData map[string]any) (picked []int, met bool, err error) {
-	need, err := r.requiredCount(tokens, ctxData)
+	// One environment for both expressions: this runs on every enablement probe,
+	// and building it copies the context and every token's data. The count is
+	// evaluated first, before `matches` starts writing `token` into the map, so
+	// the count expression can never see a per-token value.
+	env := requirementEnv(tokens, ctxData)
+	need, err := r.requiredCount(env)
 	if err != nil {
 		return nil, false, err
 	}
 
-	env := requirementEnv(tokens, ctxData)
 	seen := make(map[string]bool)
 	for i := range tokens {
 		if len(picked) == need {
@@ -213,9 +217,10 @@ func (r Requirement) matches(tok Token, env map[string]any) (bool, error) {
 	return b, nil
 }
 
-// requiredCount evaluates the count expression to a non-negative integer.
-func (r Requirement) requiredCount(tokens []Token, ctxData map[string]any) (int, error) {
-	out, err := expr.Run(r.countPrg, requirementEnv(tokens, ctxData))
+// requiredCount evaluates the count expression to a non-negative integer against
+// the environment prepared by selectTokens.
+func (r Requirement) requiredCount(env map[string]any) (int, error) {
+	out, err := expr.Run(r.countPrg, env)
 	if err != nil {
 		return 0, fmt.Errorf("%w: requirement on place %q: count %q: %w",
 			ErrInvalidExpression, r.spec.Place, r.spec.Count, err)

--- a/requirement_test.go
+++ b/requirement_test.go
@@ -1,0 +1,648 @@
+// Copyright (c) 2026 Ehab Terra
+// SPDX-License-Identifier: MIT
+
+package workflow_test
+
+import (
+	"context"
+	"errors"
+	"math"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/ehabterra/workflow"
+)
+
+// approvalNet is the shape issue #34 exists for: a state place (`submitted`)
+// joined with a POOL place (`approvals`) that accumulates one colored token per
+// approval. How many approvals are needed is not in the net — it is
+// len(required_roles), a value the host resolves from the record at fire time.
+//
+//	approve_final : [submitted, approvals] -> [approved]   require over approvals
+//	approve_partial: [submitted] -> [submitted]            the "not yet" branch
+//
+// ApplyAny(final, partial) then routes itself: final is simply not enabled
+// until the chain is satisfied, so no host-side satisfaction check exists.
+func approvalNet(t *testing.T) *workflow.Definition {
+	t.Helper()
+
+	final := workflow.MustNewTransition("approve_final",
+		[]workflow.Place{"submitted", "approvals"}, []workflow.Place{"approved"})
+	final.SetRequirements(workflow.MustNewRequirement(workflow.RequirementSpec{
+		Place:    "approvals",
+		Where:    "token.role in required_roles",
+		Distinct: "role",
+		Count:    "len(required_roles)",
+	}))
+	// Leftovers — approvals from roles outside the chain — are discarded with
+	// the same firing rather than lingering in the pool.
+	final.SetResets("approvals")
+
+	partial := workflow.MustNewTransition("approve_partial",
+		[]workflow.Place{"submitted"}, []workflow.Place{"submitted"})
+
+	def, err := workflow.NewDefinition(
+		[]workflow.Place{"submitted", "approvals", "approved"},
+		[]workflow.Transition{*final, *partial},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return def
+}
+
+func approvalWorkflow(t *testing.T, chain ...string) *workflow.Workflow {
+	t.Helper()
+	wf, err := workflow.NewWorkflow("req-1", approvalNet(t), "submitted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	roles := make([]any, len(chain))
+	for i, r := range chain {
+		roles[i] = r
+	}
+	wf.SetContext("required_roles", roles)
+	return wf
+}
+
+func approve(t *testing.T, wf *workflow.Workflow, role, by string) {
+	t.Helper()
+	if _, err := wf.CreateToken("approvals", workflow.TokenData{"role": role, "by": by}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRequirementChainSatisfaction is the headline: the transition waits for a
+// set whose size is only known at runtime, with no host-side satisfaction check.
+func TestRequirementChainSatisfaction(t *testing.T) {
+	ctx := context.Background()
+	wf := approvalWorkflow(t, "manager", "finance")
+
+	// Nothing approved yet: the pool is empty, so the AND-join is not even
+	// structurally enabled.
+	if err := wf.CanTransition("approve_final"); !errors.Is(err, workflow.ErrNotEnabled) {
+		t.Fatalf("empty pool: want ErrNotEnabled, got %v", err)
+	}
+
+	// One of two approvals: the pool IS marked, so only the requirement can
+	// distinguish "some approvals" from "the chain is satisfied".
+	approve(t, wf, "manager", "alice")
+	err := wf.CanTransition("approve_final")
+	if !errors.Is(err, workflow.ErrNotEnabled) {
+		t.Fatalf("half a chain: want ErrNotEnabled, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "len(required_roles)") {
+		t.Errorf("the rejection should name the unmet requirement, got %q", err)
+	}
+
+	fired, err := wf.ApplyAny(ctx, "approve_final", "approve_partial")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fired != "approve_partial" {
+		t.Fatalf("with an unsatisfied chain ApplyAny must fall through to the partial branch, got %q", fired)
+	}
+
+	// The second approval completes the chain.
+	approve(t, wf, "finance", "bob")
+	fired, err = wf.ApplyAny(ctx, "approve_final", "approve_partial")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fired != "approve_final" {
+		t.Fatalf("satisfied chain: want approve_final, got %q", fired)
+	}
+	if places := wf.CurrentPlaces(); len(places) != 1 || places[0] != "approved" {
+		t.Fatalf("want [approved], got %v", places)
+	}
+	if n := wf.TokenCount("approvals"); n != 0 {
+		t.Errorf("the reset arc should have emptied the pool, %d left", n)
+	}
+}
+
+// TestRequirementDistinctDeDuplicates: two approvals from the SAME role are one
+// approval. Without this the count is satisfiable by one enthusiastic approver.
+func TestRequirementDistinctDeDuplicates(t *testing.T) {
+	wf := approvalWorkflow(t, "manager", "finance")
+	approve(t, wf, "manager", "alice")
+	approve(t, wf, "manager", "alice-again")
+
+	if err := wf.CanTransition("approve_final"); !errors.Is(err, workflow.ErrNotEnabled) {
+		t.Fatalf("two approvals from one role must not satisfy a two-role chain, got %v", err)
+	}
+
+	approve(t, wf, "finance", "bob")
+	if err := wf.CanTransition("approve_final"); err != nil {
+		t.Fatalf("distinct roles satisfied: %v", err)
+	}
+}
+
+// TestRequirementWhereExcludesOutOfChainTokens: chain membership is structural.
+// A token whose role is not in the chain can never count toward the join, so
+// "is this actor even a required approver?" stops being a check the host has to
+// remember to write.
+func TestRequirementWhereExcludesOutOfChainTokens(t *testing.T) {
+	wf := approvalWorkflow(t, "manager", "finance")
+	approve(t, wf, "manager", "alice")
+	approve(t, wf, "intern", "mallory")
+	approve(t, wf, "", "roleless")
+
+	if err := wf.CanTransition("approve_final"); !errors.Is(err, workflow.ErrNotEnabled) {
+		t.Fatalf("out-of-chain approvals must not satisfy the join, got %v", err)
+	}
+
+	approve(t, wf, "finance", "bob")
+	if err := wf.ApplyTransition("approve_final"); err != nil {
+		t.Fatal(err)
+	}
+	// The two chain approvals flowed to the output; the reset arc discarded the
+	// two that never counted.
+	if n := len(wf.GetTokens("approved")); n != 2 {
+		t.Fatalf("want the 2 counted approvals at approved, got %d", n)
+	}
+}
+
+// poolNet is the mechanics case: take exactly N from a pool, leave the rest.
+func poolNet(t *testing.T, count string) *workflow.Definition {
+	t.Helper()
+	ship := workflow.MustNewTransition("ship", []workflow.Place{"pool"}, []workflow.Place{"shipped"})
+	ship.SetRequirements(workflow.MustNewRequirement(workflow.RequirementSpec{Place: "pool", Count: count}))
+	def, err := workflow.NewDefinition(
+		[]workflow.Place{"pool", "shipped"},
+		[]workflow.Transition{*ship},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return def
+}
+
+func poolWorkflow(t *testing.T, count string, n int) *workflow.Workflow {
+	t.Helper()
+	m := workflow.NewMarking(nil)
+	for i := range n {
+		m.AddToken("pool", workflow.NewToken(workflow.TokenData{"order": i}))
+	}
+	wf, err := workflow.NewWorkflowFromMarking("batch", poolNet(t, count), m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return wf
+}
+
+// TestRequirementConsumesExactlyNAndLeavesRemainder pins the consumption half:
+// an ordinary input place is drained, a required one is not.
+func TestRequirementConsumesExactlyNAndLeavesRemainder(t *testing.T) {
+	wf := poolWorkflow(t, "batch_size", 5)
+	wf.SetContext("batch_size", 2)
+
+	before := wf.GetTokens("pool")
+	if err := wf.ApplyTransition("ship"); err != nil {
+		t.Fatal(err)
+	}
+
+	shipped := wf.GetTokens("shipped")
+	if len(shipped) != 2 {
+		t.Fatalf("want 2 tokens shipped, got %d", len(shipped))
+	}
+	left := wf.GetTokens("pool")
+	if len(left) != 3 {
+		t.Fatalf("want 3 tokens left in the pool, got %d", len(left))
+	}
+
+	// Selection is deterministic — the place's own order — and the survivors
+	// keep theirs, so a second firing takes the next two and not a reshuffle.
+	if shipped[0].ID() != before[0].ID() || shipped[1].ID() != before[1].ID() {
+		t.Errorf("want the first two pool tokens consumed, got %v", shipped)
+	}
+	for i, tok := range left {
+		if tok.ID() != before[i+2].ID() {
+			t.Fatalf("survivor %d out of order: want %s, got %s", i, before[i+2].ID(), tok.ID())
+		}
+	}
+
+	if err := wf.ApplyTransition("ship"); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(wf.GetTokens("pool")); n != 1 {
+		t.Fatalf("after a second batch want 1 left, got %d", n)
+	}
+	// The pool still holds a token, so the place stays marked — but one is not
+	// enough for another batch.
+	if err := wf.ApplyTransition("ship"); !errors.Is(err, workflow.ErrNotEnabled) {
+		t.Fatalf("want ErrNotEnabled with an under-full pool, got %v", err)
+	}
+}
+
+// TestRequirementCountFromPersistedContext: a count that arrives back from
+// storage as a JSON float64 must behave exactly as the int did before the save.
+func TestRequirementCountFromPersistedContext(t *testing.T) {
+	wf := poolWorkflow(t, "batch_size", 3)
+	wf.SetContext("batch_size", float64(2)) // what JSON storage hands back
+
+	if err := wf.ApplyTransition("ship"); err != nil {
+		t.Fatalf("float64 count: %v", err)
+	}
+	if n := len(wf.GetTokens("shipped")); n != 2 {
+		t.Fatalf("want 2 shipped, got %d", n)
+	}
+}
+
+// TestRequirementCountExpressionFaultIsNotJustNotEnabled: a count that cannot be
+// evaluated is a definition/environment fault. It must NOT look like "not yet",
+// or ApplyAny would quietly skip past a broken definition.
+func TestRequirementCountExpressionFaultIsNotJustNotEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		count any
+	}{
+		{"not a number", "batch_size"},
+		{"fractional", 2.5},
+		{"negative", -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wf := poolWorkflow(t, "batch_size", 3)
+			wf.SetContext("batch_size", tc.count)
+
+			err := wf.ApplyTransition("ship")
+			if err == nil {
+				t.Fatal("want an error")
+			}
+			if errors.Is(err, workflow.ErrTransitionNotAllowed) {
+				t.Fatalf("a broken count must not read as a blocked transition: %v", err)
+			}
+			if !errors.Is(err, workflow.ErrInvalidExpression) {
+				t.Fatalf("want ErrInvalidExpression, got %v", err)
+			}
+		})
+	}
+}
+
+// TestRequirementCountAcceptsEveryIntegerKind: a count reaches the engine as
+// whatever type the host put in the context, so every integer kind has to
+// behave the same. Anything that is not a whole, in-range, non-negative number
+// is a fault.
+func TestRequirementCountAcceptsEveryIntegerKind(t *testing.T) {
+	good := map[string]any{
+		"int":     2,
+		"int8":    int8(2),
+		"int16":   int16(2),
+		"int32":   int32(2),
+		"int64":   int64(2),
+		"uint":    uint(2),
+		"uint8":   uint8(2),
+		"uint16":  uint16(2),
+		"uint32":  uint32(2),
+		"uint64":  uint64(2),
+		"float32": float32(2),
+		"float64": float64(2),
+	}
+	for name, v := range good {
+		t.Run(name, func(t *testing.T) {
+			wf := poolWorkflow(t, "batch_size", 3)
+			wf.SetContext("batch_size", v)
+			if err := wf.ApplyTransition("ship"); err != nil {
+				t.Fatalf("count as %s: %v", name, err)
+			}
+			if n := len(wf.GetTokens("shipped")); n != 2 {
+				t.Fatalf("want 2 shipped, got %d", n)
+			}
+		})
+	}
+
+	bad := map[string]any{
+		"out of int range": uint64(math.MaxUint64),
+		"boolean":          true,
+		"nil":              nil,
+	}
+	for name, v := range bad {
+		t.Run(name, func(t *testing.T) {
+			wf := poolWorkflow(t, "batch_size", 3)
+			wf.SetContext("batch_size", v)
+			if err := wf.ApplyTransition("ship"); !errors.Is(err, workflow.ErrInvalidExpression) {
+				t.Fatalf("want ErrInvalidExpression, got %v", err)
+			}
+		})
+	}
+}
+
+// TestRequirementExpressionRuntimeFaults: an expression that compiles but blows
+// up at fire time is still a fault, not a "not yet".
+func TestRequirementExpressionRuntimeFaults(t *testing.T) {
+	cases := map[string]workflow.RequirementSpec{
+		"count faults":     {Place: "pool", Count: "tokens[99]"},
+		"where faults":     {Place: "pool", Count: "1", Where: "tokens[99] == 1"},
+		"where not a bool": {Place: "pool", Count: "1", Where: "token.order"},
+	}
+	for name, spec := range cases {
+		t.Run(name, func(t *testing.T) {
+			ship := workflow.MustNewTransition("ship", []workflow.Place{"pool"}, []workflow.Place{"shipped"})
+			ship.SetRequirements(workflow.MustNewRequirement(spec))
+			def, err := workflow.NewDefinition(
+				[]workflow.Place{"pool", "shipped"}, []workflow.Transition{*ship})
+			if err != nil {
+				t.Fatal(err)
+			}
+			m := workflow.NewMarking(nil)
+			m.AddToken("pool", workflow.NewToken(workflow.TokenData{"order": 1}))
+			wf, err := workflow.NewWorkflowFromMarking("b", def, m)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Every enablement path must report it, not just the firing one.
+			if _, err := wf.EnabledTransitions(); !errors.Is(err, workflow.ErrInvalidExpression) {
+				t.Errorf("EnabledTransitions: want ErrInvalidExpression, got %v", err)
+			}
+			if err := wf.ApplyTransition("ship"); !errors.Is(err, workflow.ErrInvalidExpression) {
+				t.Errorf("ApplyTransition: want ErrInvalidExpression, got %v", err)
+			}
+			if err := wf.Apply([]workflow.Place{"shipped"}); !errors.Is(err, workflow.ErrInvalidExpression) {
+				t.Errorf("Apply: want ErrInvalidExpression, got %v", err)
+			}
+		})
+	}
+}
+
+// TestRequirementWhereOnUncoloredToken: a required place may still hold the
+// uncolored presence token a boolean net starts with. It carries no data, so a
+// where clause simply never matches it — it must not fault the evaluation.
+func TestRequirementWhereOnUncoloredToken(t *testing.T) {
+	ship := workflow.MustNewTransition("ship", []workflow.Place{"pool"}, []workflow.Place{"shipped"})
+	ship.SetRequirements(workflow.MustNewRequirement(workflow.RequirementSpec{
+		Place: "pool", Count: "1", Where: "token.ready == true",
+	}))
+	def, err := workflow.NewDefinition(
+		[]workflow.Place{"pool", "shipped"}, []workflow.Transition{*ship})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wf, err := workflow.NewWorkflow("b", def, "pool") // a bare presence token
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := wf.ApplyTransition("ship"); !errors.Is(err, workflow.ErrNotEnabled) {
+		t.Fatalf("a presence token cannot match a where clause: %v", err)
+	}
+	if _, err := wf.CreateToken("pool", workflow.TokenData{"ready": true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := wf.ApplyTransition("ship"); err != nil {
+		t.Fatal(err)
+	}
+	// Only the matching token left; the presence token stays behind, which is
+	// why a pool place should not be seeded with one.
+	if n := wf.TokenCount("pool"); n != 1 {
+		t.Fatalf("want the presence token left behind, got %d tokens", n)
+	}
+}
+
+func TestMustNewRequirementPanicsOnMalformed(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("want a panic")
+		}
+	}()
+	workflow.MustNewRequirement(workflow.RequirementSpec{Place: "p", Count: "len("})
+}
+
+// TestRequirementZeroCountConsumesNothing: a count of zero is met by an empty
+// selection, so the required place keeps everything it holds.
+func TestRequirementZeroCountConsumesNothing(t *testing.T) {
+	wf := poolWorkflow(t, "0", 2)
+	if err := wf.ApplyTransition("ship"); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(wf.GetTokens("pool")); n != 2 {
+		t.Fatalf("a zero count consumes nothing, want 2 left, got %d", n)
+	}
+	if !wf.Marking().HasPlace("shipped") {
+		t.Error("the transition still fired, so its output must be marked")
+	}
+}
+
+// TestRequirementEnabledTransitionsFilters: the enablement view agrees with what
+// firing would actually do.
+func TestRequirementEnabledTransitionsFilters(t *testing.T) {
+	wf := approvalWorkflow(t, "manager", "finance")
+	approve(t, wf, "manager", "alice")
+
+	names := func() []string {
+		ts, err := wf.EnabledTransitions()
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := make([]string, len(ts))
+		for i := range ts {
+			out[i] = ts[i].Name()
+		}
+		return out
+	}
+
+	if got := names(); len(got) != 1 || got[0] != "approve_partial" {
+		t.Fatalf("want only approve_partial enabled, got %v", got)
+	}
+	approve(t, wf, "finance", "bob")
+	if got := names(); len(got) != 2 {
+		t.Fatalf("want both branches enabled once the chain is satisfied, got %v", got)
+	}
+}
+
+// TestRequirementAfterEventReportsConsumedTokensOnly: listeners must see the
+// tokens the firing actually took, not everything that was in the place.
+func TestRequirementAfterEventReportsConsumedTokensOnly(t *testing.T) {
+	wf := poolWorkflow(t, "2", 5)
+	var seen int
+	wf.AddEventListener(workflow.EventAfterTransition, func(ev workflow.Event) error {
+		seen = len(ev.Tokens())
+		return nil
+	})
+	if err := wf.ApplyTransition("ship"); err != nil {
+		t.Fatal(err)
+	}
+	if seen != 2 {
+		t.Fatalf("after-event should report the 2 consumed tokens, got %d", seen)
+	}
+}
+
+// TestRequirementConcurrentFiringsDoNotDoubleConsume: the selection is
+// re-resolved under the write lock, so two racing firings split the pool rather
+// than both taking the same tokens.
+func TestRequirementConcurrentFiringsDoNotDoubleConsume(t *testing.T) {
+	wf := poolWorkflow(t, "2", 6)
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	fired := 0
+	for range 3 {
+		wg.Go(func() {
+			if err := wf.ApplyTransition("ship"); err == nil {
+				mu.Lock()
+				fired++
+				mu.Unlock()
+			}
+		})
+	}
+	wg.Wait()
+
+	if fired != 3 {
+		t.Fatalf("three batches of two fit in a pool of six, %d fired", fired)
+	}
+	if n := len(wf.GetTokens("pool")); n != 0 {
+		t.Fatalf("pool should be empty, %d left", n)
+	}
+	if n := len(wf.GetTokens("shipped")); n != 6 {
+		t.Fatalf("every token must be accounted for, got %d shipped", n)
+	}
+}
+
+// --- construction and validation ---
+
+func TestNewRequirementRejectsMalformedDeclarations(t *testing.T) {
+	cases := map[string]workflow.RequirementSpec{
+		"no place":  {Count: "1"},
+		"no count":  {Place: "pool", Count: "  "},
+		"bad count": {Place: "pool", Count: "len("},
+		"bad where": {Place: "pool", Count: "1", Where: "token."},
+	}
+	for name, spec := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := workflow.NewRequirement(spec); err == nil {
+				t.Fatal("want an error")
+			}
+		})
+	}
+}
+
+func TestDefinitionRejectsIncoherentRequirements(t *testing.T) {
+	req := func(p workflow.Place) workflow.Requirement {
+		return workflow.MustNewRequirement(workflow.RequirementSpec{Place: p, Count: "1"})
+	}
+	places := []workflow.Place{"a", "b", "c"}
+
+	t.Run("place is not an input", func(t *testing.T) {
+		tr := workflow.MustNewTransition("t", []workflow.Place{"a"}, []workflow.Place{"c"})
+		tr.SetRequirements(req("b"))
+		if _, err := workflow.NewDefinition(places, []workflow.Transition{*tr}); err == nil {
+			t.Fatal("a requirement over a place the transition does not consume must be rejected")
+		}
+	})
+
+	t.Run("duplicate place", func(t *testing.T) {
+		tr := workflow.MustNewTransition("t", []workflow.Place{"a"}, []workflow.Place{"c"})
+		tr.SetRequirements(req("a"), req("a"))
+		if _, err := workflow.NewDefinition(places, []workflow.Transition{*tr}); err == nil {
+			t.Fatal("two requirements on one place would be two selectors; must be rejected")
+		}
+	})
+
+	t.Run("with from_any", func(t *testing.T) {
+		tr := workflow.MustNewTransition("t", []workflow.Place{"a", "b"}, []workflow.Place{"c"})
+		tr.SetFromAny(true)
+		tr.SetRequirements(req("a"))
+		if _, err := workflow.NewDefinition(places, []workflow.Transition{*tr}); err == nil {
+			t.Fatal("from_any and require both resolve the input; the combination must be rejected")
+		}
+	})
+}
+
+// TestRequirementRejectsPerTokenFiring: the requirement already selects the
+// tokens, so naming one would be a second, conflicting selector.
+func TestRequirementRejectsPerTokenFiring(t *testing.T) {
+	wf := poolWorkflow(t, "1", 2)
+	tok := wf.GetTokens("pool")[0]
+	err := wf.ApplyTransitionForToken(context.Background(), "ship", tok.ID())
+	if !errors.Is(err, workflow.ErrInvalidTransition) {
+		t.Fatalf("want ErrInvalidTransition, got %v", err)
+	}
+}
+
+func TestSetRequirementsCopiesAndClears(t *testing.T) {
+	tr := workflow.MustNewTransition("t", []workflow.Place{"a"}, []workflow.Place{"b"})
+	reqs := []workflow.Requirement{workflow.MustNewRequirement(workflow.RequirementSpec{Place: "a", Count: "1"})}
+	tr.SetRequirements(reqs...)
+
+	reqs[0] = workflow.MustNewRequirement(workflow.RequirementSpec{Place: "a", Count: "99"})
+	if got := tr.Requirements()[0].Spec().Count; got != "1" {
+		t.Errorf("the transition must not alias the caller's slice, got count %q", got)
+	}
+
+	tr.SetRequirements()
+	if tr.Requirements() != nil {
+		t.Error("SetRequirements() with no arguments should clear")
+	}
+}
+
+// --- fingerprint / diff / diagram ---
+
+func requirementDef(t *testing.T, reqs ...workflow.Requirement) *workflow.Definition {
+	t.Helper()
+	tr := workflow.MustNewTransition("ship", []workflow.Place{"pool", "aux"}, []workflow.Place{"shipped"})
+	tr.SetRequirements(reqs...)
+	def, err := workflow.NewDefinition(
+		[]workflow.Place{"pool", "aux", "shipped"},
+		[]workflow.Transition{*tr},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return def
+}
+
+// TestRequirementIsFingerprinted: a requirement decides when the net can fire,
+// so it is structure — changing one must invalidate persisted instances, and
+// NOT declaring one must leave the old fingerprint untouched.
+func TestRequirementIsFingerprinted(t *testing.T) {
+	base := workflow.RequirementSpec{Place: "pool", Count: "2"}
+	fp := func(specs ...workflow.RequirementSpec) string {
+		reqs := make([]workflow.Requirement, len(specs))
+		for i, s := range specs {
+			reqs[i] = workflow.MustNewRequirement(s)
+		}
+		return requirementDef(t, reqs...).Fingerprint()
+	}
+
+	none, first, second := fp(), fp(base), fp(base)
+	if first == none {
+		t.Fatal("adding a requirement must move the fingerprint")
+	}
+	if first != second {
+		t.Fatal("fingerprints must be stable")
+	}
+
+	for name, changed := range map[string]workflow.RequirementSpec{
+		"count":    {Place: "pool", Count: "3"},
+		"place":    {Place: "aux", Count: "2"},
+		"where":    {Place: "pool", Count: "2", Where: "token.ok"},
+		"distinct": {Place: "pool", Count: "2", Distinct: "role"},
+	} {
+		if fp(changed) == fp(base) {
+			t.Errorf("changing %s must move the fingerprint", name)
+		}
+	}
+
+	// Requirements are a conjunction over distinct places, so declaration order
+	// carries no meaning and must not change the hash.
+	other := workflow.RequirementSpec{Place: "aux", Count: "1"}
+	if fp(base, other) != fp(other, base) {
+		t.Error("requirement order must not affect the fingerprint")
+	}
+}
+
+// TestRequirementDiagramShowsTheJoin: the arity is an expression, not a number
+// of arcs, so a diagram that omits it misstates when the transition can fire.
+func TestRequirementDiagramShowsTheJoin(t *testing.T) {
+	def := requirementDef(t, workflow.MustNewRequirement(workflow.RequirementSpec{
+		Place: "pool", Count: "len(chain)", Distinct: "role", Where: "token.role in chain",
+	}))
+	diagram := def.Diagram()
+	// `>` renders as Mermaid's own numeric entity (`#62;`, no ampersand) — see
+	// escapeMermaidLabel; it is not an HTML entity and must not be "fixed".
+	for _, want := range []string{"pool #62;= len(chain)", "distinct by role", "where token.role in chain"} {
+		if !strings.Contains(diagram, want) {
+			t.Errorf("diagram should mention %q:\n%s", want, diagram)
+		}
+	}
+}

--- a/token_firing.go
+++ b/token_firing.go
@@ -45,16 +45,28 @@ func (w *Workflow) coloredTokensAtLocked(places []Place) []Token {
 // moveMarking consumes the tokens at the from places and produces them at the to
 // places, leaving every other place untouched. This is the token-aware
 // replacement for a whole-marking reset: it preserves colored tokens (and their
-// data) as they flow through a transition.
+// data) as they flow through a transition. It returns the colored tokens it
+// consumed, which is what the after-transition event reports as moved.
+//
+// An input place is normally drained entirely. The exception is a place listed
+// in picked — a dynamic-cardinality join (see Transition.SetRequirements) — from
+// which exactly the selected tokens are taken and the REMAINDER IS LEFT BEHIND,
+// in its original order. The indexes in picked address the place's tokens as
+// they stand right now, so the caller must have resolved them under this same
+// lock hold.
 //
 // When a single output place is involved, consumed colored tokens keep their
 // identities (the common linear/batch case). For an AND-split (multiple outputs)
 // each output receives a fresh copy of every consumed token. When no colored
 // tokens are consumed it falls back to boolean presence (one uncolored token per
 // output). Callers must hold w.mu.
-func (w *Workflow) moveMarking(from, to, resets []Place) {
+func (w *Workflow) moveMarking(from, to, resets []Place, picked map[Place][]int) []Token {
 	var carried []Token
 	for _, f := range from {
+		if idx, partial := picked[f]; partial {
+			carried = append(carried, w.takeTokens(f, idx)...)
+			continue
+		}
 		for _, tok := range w.marking.TokensAt(f) {
 			if isColored(tok) {
 				carried = append(carried, tok)
@@ -71,6 +83,47 @@ func (w *Workflow) moveMarking(from, to, resets []Place) {
 		_ = w.marking.RemovePlace(p)
 	}
 	w.produce(to, carried)
+	return carried
+}
+
+// takeTokens removes the tokens at the given indexes from place and returns the
+// colored ones among them, leaving every other token in the place in its
+// original order. Removal goes through the Marking interface (clear, then
+// re-add the survivors) rather than by token ID, because uncolored presence
+// tokens all share the empty ID and could not be told apart by one.
+//
+// Callers must hold w.mu.
+func (w *Workflow) takeTokens(place Place, idx []int) []Token {
+	if len(idx) == 0 {
+		return nil
+	}
+	all := w.marking.TokensAt(place)
+	take := make(map[int]bool, len(idx))
+	for _, i := range idx {
+		take[i] = true
+	}
+
+	var taken, keep []Token
+	for i, tok := range all {
+		if take[i] {
+			taken = append(taken, tok)
+		} else {
+			keep = append(keep, tok)
+		}
+	}
+
+	_ = w.marking.RemovePlace(place) // no-op error when already empty
+	for _, tok := range keep {
+		w.marking.AddToken(place, tok)
+	}
+
+	var carried []Token
+	for _, tok := range taken {
+		if isColored(tok) {
+			carried = append(carried, tok)
+		}
+	}
+	return carried
 }
 
 // produce places carried tokens at each output place (see moveMarking). When the
@@ -167,6 +220,14 @@ func (w *Workflow) ApplyTransitionForToken(ctx context.Context, transitionName s
 	}
 	if targetTransition == nil {
 		return fmt.Errorf("%w: %s", ErrTransitionNotFound, transitionName)
+	}
+
+	// A dynamic-cardinality join already decides which tokens a firing consumes;
+	// naming one here would be a second, conflicting selector. Reject it rather
+	// than silently letting one win.
+	if len(targetTransition.requires) > 0 {
+		return fmt.Errorf("%w: transition %s declares require, which selects the tokens to consume; per-token firing is not available for it",
+			ErrInvalidTransition, transitionName)
 	}
 
 	from := targetTransition.From()

--- a/transition.go
+++ b/transition.go
@@ -48,6 +48,11 @@ type Transition struct {
 	// atomic firing.
 	resets []Place
 
+	// requires holds the dynamic-cardinality joins over this transition's input
+	// places: enablement conditions whose arity is resolved at fire time rather
+	// than fixed by the arc structure. See SetRequirements.
+	requires []Requirement
+
 	// effects holds the transactional effects this transition declares, in
 	// execution order, resolved against the Manager's EffectRegistry when the
 	// transition fires. They commit with the state change.
@@ -205,6 +210,55 @@ func (t *Transition) Resets() []Place {
 	}
 	out := make([]Place, len(t.resets))
 	copy(out, t.resets)
+	return out
+}
+
+// SetRequirements declares dynamic-cardinality joins over this transition's
+// input places — the "wait for a set whose size is only known at runtime"
+// primitive. Requirements are part of the definition's Fingerprint.
+//
+// A requirement does two things:
+//
+//   - ENABLEMENT. On top of the structural check (its place must be marked),
+//     the place must hold at least `count` tokens matching `where`, counted
+//     `distinct` by a field when one is named. An unmet requirement is
+//     ErrNotEnabled, so an ApplyAny candidate simply loses to its sibling.
+//   - CONSUMPTION. Firing consumes EXACTLY the tokens the requirement selected
+//     and LEAVES THE REMAINDER in the place. This differs from an ordinary input
+//     place, which is drained entirely. Only the selected tokens are carried to
+//     the outputs.
+//
+// Two deliberate restrictions, both enforced by NewDefinition, because each
+// would mean two competing token selectors on one transition:
+//
+//   - a requirement's place must be one of the transition's own inputs, and at
+//     most one requirement may target a given place;
+//   - a transition may not combine requirements with FromAny.
+//
+// Per-token firing (ApplyTransitionForToken) is likewise rejected on a
+// transition with requirements: the requirement IS the token selection.
+//
+// Reset arcs are unchanged and still clear WHOLE places, so a place that is both
+// required and reset ends up empty regardless of what the requirement selected.
+// Requirements are not evaluated by the Due API — like guards, they are honored
+// when the transition actually fires.
+func (t *Transition) SetRequirements(reqs ...Requirement) {
+	if len(reqs) == 0 {
+		t.requires = nil
+		return
+	}
+	t.requires = make([]Requirement, len(reqs))
+	copy(t.requires, reqs)
+}
+
+// Requirements returns the transition's dynamic-cardinality joins. The returned
+// slice is a copy; the requirements themselves are immutable.
+func (t *Transition) Requirements() []Requirement {
+	if len(t.requires) == 0 {
+		return nil
+	}
+	out := make([]Requirement, len(t.requires))
+	copy(out, t.requires)
 	return out
 }
 

--- a/workflow.go
+++ b/workflow.go
@@ -502,6 +502,13 @@ func (w *Workflow) CanTransitionWithContext(ctx context.Context, transitionName 
 		return ErrNotEnabled
 	}
 
+	// Dynamic-cardinality joins: the marked-place check above is structural, so a
+	// transition that waits for a runtime-resolved number of tokens is only
+	// really enabled once its requirements are satisfied too.
+	if err := w.requirementsMet(targetTransition); err != nil {
+		return err
+	}
+
 	// Validate guard constraints
 	tokens := w.coloredTokensAt(consumeFrom)
 	event := NewGuardEvent(ctx, targetTransition, currentPlaces, targetTransition.To(), tokens, w)
@@ -633,6 +640,13 @@ func (w *Workflow) ApplyTransitionWithContext(ctx context.Context, transitionNam
 		return ErrNotEnabled
 	}
 
+	// Dynamic-cardinality joins (see CanTransitionWithContext). This is the
+	// cheap pre-lock answer; it is re-resolved under the write lock below, which
+	// is also where the tokens to consume are selected.
+	if err := w.requirementsMet(targetTransition); err != nil {
+		return err
+	}
+
 	// Validate guard constraints
 	guardTokens := w.coloredTokensAt(consumeFrom)
 	event := NewGuardEvent(ctx, targetTransition, currentPlaces, targetTransition.To(), guardTokens, w)
@@ -683,16 +697,21 @@ func (w *Workflow) ApplyTransitionWithContext(ctx context.Context, transitionNam
 		return ErrNotEnabled
 	}
 
-	// The pre-lock token snapshot may now be stale — the re-resolved consume
-	// set can differ from the pre-lock pick — so refresh it while the tokens
-	// are still at the inputs: the after-event must report the tokens
-	// actually consumed.
-	moved = w.coloredTokensAtLocked(from)
+	// Re-resolve the requirements under the write lock and, with them, exactly
+	// which tokens this firing consumes. The pre-lock answer is not good enough:
+	// a concurrent approval may have landed in the meantime, which would make a
+	// stale index set consume the wrong tokens.
+	picked, err := w.selectRequirementsLocked(targetTransition)
+	if err != nil {
+		return err
+	}
 
 	// Move tokens from the input places to the output places (clearing any
 	// reset places), preserving colored token data and leaving unrelated
-	// places untouched.
-	w.moveMarking(from, to, targetTransition.Resets())
+	// places untouched. The consumed colored tokens replace the pre-lock
+	// snapshot, which may be stale — the after-event must report the tokens
+	// actually consumed.
+	moved = w.moveMarking(from, to, targetTransition.Resets(), picked)
 	// Log the firing while still holding the lock, before the after-event runs
 	// listeners: a listener that errors aborts the caller's function, so
 	// Execute never reaches the drain and the log is discarded with the attempt.
@@ -749,6 +768,14 @@ func (w *Workflow) ApplyWithContext(ctx context.Context, targetPlaces []Place) e
 				}
 			}
 			if matches {
+				// A transition whose dynamic-cardinality join is not satisfied
+				// is not enabled; keep looking for a sibling that is.
+				if _, rerr := w.selectRequirementsLocked(&t); rerr != nil {
+					if errors.Is(rerr, ErrNotEnabled) {
+						continue
+					}
+					return rerr
+				}
 				from = consumed
 				transition = &t
 				break
@@ -773,24 +800,23 @@ func (w *Workflow) ApplyWithContext(ctx context.Context, targetPlaces []Place) e
 
 	// Re-verify enablement under the write lock (see ApplyTransitionWithContext):
 	// a concurrent firing may have consumed the input places while the lock was
-	// released for the before-listeners. The OR-input consume set is
-	// re-resolved for the same reason.
+	// released for the before-listeners. The OR-input consume set and the
+	// dynamic-cardinality selection are re-resolved for the same reason.
 	var enabled bool
 	from, enabled = transition.consumeSet(w.marking.HasPlace)
 	if !enabled {
 		return ErrNotEnabled
 	}
-
-	// The pre-lock token snapshot may now be stale — the re-resolved consume
-	// set can differ from the pre-lock pick — so refresh it while the tokens
-	// are still at the inputs: the after-event must report the tokens
-	// actually consumed.
-	moved = w.coloredTokensAtLocked(from)
+	picked, err := w.selectRequirementsLocked(transition)
+	if err != nil {
+		return err
+	}
 
 	// Move tokens from the input places to the output places (clearing any
 	// reset places), preserving colored token data and leaving unrelated
-	// places untouched.
-	w.moveMarking(from, targetPlaces, transition.Resets())
+	// places untouched. The consumed colored tokens replace the pre-lock
+	// snapshot, which may be stale.
+	moved = w.moveMarking(from, targetPlaces, transition.Resets(), picked)
 	w.recordFired(transition.Name(), from, w.currentPlacesLocked())
 
 	// Fire after transition event (unlock before calling listeners)
@@ -847,13 +873,23 @@ func (w *Workflow) EnabledTransitions() ([]Transition, error) {
 	currentPlaces := w.marking.Places()
 
 	// Check each transition: all inputs marked (AND-join) or any one
-	// (OR-input / FromAny).
+	// (OR-input / FromAny), then any dynamic-cardinality join over those
+	// inputs. An unsatisfied requirement just means "not enabled yet"; a
+	// requirement that cannot be evaluated at all is a definition fault and is
+	// reported rather than silently hiding the transition.
 	for _, trans := range w.definition.Transitions {
 		if _, ok := trans.consumeSet(func(p Place) bool {
 			return slices.Contains(currentPlaces, p)
-		}); ok {
-			enabled = append(enabled, trans)
+		}); !ok {
+			continue
 		}
+		if _, err := w.selectRequirementsLocked(&trans); err != nil {
+			if errors.Is(err, ErrNotEnabled) {
+				continue
+			}
+			return nil, err
+		}
+		enabled = append(enabled, trans)
 	}
 	return enabled, nil
 }

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -106,6 +106,22 @@ workflow:
       from: [string]        # Required: Source places
       to: [string]          # Required: Target places
       guard: string         # Optional: Expression guard
+      after: string         # Optional: Timeout duration, e.g. "72h" (host-driven timers)
+      from_any: bool        # Optional: OR-input — enabled by ANY one marked input, consuming only it
+      resets: [string]      # Optional: Places cleared when this transition fires (cancellation region)
+      require:              # Optional: Dynamic-cardinality joins over input places
+        - place: string     #   Required: which input place's tokens are counted
+          count: string|int #   Required: how many are needed (expression, or a literal)
+          where: string     #   Optional: per-token predicate; `token` is the token's data
+          distinct: string  #   Optional: token field the counted tokens must be unique by
+      effects:              # Optional: effects run INSIDE the state-save transaction, in order
+        - name: string
+          params:
+            key: value
+      after_commit:         # Optional: effects run only after the transaction commits (at-least-once)
+        - name: string
+          params:
+            key: value
       metadata:             # Optional: Transition metadata
         key: value
       notes: string         # Optional: Default notes for history

--- a/yaml/config.go
+++ b/yaml/config.go
@@ -7,6 +7,9 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"slices"
+	"strconv"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -95,6 +98,10 @@ type TransitionConfig struct {
 	Actor        string         `yaml:"actor,omitempty"`         // Default actor for history
 	CustomFields map[string]any `yaml:"custom_fields,omitempty"` // Default custom fields for history
 
+	// Require declares dynamic-cardinality joins: inputs whose arity is
+	// resolved at fire time from an expression rather than fixed by the arcs.
+	Require []RequireConfig `yaml:"require,omitempty"`
+
 	// Effects are the transactional effects this transition fires, in
 	// execution order, resolved against the Manager's EffectRegistry. They
 	// commit with the state change.
@@ -113,6 +120,46 @@ type TransitionConfig struct {
 type EffectConfig struct {
 	Name   string         `yaml:"name"`
 	Params map[string]any `yaml:"params,omitempty"`
+}
+
+// RequireConfig declares one dynamic-cardinality join on a transition: the
+// transition waits until `place` holds `count` tokens matching `where`, counted
+// once per distinct value of a field, and consumes exactly those — leaving the
+// rest of the place behind.
+//
+//	require:
+//	  - place: submitted
+//	    where: "token.role in required_roles"
+//	    distinct: role
+//	    count: "len(required_roles)"
+//
+// See workflow.RequirementSpec for the semantics and workflow.Transition's
+// SetRequirements for the firing rules.
+type RequireConfig struct {
+	Place    string    `yaml:"place"`
+	Count    ExprOrInt `yaml:"count"`
+	Where    string    `yaml:"where,omitempty"`
+	Distinct string    `yaml:"distinct,omitempty"`
+}
+
+// ExprOrInt is an expression string that also accepts a bare YAML integer, so
+// the fixed-arity case reads as `count: 3` rather than forcing quotes around a
+// number that is not really an expression to the author.
+type ExprOrInt string
+
+// UnmarshalYAML accepts a string expression or a plain integer.
+func (e *ExprOrInt) UnmarshalYAML(value *yaml.Node) error {
+	var s string
+	if err := value.Decode(&s); err == nil {
+		*e = ExprOrInt(s)
+		return nil
+	}
+	var i int
+	if err := value.Decode(&i); err != nil {
+		return fmt.Errorf("must be an expression string or an integer, got %q", value.Value)
+	}
+	*e = ExprOrInt(strconv.Itoa(i))
+	return nil
 }
 
 // StorageConfig defines generic storage configuration.
@@ -271,6 +318,24 @@ func (c *Config) Validate() error {
 		for _, reset := range trans.Resets {
 			if !placeSet[reset] {
 				return fmt.Errorf("transition '%s' resets undefined place '%s'", trans.Name, reset)
+			}
+		}
+
+		// A require block that names a place the transition does not consume
+		// from would be an enablement condition invisible in the arcs; the
+		// engine rejects it too, but saying so at load time points at the line.
+		for i, req := range trans.Require {
+			if req.Place == "" {
+				return fmt.Errorf("transition '%s': require[%d] has no place", trans.Name, i)
+			}
+			if !placeSet[req.Place] {
+				return fmt.Errorf("transition '%s' requires undefined place '%s'", trans.Name, req.Place)
+			}
+			if !slices.Contains(trans.From, req.Place) {
+				return fmt.Errorf("transition '%s': require place '%s' is not one of its 'from' places", trans.Name, req.Place)
+			}
+			if strings.TrimSpace(string(req.Count)) == "" {
+				return fmt.Errorf("transition '%s': require on place '%s' has no count", trans.Name, req.Place)
 			}
 		}
 	}

--- a/yaml/loader.go
+++ b/yaml/loader.go
@@ -127,6 +127,16 @@ func (l *Loader) LoadDefinition(config *Config) (*workflow.Definition, error) {
 			transition.SetResets(resets...)
 		}
 
+		// Dynamic-cardinality joins. Expressions are compiled here, so a
+		// malformed count fails the load rather than the first firing.
+		if len(transConfig.Require) > 0 {
+			reqs, err := requirements(transConfig.Name, transConfig.Require)
+			if err != nil {
+				return nil, err
+			}
+			transition.SetRequirements(reqs...)
+		}
+
 		// Add transition metadata
 		if len(transConfig.Metadata) > 0 {
 			for key, value := range transConfig.Metadata {
@@ -230,6 +240,25 @@ func (l *Loader) LoadWorkflow(config *Config, workflowID string) (*workflow.Work
 	}
 
 	return wf, nil
+}
+
+// requirements compiles the declared dynamic-cardinality joins for one
+// transition.
+func requirements(transition string, cfgs []RequireConfig) ([]workflow.Requirement, error) {
+	reqs := make([]workflow.Requirement, len(cfgs))
+	for i, c := range cfgs {
+		r, err := workflow.NewRequirement(workflow.RequirementSpec{
+			Place:    workflow.Place(c.Place),
+			Count:    string(c.Count),
+			Where:    c.Where,
+			Distinct: c.Distinct,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("transition '%s': require[%d]: %w", transition, i, err)
+		}
+		reqs[i] = r
+	}
+	return reqs, nil
 }
 
 // effectDecls converts declared effects, rejecting an empty name: an effect

--- a/yaml/requirement_test.go
+++ b/yaml/requirement_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Ehab Terra
+// SPDX-License-Identifier: MIT
+
+package yaml_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/workflow"
+	"github.com/ehabterra/workflow/yaml"
+)
+
+const approvalYAML = `
+workflow:
+  name: requisition_approval
+  initial_marking: submitted
+  places:
+    - name: submitted
+    - name: approvals
+    - name: approved
+  transitions:
+    - name: approve_final
+      from: [submitted, approvals]
+      to: [approved]
+      resets: [approvals]
+      require:
+        - place: approvals
+          where: "token.role in required_roles"
+          distinct: role
+          count: "len(required_roles)"
+    - name: approve_partial
+      from: [submitted]
+      to: [submitted]
+`
+
+// TestRequireFromYAML: the whole chain-satisfaction pattern is declarative —
+// the host records approvals as tokens and asks the net, it does not compute
+// whether the chain is satisfied.
+func TestRequireFromYAML(t *testing.T) {
+	cfg, err := yaml.LoadConfigFromBytes([]byte(approvalYAML))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	wf, err := yaml.NewLoader().LoadWorkflow(cfg, "req-1")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	wf.SetContext("required_roles", []any{"manager", "finance"})
+
+	reqs := wf.Definition().Transition("approve_final").Requirements()
+	if len(reqs) != 1 {
+		t.Fatalf("require not wired, got %v", reqs)
+	}
+	if got := reqs[0].Spec(); got.Place != "approvals" || got.Distinct != "role" || got.Count != "len(required_roles)" {
+		t.Fatalf("requirement mis-decoded: %+v", got)
+	}
+
+	record := func(role string) {
+		t.Helper()
+		if _, err := wf.CreateToken("approvals", workflow.TokenData{"role": role}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ctx := context.Background()
+	record("manager")
+	fired, err := wf.ApplyAny(ctx, "approve_final", "approve_partial")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fired != "approve_partial" {
+		t.Fatalf("one of two roles: want approve_partial, got %q", fired)
+	}
+
+	record("finance")
+	fired, err = wf.ApplyAny(ctx, "approve_final", "approve_partial")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fired != "approve_final" {
+		t.Fatalf("chain satisfied: want approve_final, got %q", fired)
+	}
+	if places := wf.Marking().Places(); len(places) != 1 || places[0] != "approved" {
+		t.Fatalf("want [approved], got %v", places)
+	}
+}
+
+// TestRequireCountAcceptsBareInteger: a fixed arity should not have to be
+// quoted just because the field also accepts an expression.
+func TestRequireCountAcceptsBareInteger(t *testing.T) {
+	cfg, err := yaml.LoadConfigFromBytes([]byte(`
+workflow:
+  name: batch
+  initial_marking: pool
+  transitions:
+    - name: ship
+      from: [pool]
+      to: [shipped]
+      require:
+        - place: pool
+          count: 3
+`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	wf, err := yaml.NewLoader().LoadWorkflow(cfg, "b1")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if got := wf.Definition().Transition("ship").Requirements()[0].Spec().Count; got != "3" {
+		t.Fatalf("want count \"3\", got %q", got)
+	}
+}
+
+func TestRequireValidation(t *testing.T) {
+	cases := map[string]struct {
+		yaml string
+		want string
+	}{
+		"undefined place": {
+			yaml: `
+workflow:
+  name: w
+  initial_marking: a
+  places:
+    - name: a
+    - name: b
+  transitions:
+    - name: t
+      from: [a]
+      to: [b]
+      require:
+        - place: nowhere
+          count: 1
+`,
+			want: "undefined place",
+		},
+		"place is not an input": {
+			yaml: `
+workflow:
+  name: w
+  initial_marking: a
+  transitions:
+    - name: t
+      from: [a]
+      to: [b]
+      require:
+        - place: b
+          count: 1
+`,
+			want: "not one of its 'from' places",
+		},
+		"missing count": {
+			yaml: `
+workflow:
+  name: w
+  initial_marking: a
+  transitions:
+    - name: t
+      from: [a]
+      to: [b]
+      require:
+        - place: a
+`,
+			want: "has no count",
+		},
+		"missing place": {
+			yaml: `
+workflow:
+  name: w
+  initial_marking: a
+  transitions:
+    - name: t
+      from: [a]
+      to: [b]
+      require:
+        - count: 1
+`,
+			want: "has no place",
+		},
+		"unknown key": {
+			yaml: `
+workflow:
+  name: w
+  initial_marking: a
+  transitions:
+    - name: t
+      from: [a]
+      to: [b]
+      require:
+        - place: a
+          cnt: 1
+`,
+			want: "field cnt not found",
+		},
+		"count is neither expression nor integer": {
+			yaml: `
+workflow:
+  name: w
+  initial_marking: a
+  transitions:
+    - name: t
+      from: [a]
+      to: [b]
+      require:
+        - place: a
+          count: [1, 2]
+`,
+			want: "expression string or an integer",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := yaml.LoadConfigFromBytes([]byte(tc.yaml))
+			if err == nil {
+				t.Fatal("want an error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want an error mentioning %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// TestRequireExpressionCompiledAtLoad: a malformed count must fail the load,
+// not the first firing of the branch that uses it.
+func TestRequireExpressionCompiledAtLoad(t *testing.T) {
+	cfg, err := yaml.LoadConfigFromBytes([]byte(`
+workflow:
+  name: w
+  initial_marking: a
+  transitions:
+    - name: t
+      from: [a]
+      to: [b]
+      require:
+        - place: a
+          count: "len("
+`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	_, err = yaml.NewLoader().LoadDefinition(cfg)
+	if !errors.Is(err, workflow.ErrInvalidExpression) {
+		t.Fatalf("want ErrInvalidExpression at build time, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #34. Next item in the #46 sequence after #45 and #36 (both merged).

## The gap

`Transition.consumeSet` is the single enablement chokepoint and it only asks *"is
this place marked?"* — a boolean. So the number of things a transition waits for is
a property of the drawing. An approval chain's length is not: it comes from the
record's value, and is only known at fire time.

That one gap is what kept the whole approval brain hand-written. Measured in #45:
the ledger, the required-set and the satisfaction test all lived in Go, and
`chainSatisfied` took a `pending` parameter because the host had to ask *"would the
chain be satisfied IF this approval were recorded?"* — simulating the write it was
about to make, because the transition that records the approval is the one whose
guard needs the answer.

## What this adds

```yaml
- name: approve_final
  from: [submitted, approvals]
  to: [approved]
  resets: [approvals]
  require:
    - place: approvals
      where: "token.role in chain"   # only chain members count
      distinct: role                 # two approvals from one role are one
      count: "len(chain)"            # resolved at fire time
```

`count`, `where` and `distinct` compile at definition-build time and evaluate
against the workflow context plus the place's tokens.

**A requirement is both an enablement condition and a token selector.** Firing
consumes exactly the tokens it selected and **leaves the remainder in the place** —
an ordinary input place is drained. That asymmetry is what makes "take a batch of 10
out of a pool of 50" a definition rather than a loop. Selection is deterministic
(the place's own order) and is re-resolved under the write lock, so concurrent
firings split a pool instead of double-consuming it (`-race` test included).

An unmet requirement is `ErrNotEnabled`, so an `ApplyAny` candidate simply loses to
its sibling. A requirement that cannot be *evaluated* — broken expression, count
that is not a non-negative integer — is a hard error, never a silent skip.

### Deliberate restrictions, enforced at `NewDefinition`

Each would put two competing token selectors on one transition:

- `require` + `from_any`
- two requirements on the same place
- a requirement over a place that is not one of the transition's inputs
- `ApplyTransitionForToken` on a transition with requirements

Reset arcs are unchanged and still clear **whole** places.

### Fingerprint compatibility

The requirements segment is written to a transition's structural record only when
present, so definitions written before this feature — including effect-only ones
from #36 — hash byte-for-byte as they did, and persisted instances load without a
migration. Requirement records are sorted (a conjunction over distinct places has no
meaningful order), unlike effects, whose order is execution order.

## Re-measurement (#46 step 3)

`internal/spike/approval` rewritten to use the join and re-measured with an explicit,
scripted counting rule (both columns re-measured the same way; see `COVERAGE.md`):

| | after #36 | after #34 |
|---|---|---|
| Declarative (`workflow.yaml`) | 85 | **109** |
| Go — orchestration | 208 | **151** |
| Go — effect implementations | 180 | **164** |

**50% → 68% declarative by concern; 18% → 26% by line.** The headline is that this
time **Go shrank, by 73 lines**. `chainSatisfied`, `approvedRoles`, `roleInChain` and
the `record_approval` effect (plus the `approvals` table) are *deleted*, not
relocated — #36 moved decisions, #34 removed them. The 70%-by-concern target
`COVERAGE.md` set for #34+#35+#36 is intact with #35 still open.

### An unplanned result

The authorization hole a reviewer caught in the #45 spike is now structurally
unreachable, and not because of the check. The approval is a token created *inside*
the `Execute` cycle, so appending it and firing are one atomic unit: if the net
refuses the firing, `Execute` returns before saving and the token never existed.
`TestRolelessActorCannotApprove` / `TestOutOfChainActorCannotApprove` now assert an
empty pool and pass without the host check being load-bearing — it survives only to
pick between 403 and 409, which is #38's job.

## Tests & docs

- `requirement_test.go`, `yaml/requirement_test.go` — chain satisfaction, distinct
  de-duplication, `where` exclusion, consume-N-leave-remainder with deterministic
  order, every integer kind a count can arrive as (incl. JSON `float64`), runtime
  expression faults across all three enablement paths, concurrency under `-race`,
  fingerprint stability/sensitivity, diagram rendering, and every rejected
  combination. Root package coverage 95.4%.
- Docs: `CPN_GUIDE.md` (new section), README "What ships", `BOUNDARIES.md` §5 (where
  this boundary is *not* — dynamic cardinality is net semantics, org modelling stays
  out), `yaml/README.md` schema block (also filled in `after`/`from_any`/`resets`/
  `effects`/`after_commit`, which had drifted), `ROADMAP.md` (N-token thresholds
  un-parked), `CLAUDE.md` (the not-drained invariant + the lock-hold rule for
  requirement indexes), `CHANGELOG.md`.

`gofmt -s`, `go vet`, `golangci-lint` clean; `go test -p 1 ./...` plus `contrib/otel`
and `examples/expense_approval` green.

> Independent of #50, which adds the README entry #48 shipped without. Different
> sections of the file — the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)