### PR TITLE
docs(readme): add the declared-effects entry to "What ships"

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,36 @@ audit records are exactly-once). The crash windows that remain — and the
 reconciler pattern that closes them — are documented honestly in
 [docs/guides/PRODUCTION_RECIPES.md](docs/guides/PRODUCTION_RECIPES.md).
 
+**Declared effects.** A transition can say what *happens* when it fires, not
+just that it may. `effects:` names ordered effects that run **inside the
+state-save transaction**; `after_commit:` is the phase for work that must not
+be transactional (mail, third-party calls):
+
+```yaml
+- name: approve
+  from: [review]
+  to: [approved]
+  effects:
+    - name: audit
+      params: {action: "article.approve"}
+    - name: outbox
+      params: {event: "article.approved"}
+  after_commit:
+    - name: email
+      params: {to: "submitter", template: "approved"}
+```
+
+Implementations are registered once at startup against an `EffectRegistry`
+(`Validate(def)` catches a name nothing implements *then*, rather than the first
+time a rare branch fires) and wired in with `workflow.WithEffectRegistry`. Each
+receives an `EffectEvent` — instance id, transition, the marking either side of
+the firing, its declared params, and a copy of the instance context. Because
+effects bind to the *transition*, two guarded alternatives out of one place fire
+**different** effect sets, so an `ApplyAny` branch needs no host-side switch. A
+definition that declares effects without a registry is a loud error, never a
+silent skip — and after-commit effects are **at-least-once**: the library
+provides the phase, not the guarantee.
+
 **Definition evolution.** Every save stamps a structural fingerprint and a
 compact shape. When a deployed definition changes, your
 `WithDefinitionMigration` hook receives a **structural diff** — places and


### PR DESCRIPTION
Follow-up to #48 (#36), which shipped declarative effects without a README entry.

`## What ships` is the canonical feature list, and it described the net, colored
tokens, host-driven timers, crash-consistent writes, definition evolution and
cross-instance queries — but not the one thing that lets a definition say what
*happens* when a transition fires. A reader comparing the README against the
CHANGELOG would have concluded effects were not shipped.

Adds a paragraph after **Crash-consistent writes** (the natural neighbour — it
already introduces `WithTxSideEffect`) covering both phases, the `EffectRegistry`
and its startup `Validate`, `EffectEvent`, the per-transition binding that removes
the host-side `ApplyAny` switch, and the two honest caveats: a definition that
declares effects without a registry is a loud error, and after-commit effects are
at-least-once.

The YAML snippet was verified to load and build through the real loader before
committing, per the "README snippets are verified" rule.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)