### PR TITLE
feat: transaction-scoped guards — let a guard read host state inside the firing tx (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Transaction-scoped guards** (issue #35) — a guard can now read host state
+  **inside the firing transaction**, instead of a value the host resolved before
+  the transaction existed and hoped was still true. `tx_guard:` (Go:
+  `NewTxExpressionConstraint`) compiles an expression against an environment a
+  **`TxEnvBuilder`** assembles from the transaction itself; what the builder
+  returns is *added* to the standard guard environment, so an expression can
+  compare something read live against something the host passed in
+  (`actor != submitterOf()`). YAML definitions get one via
+  `yaml.NewLoaderWithTxEnv`; a `tx_guard:` without a builder fails at load.
+  **This inverts the write path when a definition uses it.** Ordinarily a fire
+  happens in memory and a transaction opens only at the save; with a tx-scoped
+  guard `Manager.Execute` runs the WHOLE load → fire → save cycle inside one
+  transaction, so the guard reads the same snapshot the version check will be
+  made against — and `ApplyAny` can route on it, not merely veto a branch already
+  chosen. The trade is explicit: a database transaction is held open across the
+  caller's `fn`, its guards, and every listener they trigger. Keep that code
+  short and free of network calls (documented in `docs/BOUNDARIES.md`).
+  This needs a backend that can lend out its transaction: the new optional
+  **`TxScopedStorage`** / **`TxScopedDueStorage`** interfaces (`BeginScope`,
+  `LoadStateScoped`, `SaveStateScoped`, `SaveStateScopedWithDue`), implemented by
+  both SQL backends and covered by the `storagetest` conformance kit. A
+  definition with tx-scoped guards on a backend without it is a loud
+  `errors.ErrUnsupported`, never a silent evaluation against stale data; so is
+  evaluating one outside a firing transaction, which returns the new
+  **`ErrNoTransaction`**. Retries re-decide: each `ErrConflict` attempt opens a
+  new transaction and re-evaluates. The definition-migration handler is consulted
+  *before* the scope opens, since it is host code that may write to storage.
+  `tx_guard` is part of `Definition.Fingerprint()` and is rendered on the diagram
+  (marked ⛁, because *when* it is evaluated is what differs).
+  Re-measured on `internal/spike/approval`: declarative coverage **68% → 80% by
+  concern**, which clears the ≥70% bar `COVERAGE.md` set for #34+#35+#36 before
+  any of them existed. By line it went **25% → 23%**: three pre-computed booleans
+  left Go and were replaced by more verbose SQL, which is recorded rather than
+  massaged.
+- **`examples/feature_tour/` — the example that must stay current.** One runnable
+  workflow exercising every shipped feature, with one test per feature and a
+  README table mapping feature → where → test. It lives in the root module (no
+  `go.mod` of its own) so `go test -p 1 ./...` always compiles it against the
+  working tree: an example pinned to a published version cannot demonstrate an
+  unreleased feature, and one that never runs cannot fail. Features that
+  genuinely cannot be shown there get a row in its "not demonstrated, and why"
+  table. `CONTRIBUTING.md` and `CLAUDE.md` now require updating it with every
+  user-visible feature. It earned its keep immediately: converting it surfaced
+  the tx-environment design defect noted above.
 - **Dynamic-cardinality joins** (issue #34) — a transition can now be enabled by
   a token **count resolved at fire time**, not fixed by the arc structure. The
   classic AND-join asks only "is this place marked?", so the number of things a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ This is a multi-module repo. The **root module** is dependency-light on purpose.
 | `yaml/` | root | YAML config loader + template resolution + storage-setup helpers. |
 | `storagetest/` | root | **Conformance kit** — one suite every `Storage` backend must pass (`storagetest.Run`). |
 | `workflowtest/` | root | Public test helpers: `AssertMarking`/`AssertHas`, the `Apply` path runner, the `AssertGuard` harness, and a fake `Clock`. |
+| `examples/feature_tour/` | root | **The example that must stay current** — every shipped feature used once, one test each, kept in the root module so it can never rot. See the checklist in its README. |
 | `internal/spike/` | root | **Measurement artifacts, not shipped code and not examples.** `approval/` is the declarative-coverage spike (issue #45): a realistic approval workflow built against only what ships, so the value proposition has a number. `internal/` keeps it out of the public API; it stays in the root module so `go test -p 1 ./...` re-runs it and it can't rot. Excluded in `codecov.yml`. Its tests deliberately assert current *defects* — see `COVERAGE.md` before "fixing" one. |
 | `contrib/otel/` | **separate** go.mod | OpenTelemetry integration. Kept out of the root module so the core stays dependency-free. |
 | `examples/*/` | mostly **separate** go.mod each | Runnable demos (`expense_approval` is the dogfood reference system). |
@@ -82,6 +83,13 @@ use: operate on a **closed `*sql.DB`** to exercise query-error branches; seed a
 - **Branch + PR per change.** Branch off `main`; never commit straight to `main`.
 - **Commit trailer.** End commit messages with:
   `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- **Every user-visible feature updates `examples/feature_tour/`.** It is the one
+  example that must stay current: use the feature in its `workflow.yaml`, add a
+  test named for it, add a row to its README table, and wire any host code in
+  `tour.go`. A feature that cannot be shown there gets a row in the "not
+  demonstrated, and why" table instead — a written-down gap is a decision, a
+  missing one is a bug waiting. It lives in the ROOT module on purpose, so
+  `go test -p 1 ./...` always compiles it against the working tree.
 - **CHANGELOG + docs.** Add a `CHANGELOG.md` entry under **[Unreleased]** for every
   user-visible change. `CHANGELOG.md` and `ROADMAP.md` conflict on nearly every merge
   because parallel branches all append to them — resolve as the **union** of bullets
@@ -116,6 +124,19 @@ use: operate on a **closed `*sql.DB`** to exercise query-error branches; seed a
 - **OR-input / XOR routing.** `from_any: true` enables a transition when *any* one input
   is marked and consumes only that one. `Workflow.ApplyAny(names...)` fires the first
   allowed candidate. Reset arcs (`resets:`) clear whole places when a transition fires.
+- **Two write paths, chosen by the definition.** Ordinarily a fire mutates memory
+  and the transaction opens only at the save. A definition containing a
+  transaction-scoped guard (`tx_guard:` / `NewTxExpressionConstraint`) inverts
+  that: `Manager.Execute` opens ONE transaction and runs load → fire → save inside
+  it, so the guard reads the snapshot the version check is made against. That path
+  needs a `TxScopedStorage` backend, holds the transaction across the caller's `fn`
+  and its listeners, and consults the definition-migration handler BEFORE opening
+  the scope (the handler is host code that may write and would deadlock). Both
+  paths share `Manager.cycle`; keep them sharing it.
+- **A tx env builder ADDS to the standard guard environment, it does not replace
+  it.** A tx guard is nearly always `<read live> vs <passed in>`; replacing the
+  environment made the passed-in half evaluate to nil and the guard answer wrong.
+  This was found by converting the spike, not by review — do not "simplify" it back.
 - **A required place is NOT drained.** Ordinary input places lose every token when a
   transition fires; a place carrying a `require:` (dynamic-cardinality join) loses only
   the tokens the requirement selected, and the remainder stays in declaration order.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,14 @@ Requirements:
    go test -race ./...
    ```
    For changes to an example module, also build it: `(cd examples/<name> && go build ./... && go vet ./...)`.
-5. Add a `CHANGELOG.md` entry under **[Unreleased]**.
-6. Open a pull request and fill in the template.
+5. **If the change is a user-visible feature, update `examples/feature_tour/`** —
+   the one example that must stay current. Use the feature in its
+   `workflow.yaml`, add a test named for it, add a row to its README table, and
+   wire any host code in `tour.go`. If it genuinely cannot be shown there, add a
+   row to that README's "not demonstrated, and why" table instead. It lives in
+   the root module, so `go test -p 1 ./...` already covers it.
+6. Add a `CHANGELOG.md` entry under **[Unreleased]**.
+7. Open a pull request and fill in the template.
 
 ## Standards
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,26 @@ definition that declares effects without a registry is a loud error, never a
 silent skip — and after-commit effects are **at-least-once**: the library
 provides the phase, not the guarantee.
 
+**Guards that read live state.** A guard normally sees only what you put in the
+instance context — resolved before the transaction existed, and stale if
+anything moved in between. `tx_guard:` is evaluated **inside the firing
+transaction**:
+
+```yaml
+- name: submit
+  from: [draft]
+  to: [submitted]
+  tx_guard: "readyGate()"        # queries your tables, in THIS transaction
+```
+
+You supply the environment (`yaml.NewLoaderWithTxEnv`), the library supplies the
+transaction. A definition that uses one runs its whole load → fire → save cycle
+in a single transaction, so the guard decides against the same snapshot the
+version check is made against — and `ApplyAny` can route on it. The trade is
+explicit: that transaction is held open across your `fn` and its listeners, so
+keep them short. Needs a `TxScopedStorage` backend (both SQL backends are);
+anything else is a loud error rather than a quiet stale answer.
+
 **Definition evolution.** Every save stamps a structural fingerprint and a
 compact shape. When a deployed definition changes, your
 `WithDefinitionMigration` hook receives a **structural diff** — places and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -266,7 +266,10 @@ Formerly M3–M8. None is deleted; none proceeds without a dogfood-proven need.
   on a transition that declares `require`, since the requirement already selects
   the tokens).
 - **Static validation / `workflow lint`** (reachability, deadlock detection) — also the
-  precondition for ever claiming "deadlock-free" in marketing.
+  precondition for ever claiming "deadlock-free" in marketing. **Promoted by
+  evidence**: the #45 spike shipped a dead transition that neither the library nor
+  its tests noticed, and review has since found two more correctness holes in the
+  same small net (see `internal/spike/approval/COVERAGE.md`).
 - **HCPN / nested workflows**; **compensation/saga**; **message correlation** beyond
   id-keyed lookup.
 - **Enterprise**: full definition migration (beyond the M3.3 fingerprint), RBAC,

--- a/definition.go
+++ b/definition.go
@@ -196,20 +196,51 @@ func transitionRecord(t *Transition) string {
 	// persisted by earlier versions still load without a migration. Do not
 	// hoist this out of the conditional.
 	//
-	// Requirements ride in the same conditional and are written LAST, again only
-	// when present, so a definition that declares effects but no requirements
-	// still serializes exactly as it did before requirements existed.
+	// Requirements and the transaction-scoped guard ride in the same scheme, each
+	// written only when it or a LATER segment is present. So: no trailing
+	// segments at all for a pre-effects definition, exactly two for an
+	// effects-only one, and so on — every shape that an earlier version could
+	// persist still hashes to the same value it did then.
 	effects := t.Effects()
 	afterCommit := t.AfterCommit()
 	requires := t.Requirements()
-	if len(effects) > 0 || len(afterCommit) > 0 || len(requires) > 0 {
+	txGuard := ""
+	if g, ok := t.Metadata(txGuardMeta); ok {
+		txGuard, _ = g.(string)
+	}
+	if len(effects) > 0 || len(afterCommit) > 0 || len(requires) > 0 || txGuard != "" {
 		writeLenPrefixedList(&rec, effectRecords(effects))
 		writeLenPrefixedList(&rec, effectRecords(afterCommit))
-		if len(requires) > 0 {
-			writeLenPrefixedList(&rec, requirementRecords(requires))
-		}
+	}
+	if len(requires) > 0 || txGuard != "" {
+		writeLenPrefixedList(&rec, requirementRecords(requires))
+	}
+	if txGuard != "" {
+		writeLenPrefixed(&rec, txGuard)
 	}
 	return rec.String()
+}
+
+// txGuardMeta is the transition-metadata key holding the transaction-scoped
+// guard's expression string, mirroring how the plain "guard" string is stored
+// for the fingerprint and for diagrams. The compiled constraint is the thing
+// that actually runs; this is its structural record.
+const txGuardMeta = "tx_guard"
+
+// definitionHasTxGuards reports whether any transition carries a constraint that
+// must be evaluated inside the firing transaction. Manager.Execute needs the
+// answer BEFORE anything fires, to decide whether to open a transaction around
+// the whole cycle and to reject a backend that cannot.
+func definitionHasTxGuards(def *Definition) bool {
+	if def == nil {
+		return false
+	}
+	for i := range def.Transitions {
+		if def.Transitions[i].needsTx() {
+			return true
+		}
+	}
+	return false
 }
 
 // requirementRecords serializes requirements SORTED: requirements are a

--- a/definition.go
+++ b/definition.go
@@ -204,10 +204,7 @@ func transitionRecord(t *Transition) string {
 	effects := t.Effects()
 	afterCommit := t.AfterCommit()
 	requires := t.Requirements()
-	txGuard := ""
-	if g, ok := t.Metadata(txGuardMeta); ok {
-		txGuard, _ = g.(string)
-	}
+	txGuard := t.txGuardRecord()
 	if len(effects) > 0 || len(afterCommit) > 0 || len(requires) > 0 || txGuard != "" {
 		writeLenPrefixedList(&rec, effectRecords(effects))
 		writeLenPrefixedList(&rec, effectRecords(afterCommit))
@@ -222,10 +219,40 @@ func transitionRecord(t *Transition) string {
 }
 
 // txGuardMeta is the transition-metadata key holding the transaction-scoped
-// guard's expression string, mirroring how the plain "guard" string is stored
-// for the fingerprint and for diagrams. The compiled constraint is the thing
-// that actually runs; this is its structural record.
+// guard's expression string. The YAML loader sets it so diagrams can render the
+// expression; the fingerprint does not depend on it (see txGuardRecord).
 const txGuardMeta = "tx_guard"
+
+// txGuardRecord returns the structural record of a transition's
+// transaction-scoped guards: the expression of every tx-scoped
+// ExpressionConstraint installed on it, sorted and joined.
+//
+// It reads the CONSTRAINTS, not the metadata, because the constraints are what
+// decide when the net may fire — and what put the whole cycle inside a
+// transaction. A transition built in Go with NewTxExpressionConstraint but
+// without the matching SetMetadata would otherwise run tx-scoped while
+// fingerprinting as though it had no guard at all, so two definitions differing
+// only in their tx guard would share a fingerprint. Metadata is still folded in,
+// so a hand-set label cannot silently drop out of the hash either.
+func (t *Transition) txGuardRecord() string {
+	var parts []string
+	for _, c := range t.constraints {
+		ec, ok := c.(*ExpressionConstraint)
+		if ok && ec.NeedsTx() {
+			parts = append(parts, ec.expression)
+		}
+	}
+	if meta, ok := t.Metadata(txGuardMeta); ok {
+		if s, _ := meta.(string); s != "" && !slices.Contains(parts, s) {
+			parts = append(parts, s)
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	slices.Sort(parts)
+	return strings.Join(parts, "\x00")
+}
 
 // definitionHasTxGuards reports whether any transition carries a constraint that
 // must be evaluated inside the firing transaction. Manager.Execute needs the

--- a/docs/BOUNDARIES.md
+++ b/docs/BOUNDARIES.md
@@ -72,6 +72,20 @@ out is still everything about *who those participants are* — the chain itself
 is a value you resolve and hand in, and the roles a token carries mean nothing
 to the engine beyond being data it can count and de-duplicate.
 
+## 5a. A transaction-scoped guard holds a transaction open across your code
+
+`tx_guard:` exists because a decision made before a transaction opens can be
+stale by the time it commits (see `NewTxExpressionConstraint`). Paying for that
+means `Manager.Execute` runs the whole load → fire → save cycle inside one
+database transaction — and *your* code runs inside it too: the `fn` you passed,
+the guards, and every event listener they trigger.
+
+The library will not hide that. A listener that makes an HTTP call, or an `fn`
+that waits on something, holds a row lock for as long as it takes; on SQLite it
+holds the writer. Keep the cycle short and local, or use an ordinary guard and
+accept the pre-read. There is no timeout knob, because the right bound is the
+one your database already enforces.
+
 ## 6. Cross-instance atomicity is a seam, not a feature
 
 Saves are atomic per instance. A step spanning two instances is two

--- a/errors.go
+++ b/errors.go
@@ -80,10 +80,14 @@ var (
 
 	// ErrNoTransaction is returned when a transaction-scoped guard (see
 	// NewTxExpressionConstraint) is evaluated with no firing transaction bound —
-	// a bare Workflow.ApplyTransition, a CanTransition probe outside Execute, or
-	// a backend that is not a TxScopedStorage. Such a guard exists precisely
-	// because a stale answer is wrong, so it refuses to give one rather than
-	// silently reading outside the transaction.
+	// a bare Workflow.ApplyTransition, or a CanTransition probe outside Execute.
+	// Such a guard exists precisely because a stale answer is wrong, so it
+	// refuses to give one rather than silently reading outside the transaction.
+	//
+	// A backend that cannot open a scope is a different failure and is reported
+	// differently: Manager.Execute rejects it with errors.ErrUnsupported before
+	// anything fires, so the problem is named as a missing capability rather
+	// than as a guard that happened to have no transaction.
 	ErrNoTransaction = errors.New("no active transaction for a transaction-scoped guard")
 
 	// ErrDefinitionMismatch is returned by the Manager when a persisted instance

--- a/errors.go
+++ b/errors.go
@@ -78,6 +78,14 @@ var (
 	// ErrTokenNotFound is returned when a token cannot be found in a place.
 	ErrTokenNotFound = errors.New("token not found")
 
+	// ErrNoTransaction is returned when a transaction-scoped guard (see
+	// NewTxExpressionConstraint) is evaluated with no firing transaction bound —
+	// a bare Workflow.ApplyTransition, a CanTransition probe outside Execute, or
+	// a backend that is not a TxScopedStorage. Such a guard exists precisely
+	// because a stale answer is wrong, so it refuses to give one rather than
+	// silently reading outside the transaction.
+	ErrNoTransaction = errors.New("no active transaction for a transaction-scoped guard")
+
 	// ErrDefinitionMismatch is returned by the Manager when a persisted instance
 	// was created against a different workflow definition than the one supplied to
 	// load it (the stored definition fingerprint differs). It guards against

--- a/examples/feature_tour/README.md
+++ b/examples/feature_tour/README.md
@@ -1,0 +1,115 @@
+# Feature tour — the example that must stay current
+
+A single runnable workflow exercising **every feature the library ships**, with
+one test per feature. The other examples each illustrate one idea; this one is
+the index.
+
+```bash
+go test ./examples/feature_tour/
+```
+
+## Why it exists
+
+Three things rot independently: the code, the docs, and the belief that a
+feature still works together with the others. This example is the place where
+all three are checked at once. It is deliberately **inside the root module** —
+no `go.mod` of its own — so `go test -p 1 ./...` compiles and runs it against the
+working tree. An example pinned to a published version cannot demonstrate an
+unreleased feature, and an example that never runs cannot fail.
+
+It has already earned its keep: converting it surfaced a design defect in `#35`
+(a transaction-scoped environment that replaced the standard one instead of
+adding to it, so `actor` silently evaluated to nil) that neither the unit tests
+nor review had caught.
+
+## ▶ Adding a feature? Do these four things
+
+1. **Use it in `workflow.yaml`** if it is declarable, with a `# [feature name]`
+   comment saying what it demonstrates.
+2. **Add one test to `tour_test.go`**, named for the feature, asserting the
+   behavior a user would care about — not the implementation.
+3. **Add a row to the table below**, linking the issue.
+4. **Wire it in `tour.go`** if it needs host code (an effect implementation, an
+   environment function, a storage capability).
+
+If a feature genuinely cannot be shown here, say why in the table rather than
+leaving the row out. A gap that is written down is a decision; a gap that is
+missing is a bug waiting.
+
+## What is demonstrated
+
+| Feature | Where | Test |
+|---|---|---|
+| Marking as state (parallel places) | `submit` AND-split | `TestMarkingIsTheState` |
+| Place metadata → status projection | `places:` metadata | `TestMarkingIsTheState` |
+| Guards (expression over context) | `reject` | `TestGuardRejectsWithoutTheRole` |
+| **Transaction-scoped guards** ([#35](https://github.com/ehabterra/workflow/issues/35)) | `submit`, `approve` | `TestTxGuardReadsHostStateInTheFiringTransaction`, `TestSeparationOfDutiesIsReadLive` |
+| **Dynamic-cardinality join** ([#34](https://github.com/ehabterra/workflow/issues/34)) | `approve` `require:` | `TestDynamicCardinalityJoin` |
+| Colored tokens (data-carrying) | the `signoffs` pool | `TestDynamicCardinalityJoin` |
+| AND-join | `approve` | `TestDynamicCardinalityJoin` |
+| OR-input / `from_any` | `archive` | `TestOrInputConsumesOnlyTheMarkedStage` |
+| Reset arcs (cancellation regions) | `reject`, `approve` | `TestResetArcsCancelSiblingBranches` |
+| Host-driven timers (`after:`) | `escalate` | `TestHostDrivenTimers` |
+| **Declared effects** ([#36](https://github.com/ehabterra/workflow/issues/36)) | `effects:` on every transition | `TestEffectsCommitWithTheStateChange` |
+| **After-commit phase** ([#36](https://github.com/ehabterra/workflow/issues/36)) | `after_commit:` | `TestEffectsCommitWithTheStateChange` |
+| Atomic effects (roll back with state) | — | `TestEffectFailureRollsBackTheStateChange` |
+| Effect-registry startup validation | `New` | covered by every test (it runs at wiring) |
+| Definition fingerprint | — | `TestDefinitionFingerprintCatchesADriftedDefinition` |
+| Mermaid diagrams from the definition | — | `TestDiagramIsGeneratedFromTheDefinition` |
+| Strict YAML decoding | `New` | covered by every test |
+| Optimistic concurrency (`Execute` retries) | `Fire` | exercised throughout; contention is covered in the root suite |
+
+### Not demonstrated here, and why
+
+| Feature | Why not |
+|---|---|
+| Postgres backend | The tour runs on SQLite so it needs no Docker. Both backends are held to the same contract by `storagetest`. |
+| Per-token firing (`ApplyTransitionForToken`) | It is mutually exclusive with `require:`, which this net uses. See `examples/cpn_batch_processing`. |
+| Cross-instance token queries (`ListPlaceTokens`) | Needs a fleet; the tour is one instance at a time. |
+| History store | Opt-in and separate from the core; see the `history/` package. |
+| OpenTelemetry (`contrib/otel`) | Separate module, so it cannot be imported from the root one. |
+| Definition migration | Needs two deployed versions of a definition; `TestDefinitionFingerprintCatchesADriftedDefinition` covers the detection half. |
+| Atomic multi-instance transitions | Not shipped — [#37](https://github.com/ehabterra/workflow/issues/37). |
+| Declarative status projection | Not shipped — [#39](https://github.com/ehabterra/workflow/issues/39). `Status()` is host code here, which is the point. |
+| Identifiable guard rejections | Not shipped — [#38](https://github.com/ehabterra/workflow/issues/38). |
+
+## The workflow
+
+A document review: submit splits into legal **and** finance review, sign-offs
+accumulate in a pool until the required set is complete, finance escalates on a
+deadline, and either outcome can be archived.
+
+```mermaid
+flowchart TD
+    p_draft(["draft"])
+    p_legal(["legal"])
+    p_finance(["finance"])
+    p_signoffs(["signoffs"])
+    p_approved(["approved"])
+    p_rejected(["rejected"])
+    p_escalated(["escalated"])
+    p_archived(["archived"])
+    t_submit["submit<br/>⛁ everyLineCosted()"]
+    t_approve["approve<br/>signoffs ≥ len(required_roles)"]
+    t_escalate["⏱ escalate<br/>after 72h"]
+    t_reject["reject"]
+    t_archive["archive"]
+    p_draft --> t_submit
+    t_submit --> p_legal
+    t_submit --> p_finance
+    p_legal --> t_approve
+    p_finance --> t_approve
+    p_signoffs --> t_approve
+    t_approve --> p_approved
+    p_finance --> t_escalate
+    t_escalate --> p_escalated
+    p_legal --> t_reject
+    t_reject --> p_rejected
+    t_reject -. cancels .-> p_finance
+    p_approved --> t_archive
+    p_escalated --> t_archive
+    t_archive --> p_archived
+```
+
+The library renders the real one, with the live marking highlighted:
+`tour.Diagram(ctx, id)`.

--- a/examples/feature_tour/tour.go
+++ b/examples/feature_tour/tour.go
@@ -1,0 +1,312 @@
+// Copyright (c) 2026 Ehab Terra
+// SPDX-License-Identifier: MIT
+
+// Package featuretour is a runnable tour of every feature the library ships.
+//
+// It exists to be UPDATED WITH EVERY FEATURE. Unlike the other examples, which
+// each illustrate one idea, this one is the index: if a user-visible capability
+// is not exercised here, either it is undocumented or it has been quietly
+// broken. See README.md for the checklist a feature PR follows.
+//
+// It deliberately lives in the ROOT module rather than having its own go.mod, so
+// `go test -p 1 ./...` compiles and runs it against the working tree. An example
+// pinned to a published version cannot demonstrate an unreleased feature, and an
+// example that does not run cannot fail.
+package featuretour
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	_ "embed"
+
+	"github.com/ehabterra/workflow"
+	"github.com/ehabterra/workflow/storage"
+	wfyaml "github.com/ehabterra/workflow/yaml"
+)
+
+//go:embed workflow.yaml
+var definitionYAML []byte
+
+// Schema is the HOST's table. The library owns its own; this one exists so the
+// tour has real application state for a transaction-scoped guard to query.
+const Schema = `
+CREATE TABLE IF NOT EXISTS documents (
+	id      TEXT PRIMARY KEY,
+	author  TEXT NOT NULL,
+	costed  INTEGER NOT NULL DEFAULT 1
+);
+CREATE TABLE IF NOT EXISTS audit_log (
+	seq    INTEGER PRIMARY KEY AUTOINCREMENT,
+	doc    TEXT NOT NULL,
+	action TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS outbox (
+	seq   INTEGER PRIMARY KEY AUTOINCREMENT,
+	doc   TEXT NOT NULL,
+	event TEXT NOT NULL
+);
+`
+
+// Tour holds everything one run needs.
+type Tour struct {
+	DB  *sql.DB
+	Def *workflow.Definition
+	Mgr *workflow.Manager
+
+	// Notified collects after-commit notifications so a caller can assert on
+	// them. They are AT-LEAST-ONCE — the library provides the phase, not the
+	// guarantee.
+	Notified []string
+
+	// now is the tour's clock. Timers are host-driven, so the tour owns time
+	// and never sleeps.
+	now time.Time
+}
+
+// New wires the tour: definition, storage, effect registry, manager.
+func New(ctx context.Context, db *sql.DB) (*Tour, error) {
+	// The tour owns the clock, but it starts from the real one: tokens are
+	// stamped with the workflow's own clock as they enter a place, and Manager
+	// does not (yet) let a host inject a clock into an ordinary Execute — only
+	// into FireDue. Starting from now and advancing forward keeps the two
+	// comparable without sleeping.
+	t := &Tour{DB: db, now: time.Now()}
+
+	// [YAML config] Strict decoding: an unknown key is an error with a line
+	// number, never a silently ignored typo.
+	cfg, err := wfyaml.LoadConfigFromBytes(definitionYAML)
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+
+	// [tx_guard environment] The functions a tx_guard: expression may call. Each
+	// reads through the transaction the firing runs inside — which is the whole
+	// point: the answer is as of the state the save will be checked against.
+	// What this returns is ADDED to the standard guard environment, so an
+	// expression can mix a live read with a value the host passed in.
+	def, err := wfyaml.NewLoaderWithTxEnv(func(ctx context.Context, tx any, ev workflow.Event) map[string]any {
+		sqlTx, ok := tx.(*sql.Tx)
+		if !ok {
+			return nil
+		}
+		id := ev.Workflow().Name()
+		return map[string]any{
+			"everyLineCosted": func() bool {
+				var costed int
+				if err := sqlTx.QueryRowContext(ctx,
+					`SELECT costed FROM documents WHERE id = ?`, id).Scan(&costed); err != nil {
+					return false
+				}
+				return costed == 1
+			},
+			"authorOf": func() string {
+				var author string
+				if err := sqlTx.QueryRowContext(ctx,
+					`SELECT author FROM documents WHERE id = ?`, id).Scan(&author); err != nil {
+					return ""
+				}
+				return author
+			},
+		}
+	}).LoadDefinition(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("load definition: %w", err)
+	}
+	t.Def = def
+
+	store, err := storage.NewSQLiteStorage(db)
+	if err != nil {
+		return nil, fmt.Errorf("storage: %w", err)
+	}
+	if err := store.EnsureSchema(ctx); err != nil {
+		return nil, fmt.Errorf("workflow schema: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, Schema); err != nil {
+		return nil, fmt.Errorf("host schema: %w", err)
+	}
+
+	// [effect registry] Implementations are registered once at startup; the
+	// DEFINITION says which transitions fire which, in what order.
+	reg := workflow.NewEffectRegistry()
+	if err := reg.Register("audit", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		_, err := tx.(*sql.Tx).ExecContext(ctx,
+			`INSERT INTO audit_log (doc, action) VALUES (?, ?)`, ev.WorkflowID, ev.Params["action"])
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	if err := reg.Register("outbox", func(ctx context.Context, tx any, ev workflow.EffectEvent) error {
+		_, err := tx.(*sql.Tx).ExecContext(ctx,
+			`INSERT INTO outbox (doc, event) VALUES (?, ?)`, ev.WorkflowID, ev.Params["event"])
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	if err := reg.RegisterAfterCommit("notify", func(ctx context.Context, ev workflow.EffectEvent) error {
+		t.Notified = append(t.Notified, fmt.Sprintf("%v:%v", ev.Params["to"], ev.Params["template"]))
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	// [registry validation] An effect the definition names but nothing
+	// implements fails HERE, not the first time a rare branch fires.
+	if err := reg.Validate(def); err != nil {
+		return nil, fmt.Errorf("effect wiring: %w", err)
+	}
+
+	t.Mgr = workflow.NewManager(workflow.NewRegistry(), store, workflow.WithEffectRegistry(reg))
+	return t, nil
+}
+
+// Now returns the tour's clock. Timers are host-driven: the library answers
+// "what is due at T?" and the host decides what T is.
+func (t *Tour) Now() time.Time { return t.now }
+
+// Advance moves the tour's clock forward.
+func (t *Tour) Advance(d time.Duration) { t.now = t.now.Add(d) }
+
+// CreateDocument inserts the host record and its workflow instance.
+func (t *Tour) CreateDocument(ctx context.Context, id, author string, costed bool) error {
+	c := 0
+	if costed {
+		c = 1
+	}
+	if _, err := t.DB.ExecContext(ctx,
+		`INSERT INTO documents (id, author, costed) VALUES (?, ?, ?)`, id, author, c); err != nil {
+		return err
+	}
+	_, err := t.Mgr.CreateWorkflow(ctx, id, t.Def, "draft")
+	return err
+}
+
+// Fire seeds the instance context and applies transitions through Execute — the
+// load → fire → save cycle with optimistic-concurrency retries. Because the
+// definition carries a tx_guard, that whole cycle runs inside ONE transaction.
+func (t *Tour) Fire(ctx context.Context, id string, seed map[string]any, apply func(*workflow.Workflow) error) error {
+	return t.Mgr.Execute(ctx, id, t.Def, func(wf *workflow.Workflow) error {
+		// Execute may re-run this on ErrConflict, so seeding must be
+		// idempotent — a plain overwrite per attempt is.
+		for k, v := range seed {
+			wf.SetContext(k, v)
+		}
+		return apply(wf)
+	})
+}
+
+// Submit fires the AND-split. Nothing here evaluates the cost-code gate: the
+// tx_guard does, inside the transaction.
+func (t *Tour) Submit(ctx context.Context, id, actor string) error {
+	return t.Fire(ctx, id, map[string]any{"actor": actor}, func(wf *workflow.Workflow) error {
+		return wf.ApplyTransitionWithContext(ctx, "submit")
+	})
+}
+
+// Sign records one sign-off as a colored token in the pool, and tries to
+// approve. The approve transition is simply not ENABLED until the pool holds one
+// token per required role, so there is no host-side "are we done?" check.
+func (t *Tour) Sign(ctx context.Context, id, actor, role string, requiredRoles []string) (bool, error) {
+	roles := make([]any, len(requiredRoles))
+	for i, r := range requiredRoles {
+		roles[i] = r
+	}
+	approved := false
+	err := t.Fire(ctx, id, map[string]any{
+		"actor":          actor,
+		"required_roles": roles,
+	}, func(wf *workflow.Workflow) error {
+		approved = false
+		// Appending the sign-off and firing are one atomic cycle: a firing the
+		// net refuses persists neither.
+		if _, err := wf.CreateToken("signoffs", workflow.TokenData{"role": role, "by": actor}); err != nil {
+			return err
+		}
+		if err := wf.ApplyTransitionWithContext(ctx, "approve"); err != nil {
+			// Not enough sign-offs yet is the normal case, not a failure: the
+			// token still commits, so the pool accumulates.
+			if isNotEnabled(err) {
+				return nil
+			}
+			return err
+		}
+		approved = true
+		return nil
+	})
+	return approved, err
+}
+
+// Reject cancels the sibling branch and the collected sign-offs with one firing.
+func (t *Tour) Reject(ctx context.Context, id, actor string, roles []string) error {
+	return t.Fire(ctx, id, map[string]any{"actor": actor, "roles": roles}, func(wf *workflow.Workflow) error {
+		return wf.ApplyTransitionWithContext(ctx, "reject")
+	})
+}
+
+// Archive fires the OR-input transition from whichever stage is marked.
+func (t *Tour) Archive(ctx context.Context, id string) error {
+	return t.Fire(ctx, id, nil, func(wf *workflow.Workflow) error {
+		return wf.ApplyTransitionWithContext(ctx, "archive")
+	})
+}
+
+// FireDue advances every instance whose deadline has elapsed as of the tour's
+// clock — the host cron, made explicit.
+func (t *Tour) FireDue(ctx context.Context, id string) ([]string, error) {
+	return t.Mgr.FireDue(ctx, id, t.Def, t.now)
+}
+
+// Marking is the library's view of the instance: the set of places holding
+// tokens, which IS the state.
+func (t *Tour) Marking(ctx context.Context, id string) ([]workflow.Place, error) {
+	wf, err := t.Mgr.LoadWorkflow(ctx, id, t.Def)
+	if err != nil {
+		return nil, err
+	}
+	return wf.CurrentPlaces(), nil
+}
+
+// Status projects the marking onto the host's vocabulary through place
+// metadata. The map is still host code (#39).
+func (t *Tour) Status(ctx context.Context, id string) (string, error) {
+	places, err := t.Marking(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	for _, p := range places {
+		if v, ok := t.Def.PlaceMetadata(p, "status"); ok {
+			if s, ok := v.(string); ok {
+				return s, nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// Signoffs returns the tokens currently in the pool.
+func (t *Tour) Signoffs(ctx context.Context, id string) ([]workflow.Token, error) {
+	wf, err := t.Mgr.LoadWorkflow(ctx, id, t.Def)
+	if err != nil {
+		return nil, err
+	}
+	return wf.GetTokens("signoffs"), nil
+}
+
+// Diagram renders the live instance — marking highlighted, guards and joins on
+// the nodes. Generated from the same definition the engine fires, so it cannot
+// drift from behavior.
+func (t *Tour) Diagram(ctx context.Context, id string) (string, error) {
+	wf, err := t.Mgr.LoadWorkflow(ctx, id, t.Def)
+	if err != nil {
+		return "", err
+	}
+	return wf.Diagram(), nil
+}
+
+// isNotEnabled reports the "not yet" condition without treating a guard
+// rejection as one.
+func isNotEnabled(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "not enabled")
+}

--- a/examples/feature_tour/tour_test.go
+++ b/examples/feature_tour/tour_test.go
@@ -1,0 +1,369 @@
+// Copyright (c) 2026 Ehab Terra
+// SPDX-License-Identifier: MIT
+
+package featuretour
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ehabterra/workflow"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Every test below is named for the feature it pins. A feature PR adds one.
+
+func newTour(t *testing.T) (*Tour, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := sql.Open("sqlite3", "file:"+t.Name()+"?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1) // one shared in-memory database behind one lock
+
+	tour, err := New(ctx, db)
+	if err != nil {
+		t.Fatalf("new tour: %v", err)
+	}
+	return tour, ctx
+}
+
+func mustMarking(t *testing.T, tour *Tour, ctx context.Context, id string, want ...workflow.Place) {
+	t.Helper()
+	got, err := tour.Marking(ctx, id)
+	if err != nil {
+		t.Fatalf("marking: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("marking = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("marking = %v, want %v", got, want)
+		}
+	}
+}
+
+func count(t *testing.T, tour *Tour, ctx context.Context, query string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := tour.DB.QueryRowContext(ctx, query, args...).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	return n
+}
+
+// TestMarkingIsTheState — the whole mental model. Two places hold tokens at
+// once, which no status column can represent.
+func TestMarkingIsTheState(t *testing.T) {
+	tour, ctx := newTour(t)
+	if err := tour.CreateDocument(ctx, "d1", "ana", true); err != nil {
+		t.Fatal(err)
+	}
+	mustMarking(t, tour, ctx, "d1", "draft")
+
+	if err := tour.Submit(ctx, "d1", "ana"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	// [AND-split] Legal AND finance, simultaneously.
+	mustMarking(t, tour, ctx, "d1", "finance", "legal")
+
+	// [place metadata → status projection] Cosmetic, and excluded from the
+	// fingerprint, so relabelling never invalidates a running instance.
+	if s, err := tour.Status(ctx, "d1"); err != nil || s != "In review" {
+		t.Fatalf("status = %q (err %v), want %q", s, err, "In review")
+	}
+}
+
+// TestTxGuardReadsHostStateInTheFiringTransaction — #35. Nothing pre-computes
+// the cost-code gate; the guard queries the host table inside the transaction.
+func TestTxGuardReadsHostStateInTheFiringTransaction(t *testing.T) {
+	tour, ctx := newTour(t)
+	if err := tour.CreateDocument(ctx, "d2", "ana", false); err != nil { // not costed
+		t.Fatal(err)
+	}
+	if err := tour.Submit(ctx, "d2", "ana"); !errors.Is(err, workflow.ErrGuardRejected) {
+		t.Fatalf("uncosted submit: want ErrGuardRejected, got %v", err)
+	}
+	mustMarking(t, tour, ctx, "d2", "draft")
+
+	// Fix the host record — no workflow change at all — and it now passes.
+	if _, err := tour.DB.ExecContext(ctx, `UPDATE documents SET costed = 1 WHERE id = 'd2'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := tour.Submit(ctx, "d2", "ana"); err != nil {
+		t.Fatalf("costed submit: %v", err)
+	}
+	mustMarking(t, tour, ctx, "d2", "finance", "legal")
+}
+
+// TestDynamicCardinalityJoin — #34. How many sign-offs are needed is a runtime
+// value, and the transition is not enabled until the pool satisfies it.
+func TestDynamicCardinalityJoin(t *testing.T) {
+	tour, ctx := newTour(t)
+	if err := tour.CreateDocument(ctx, "d3", "ana", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := tour.Submit(ctx, "d3", "ana"); err != nil {
+		t.Fatal(err)
+	}
+
+	required := []string{"legal", "finance"}
+
+	approved, err := tour.Sign(ctx, "d3", "raj", "legal", required)
+	if err != nil {
+		t.Fatalf("first signoff: %v", err)
+	}
+	if approved {
+		t.Fatal("one of two roles must not approve")
+	}
+
+	// [distinct] A second sign-off from the SAME role does not advance it.
+	if approved, err = tour.Sign(ctx, "d3", "sam", "legal", required); err != nil {
+		t.Fatalf("duplicate role: %v", err)
+	} else if approved {
+		t.Fatal("two sign-offs from one role are one role")
+	}
+
+	if approved, err = tour.Sign(ctx, "d3", "kim", "finance", required); err != nil {
+		t.Fatalf("second role: %v", err)
+	} else if !approved {
+		t.Fatal("the chain is satisfied; approve should have fired")
+	}
+	mustMarking(t, tour, ctx, "d3", "approved")
+
+	// [reset arc] The leftover legal sign-off went with the firing.
+	toks, err := tour.Signoffs(ctx, "d3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(toks) != 0 {
+		t.Fatalf("pool = %d tokens, want 0", len(toks))
+	}
+}
+
+// TestSeparationOfDutiesIsReadLive — #35 again, this time as authorization: the
+// author cannot approve, checked against the record rather than a passed-in flag.
+func TestSeparationOfDutiesIsReadLive(t *testing.T) {
+	tour, ctx := newTour(t)
+	if err := tour.CreateDocument(ctx, "d4", "raj", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := tour.Submit(ctx, "d4", "raj"); err != nil {
+		t.Fatal(err)
+	}
+	required := []string{"legal"}
+
+	// raj is the author, so the approve is refused — and because the sign-off
+	// token is created inside the same cycle, it leaves no trace.
+	if _, err := tour.Sign(ctx, "d4", "raj", "legal", required); !errors.Is(err, workflow.ErrGuardRejected) {
+		t.Fatalf("author approving: want ErrGuardRejected, got %v", err)
+	}
+	toks, err := tour.Signoffs(ctx, "d4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(toks) != 0 {
+		t.Fatalf("a refused cycle left %d tokens behind", len(toks))
+	}
+
+	// Anyone else works.
+	if approved, err := tour.Sign(ctx, "d4", "kim", "legal", required); err != nil || !approved {
+		t.Fatalf("non-author signoff: approved=%v err=%v", approved, err)
+	}
+}
+
+// TestResetArcsCancelSiblingBranches — rejecting one branch cancels the other
+// and discards collected sign-offs, atomically.
+func TestResetArcsCancelSiblingBranches(t *testing.T) {
+	tour, ctx := newTour(t)
+	if err := tour.CreateDocument(ctx, "d5", "ana", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := tour.Submit(ctx, "d5", "ana"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tour.Sign(ctx, "d5", "kim", "legal", []string{"legal", "finance"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// [guard] hasRole('legal') over the instance context.
+	if err := tour.Reject(ctx, "d5", "kim", []string{"legal"}); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+	mustMarking(t, tour, ctx, "d5", "rejected")
+
+	toks, err := tour.Signoffs(ctx, "d5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(toks) != 0 {
+		t.Fatalf("reset arc left %d sign-offs behind", len(toks))
+	}
+}
+
+// TestGuardRejectsWithoutTheRole — the ordinary guard path.
+func TestGuardRejectsWithoutTheRole(t *testing.T) {
+	tour, ctx := newTour(t)
+	if err := tour.CreateDocument(ctx, "d6", "ana", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := tour.Submit(ctx, "d6", "ana"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tour.Reject(ctx, "d6", "kim", []string{"finance"}); !errors.Is(err, workflow.ErrGuardRejected) {
+		t.Fatalf("want ErrGuardRejected, got %v", err)
+	}
+}
+
+// TestHostDrivenTimers — the library records when tokens entered a place and
+// answers "what is due at T?". It never fires anything on its own.
+func TestHostDrivenTimers(t *testing.T) {
+	tour, ctx := newTour(t)
+	if err := tour.CreateDocument(ctx, "d7", "ana", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := tour.Submit(ctx, "d7", "ana"); err != nil {
+		t.Fatal(err)
+	}
+
+	fired, err := tour.FireDue(ctx, "d7")
+	if err != nil {
+		t.Fatalf("FireDue before the deadline: %v", err)
+	}
+	if len(fired) != 0 {
+		t.Fatalf("nothing is due yet, %v fired", fired)
+	}
+
+	tour.Advance(73 * time.Hour)
+	fired, err = tour.FireDue(ctx, "d7")
+	if err != nil {
+		t.Fatalf("FireDue: %v", err)
+	}
+	if len(fired) != 1 || fired[0] != "escalate" {
+		t.Fatalf("fired = %v, want [escalate]", fired)
+	}
+	// legal is still in review; finance escalated.
+	mustMarking(t, tour, ctx, "d7", "escalated", "legal")
+}
+
+// TestOrInputConsumesOnlyTheMarkedStage — from_any.
+func TestOrInputConsumesOnlyTheMarkedStage(t *testing.T) {
+	tour, ctx := newTour(t)
+	if err := tour.CreateDocument(ctx, "d8", "ana", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := tour.Submit(ctx, "d8", "ana"); err != nil {
+		t.Fatal(err)
+	}
+	tour.Advance(73 * time.Hour)
+	if _, err := tour.FireDue(ctx, "d8"); err != nil {
+		t.Fatal(err)
+	}
+
+	// archive is enabled by `escalated` alone, and consumes only it.
+	if err := tour.Archive(ctx, "d8"); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	mustMarking(t, tour, ctx, "d8", "archived", "legal")
+}
+
+// TestEffectsCommitWithTheStateChange — declared effects run in the state-save
+// transaction, in declared order, for the transition that actually fired.
+func TestEffectsCommitWithTheStateChange(t *testing.T) {
+	tour, ctx := newTour(t)
+	if err := tour.CreateDocument(ctx, "d9", "ana", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := tour.Submit(ctx, "d9", "ana"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tour.Sign(ctx, "d9", "kim", "legal", []string{"legal"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if n := count(t, tour, ctx, `SELECT COUNT(*) FROM audit_log WHERE doc = 'd9'`); n != 2 {
+		t.Errorf("audit rows = %d, want 2 (submit + approve)", n)
+	}
+	// outbox is declared only on approve.
+	if n := count(t, tour, ctx, `SELECT COUNT(*) FROM outbox WHERE doc = 'd9'`); n != 1 {
+		t.Errorf("outbox rows = %d, want 1", n)
+	}
+	// [after_commit] Ran outside the transaction, after it committed.
+	if len(tour.Notified) != 2 {
+		t.Errorf("notifications = %v, want 2 (submitted + approved)", tour.Notified)
+	}
+}
+
+// TestEffectFailureRollsBackTheStateChange — the guarantee that makes this worth
+// building on rather than a bare FSM.
+func TestEffectFailureRollsBackTheStateChange(t *testing.T) {
+	tour, ctx := newTour(t)
+	if err := tour.CreateDocument(ctx, "d10", "ana", true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tour.DB.ExecContext(ctx, `DROP TABLE audit_log`); err != nil {
+		t.Fatal(err)
+	}
+	if err := tour.Submit(ctx, "d10", "ana"); err == nil {
+		t.Fatal("submit should fail when its effect fails")
+	}
+	// The transition fired in memory; nothing persisted.
+	mustMarking(t, tour, ctx, "d10", "draft")
+}
+
+// TestDefinitionFingerprintCatchesADriftedDefinition — every save stamps a
+// structural fingerprint, so an instance cannot silently run against a
+// definition it was not created under.
+func TestDefinitionFingerprintCatchesADriftedDefinition(t *testing.T) {
+	tour, ctx := newTour(t)
+	if err := tour.CreateDocument(ctx, "d11", "ana", true); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := workflow.NewDefinition(
+		append(tour.Def.AllPlaces(), "extra"), tour.Def.AllTransitions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed.Fingerprint() == tour.Def.Fingerprint() {
+		t.Fatal("fixture: the definitions should differ")
+	}
+	if _, err := tour.Mgr.LoadWorkflow(ctx, "d11", changed); !errors.Is(err, workflow.ErrDefinitionMismatch) {
+		t.Fatalf("want ErrDefinitionMismatch, got %v", err)
+	}
+}
+
+// TestDiagramIsGeneratedFromTheDefinition — always-accurate diagrams: the same
+// definition the engine fires, with the live marking highlighted.
+func TestDiagramIsGeneratedFromTheDefinition(t *testing.T) {
+	tour, ctx := newTour(t)
+	if err := tour.CreateDocument(ctx, "d12", "ana", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := tour.Submit(ctx, "d12", "ana"); err != nil {
+		t.Fatal(err)
+	}
+
+	diagram, err := tour.Diagram(ctx, "d12")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"flowchart TD",          // it is Mermaid
+		"class p_legal current", // the live marking is highlighted
+		"⛁",                     // the tx guard is visible
+		"signoffs #62;=",        // the dynamic join is visible (Mermaid escapes >)
+		"cancels",               // reset arcs are visible
+	} {
+		if !strings.Contains(diagram, want) {
+			t.Errorf("diagram should contain %q:\n%s", want, diagram)
+		}
+	}
+}

--- a/examples/feature_tour/workflow.yaml
+++ b/examples/feature_tour/workflow.yaml
@@ -1,0 +1,108 @@
+# The feature tour's net. Every DECLARATIVE feature the library ships appears
+# here at least once, and each is labelled with the section of README.md that
+# explains it.
+#
+# ── ADDING A FEATURE? ────────────────────────────────────────────────────────
+# If it is declarable, it belongs in this file, is asserted in tour_test.go, and
+# is listed in README.md's table. See that file's checklist.
+# ─────────────────────────────────────────────────────────────────────────────
+workflow:
+  name: feature_tour
+
+  # [initial marking] A place with no token list gets a presence token.
+  initial_marking: draft
+
+  # [place metadata] Cosmetic, and deliberately NOT part of the fingerprint, so
+  # a status label or a diagram group can change without invalidating running
+  # instances. `signoffs` carries none because it is a pool, not a state.
+  places:
+    - name: draft
+      metadata: {status: Draft, editable: true}
+    - name: legal
+      metadata: {status: In review, diagram_group: Review}
+    - name: finance
+      metadata: {status: In review, diagram_group: Review}
+    - name: signoffs
+    - name: approved
+      metadata: {status: Approved}
+    - name: rejected
+      metadata: {status: Rejected, editable: true}
+    - name: escalated
+      metadata: {status: Escalated}
+    - name: archived
+      metadata: {status: Archived}
+
+  transitions:
+    # [AND-split] One transition, two outputs: legal AND finance review at once.
+    # [tx_guard] Evaluated INSIDE the firing transaction, so it queries the
+    #   host's own table rather than reading a boolean the host pre-computed.
+    # [effects] Run in the state-save transaction, in declared order.
+    # [after_commit] Runs only once that transaction has committed (at-least-once).
+    - name: submit
+      from: [draft]
+      to: [legal, finance]
+      tx_guard: "everyLineCosted()"
+      effects:
+        - name: audit
+          params: {action: "doc.submit"}
+      after_commit:
+        - name: notify
+          params: {to: "reviewers", template: "submitted"}
+
+    # [guard] The ordinary kind: an expression over instance context, evaluated
+    #   everywhere including Can/EnabledTransitions.
+    # [reset arcs] Rejecting one branch cancels the sibling branch and discards
+    #   the signoffs collected so far — atomically, in the same firing.
+    - name: reject
+      from: [legal]
+      to: [rejected]
+      guard: "hasRole('legal')"
+      resets: [finance, signoffs]
+      effects:
+        - name: audit
+          params: {action: "doc.reject"}
+
+    # [timers] Host-driven: the library records when tokens entered a place and
+    #   answers "what is due at time T?". It never fires this on its own.
+    - name: escalate
+      from: [finance]
+      to: [escalated]
+      after: 72h
+      effects:
+        - name: audit
+          params: {action: "doc.escalate"}
+
+    # [AND-join] Enabled only when legal, finance AND signoffs are all marked.
+    # [dynamic-cardinality join] ...and the pool holds one signoff per required
+    #   role, where HOW MANY is len(required_roles) — a runtime value. Firing
+    #   consumes exactly those tokens and leaves any others behind; the reset arc
+    #   then discards the remainder.
+    # [tx_guard] Separation of duties, read live: the author cannot approve.
+    - name: approve
+      from: [legal, finance, signoffs]
+      to: [approved]
+      tx_guard: "actor != authorOf()"
+      resets: [signoffs]
+      require:
+        - place: signoffs
+          where: "token.role in required_roles"
+          distinct: role
+          count: "len(required_roles)"
+      effects:
+        - name: audit
+          params: {action: "doc.approve"}
+        - name: outbox
+          params: {event: "doc.approved"}
+      after_commit:
+        - name: notify
+          params: {to: "author", template: "approved"}
+
+    # [OR-input / from_any] One transition serving two stages: archive whichever
+    #   of approved/escalated is marked, consuming only that one.
+    - name: archive
+      from: [approved, escalated]
+      to: [archived]
+      from_any: true
+      effects:
+        - name: audit
+          params: {action: "doc.archive"}

--- a/expression.go
+++ b/expression.go
@@ -124,9 +124,11 @@ func NewExpressionConstraintWithEnv(exprStr string, envBuilder func(Event) map[s
 // transaction instead of a value read before it opened.
 //
 // A definition containing one requires Manager.Execute against a
-// TxScopedStorage backend. Evaluating it outside a firing transaction — a bare
-// Workflow.ApplyTransition, a CanTransition probe, a non-transactional backend —
-// fails with ErrNoTransaction rather than quietly answering from stale state.
+// TxScopedStorage backend; Execute rejects a backend that is not one with
+// errors.ErrUnsupported, before anything fires. Evaluating the guard itself with
+// no firing transaction — a bare Workflow.ApplyTransition, or a CanTransition
+// probe outside Execute — fails with ErrNoTransaction rather than quietly
+// answering from stale state.
 // Keep ordinary preconditions in a plain guard, which works everywhere; reach
 // for this one only where staleness is a correctness problem.
 func NewTxExpressionConstraint(exprStr string, builder TxEnvBuilder) (*ExpressionConstraint, error) {

--- a/expression.go
+++ b/expression.go
@@ -4,6 +4,7 @@
 package workflow
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"slices"
@@ -18,6 +19,58 @@ type ExpressionConstraint struct {
 	expression string
 	program    *vm.Program
 	envBuilder func(Event) map[string]any
+
+	// txEnvBuilder, when set, makes this a TRANSACTION-SCOPED constraint: it is
+	// handed the transaction the firing runs inside, so the functions it puts in
+	// the environment can query host state as of that transaction. It is
+	// mutually exclusive with envBuilder.
+	txEnvBuilder TxEnvBuilder
+}
+
+// TxEnvBuilder contributes the transaction-backed part of a guard environment.
+// tx is the backend's own handle — *sql.Tx for the shipped SQL backends — and is
+// never nil when the builder is called.
+//
+// What it returns is ADDED to the standard guard environment (workflow context,
+// `token`/`tokens`, hasRole and friends), overriding same-named entries. So a
+// guard can compare something read live against something the host passed in —
+// `actor != submitterOf()` — which is what most of them do.
+//
+// The point is to close the gap between deciding and committing. Without it a
+// host resolves its decision inputs, THEN fires, and anything that changed in
+// between is silently stale; the values it injected into the workflow context
+// are a snapshot of a moment that has passed. A builder given the transaction
+// can instead expose functions that answer as of the transaction that is about
+// to commit:
+//
+//	wfyaml.NewLoaderWithTxEnv(func(ctx context.Context, tx any, ev workflow.Event) map[string]any {
+//	    q := sqlc.New(tx.(*sql.Tx))
+//	    return map[string]any{
+//	        "readyGate": func() bool { return q.EveryLineHasACostCode(ctx, ev.Workflow().Name()) },
+//	    }
+//	})
+//
+// RETRIES: Manager.Execute retries the whole load-fire-save cycle on
+// ErrConflict, and each attempt opens a NEW transaction, so the builder runs
+// again and the guard re-decides against the state the winning attempt will
+// actually commit against. That is the intended behavior — never cache the
+// answer across attempts.
+type TxEnvBuilder func(ctx context.Context, tx any, ev Event) map[string]any
+
+// TxScopedConstraint is a Constraint that must be evaluated inside the firing
+// transaction. Manager.Execute detects a definition containing one and runs the
+// whole load → fire → save cycle inside a single transaction (which requires a
+// TxScopedStorage backend), rather than firing in memory and opening the
+// transaction only at the save.
+//
+// Implement it on a custom Go constraint to opt into the same treatment;
+// NewTxExpressionConstraint is the expression-language version.
+type TxScopedConstraint interface {
+	Constraint
+
+	// NeedsTx reports that this constraint cannot be evaluated without the
+	// firing transaction.
+	NeedsTx() bool
 }
 
 // NewExpressionConstraint creates a new expression constraint.
@@ -65,10 +118,48 @@ func NewExpressionConstraintWithEnv(exprStr string, envBuilder func(Event) map[s
 	}, nil
 }
 
+// NewTxExpressionConstraint creates a TRANSACTION-SCOPED expression constraint:
+// the environment is built by a TxEnvBuilder that receives the transaction the
+// firing runs inside, so the guard can consult host state as of that
+// transaction instead of a value read before it opened.
+//
+// A definition containing one requires Manager.Execute against a
+// TxScopedStorage backend. Evaluating it outside a firing transaction — a bare
+// Workflow.ApplyTransition, a CanTransition probe, a non-transactional backend —
+// fails with ErrNoTransaction rather than quietly answering from stale state.
+// Keep ordinary preconditions in a plain guard, which works everywhere; reach
+// for this one only where staleness is a correctness problem.
+func NewTxExpressionConstraint(exprStr string, builder TxEnvBuilder) (*ExpressionConstraint, error) {
+	if exprStr == "" {
+		return nil, fmt.Errorf("expression cannot be empty")
+	}
+	if builder == nil {
+		return nil, fmt.Errorf("TxEnvBuilder cannot be nil")
+	}
+
+	program, err := expr.Compile(exprStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile expression '%s': %w", exprStr, err)
+	}
+
+	return &ExpressionConstraint{
+		expression:   exprStr,
+		program:      program,
+		txEnvBuilder: builder,
+	}, nil
+}
+
+// NeedsTx reports whether this constraint is transaction-scoped (built with
+// NewTxExpressionConstraint). It implements TxScopedConstraint.
+func (c *ExpressionConstraint) NeedsTx() bool { return c.txEnvBuilder != nil }
+
 // Validate evaluates the expression and returns error if transition should be blocked.
 func (c *ExpressionConstraint) Validate(event Event) error {
 	// Build evaluation environment from event
-	env := c.envBuilder(event)
+	env, err := c.buildEnv(event)
+	if err != nil {
+		return err
+	}
 
 	// Evaluate expression
 	result, err := expr.Run(c.program, env)
@@ -87,6 +178,32 @@ func (c *ExpressionConstraint) Validate(event Event) error {
 	}
 
 	return nil
+}
+
+// buildEnv assembles the evaluation environment. For a transaction-scoped
+// constraint it demands the firing transaction: a guard whose whole purpose is
+// to be current must never fall back to evaluating without one.
+func (c *ExpressionConstraint) buildEnv(event Event) (map[string]any, error) {
+	if c.txEnvBuilder == nil {
+		return c.envBuilder(event), nil
+	}
+	wf := event.Workflow()
+	if wf == nil {
+		return nil, fmt.Errorf("%w: transaction-scoped guard %q has no workflow", ErrNoTransaction, c.expression)
+	}
+	tx := wf.tx()
+	if tx == nil {
+		return nil, fmt.Errorf("%w: guard %q must be evaluated inside a firing transaction — "+
+			"drive it with Manager.Execute against a TxScopedStorage backend", ErrNoTransaction, c.expression)
+	}
+	// The builder's entries are ADDED to the standard environment rather than
+	// replacing it, because a transaction-scoped guard is almost always a mix:
+	// something read live (submitterOf()) compared against something the host
+	// passed in (actor). Making the builder responsible for re-supplying the
+	// context would turn every such guard into a silent nil comparison.
+	env := defaultEnvBuilder(event)
+	maps.Copy(env, c.txEnvBuilder(event.Context(), tx, event))
+	return env, nil
 }
 
 // defaultEnvBuilder creates the default evaluation environment from the event.

--- a/internal/spike/approval/COVERAGE.md
+++ b/internal/spike/approval/COVERAGE.md
@@ -33,47 +33,36 @@ what guards them, what effects they fire, and what state results. Schema, record
 CRUD, the role ladder config, and the user directory are domain code that would
 exist with or without the library, and are excluded from both sides.
 
-> **Re-measured after #34 (dynamic-cardinality join) landed.** Both columns below
-> come from the same reproducible rule (see *Re-running the measurement*), so the
-> delta is apples-to-apples. The absolute numbers differ slightly from those
-> reported in the #36 PR, which applied the same rule by hand and did not count
-> each function's doc comment; the earlier figures are kept in the footnote.
+> **Re-measured after #35 (transaction-scoped guards) landed** — the last of the
+> three features #46 said would decide whether this library is worth adopting.
+> All columns come from the same reproducible rule (see *Re-running the
+> measurement*), with one bucket renamed; that rename is called out below because
+> it changes what the middle row means.
 
-| | after #36 | after #34 |
-|---|---|---|
-| **Declarative** (`workflow.yaml`) | 85 | **109** |
-| **Go — orchestration** (branching, ledger, satisfaction, binding) | 208 | **157** |
-| **Go — effect implementations** (the SQL itself) | 180 | **164** |
-| **Total Go** | 388 | **321** |
+| | after #36 | after #34 | after #35 |
+|---|---|---|---|
+| **Declarative** (`workflow.yaml`) | 85 | 109 | **111** |
+| **Go — orchestration** (sequencing, branching, satisfaction) | 208 | 157 | **159** |
+| **Go — host implementations** (the SQL itself: effects, and now guard queries) | 180 | 164 | **222** |
+| **Total Go** | 388 | 321 | **381** |
 
-### **Declarative coverage: 25% by line** (was 18%)
+### **Declarative coverage: 23% by line** — *down* from 25%
 
-Counting orchestration only — the sequencing decisions, excluding the SQL that
-would exist under any design — it is **41%**, up from 29%.
+Report the uncomfortable number first. **Total Go went UP by 60 lines**, and it
+is not an accounting trick: the bucket rename moved `txGuardEnv` (58 lines) into
+host implementations, and that function is genuinely new code.
 
-The headline this time is that **Go went down**, by 67 lines. #36 relocated
-decisions from Go into the definition without deleting much; #34 deleted code
-outright. Three functions and an entire effect are simply gone:
+What it replaced was smaller. `readyGate(req)` was a 12-line pure function over
+an already-loaded struct, and `sod_ok` was one expression. What replaced them is
+three SQL queries with their own error handling, registered once at startup. The
+same thing happened at #36 — a registry entry is more verbose than the closure
+it replaces — and it is the honest cost of making something addressable by a
+definition instead of inlined in a call path.
 
-- `chainSatisfied` (26 lines) — the AND-join whose arity was `len(chain)`,
-  including the `pending` parameter that forced the host to *simulate the write
-  it was about to make*
-- `approvedRoles` (17 lines) — the ledger read that fed it
-- `roleInChain` (9 lines) — the authorization check the net could not express
-- the `record_approval` effect and the `approvals` table it wrote (16 lines net)
+The line count is measuring the wrong thing here, which is exactly why this
+document has always carried a second measure.
 
-What replaced them is four lines of YAML:
-
-```yaml
-require:
-  - place: approvals
-    where: "token.role in chain"
-    distinct: role
-    count: "len(chain)"
-```
-
-Line-counting YAML against Go flatters neither side — YAML is denser per line —
-so here is the same question asked by **concern**, which is the fairer measure:
+### **Declarative coverage: 80% by concern** (14 full + 4 half of 20) — was 68%
 
 | # | Workflow concern | Where it lives |
 |---|---|---|
@@ -82,13 +71,13 @@ so here is the same question asked by **concern**, which is the fairer measure:
 | 3 | Initial marking | ✅ declarative |
 | 4 | Terminal detection | ✅ declarative |
 | 5 | Guard expressions | ✅ declarative |
-| 6 | Guard *inputs* (`ready`, `sod_ok`, ~~`chain_satisfied`~~) | ⚠️ half since #34 — one of the three is gone; the rest need #35 |
-| 7 | Ready-gate evaluation | ❌ Go (#35) |
-| 8 | Approval chain resolution | ❌ Go — the ladder is domain policy, but the net now consumes it as a *value* rather than an answer |
-| 9 | Approvals ledger | ✅ **declarative since #34** — the pool of colored tokens IS the ledger |
-| 10 | Chain satisfaction (dynamic AND-join) | ✅ **declarative since #34** |
-| 11 | Separation of duties | ⚠️ half — guard declarative, input Go |
-| 12 | Last-resort override | ⚠️ half since #34 — a declared transition with its own guard and effects; the input is Go |
+| 6 | Guard *inputs* (~~`ready`~~, ~~`sod_ok`~~, ~~`chain_satisfied`~~) | ✅ **declarative since #35** — all three pre-computed booleans are gone |
+| 7 | Ready-gate evaluation | ✅ **declarative since #35** — `tx_guard: "readyGate()"` |
+| 8 | Approval chain resolution | ⚠️ half — the ladder is host policy by design, but since #35 the net verifies its INPUT in the transaction (`amountOf() == amount`) |
+| 9 | Approvals ledger | ✅ declarative since #34 — the pool of colored tokens IS the ledger |
+| 10 | Chain satisfaction (dynamic AND-join) | ✅ declarative since #34 |
+| 11 | Separation of duties | ✅ **declarative since #35** — `tx_guard: "actor != submitterOf()"`, read live |
+| 12 | Last-resort override | ⚠️ half — a declared transition; the eligibility input is org data |
 | 13 | Branch selection (partial vs final) | ✅ declarative since #36 |
 | 14 | Per-transition effect binding | ✅ declarative since #36 |
 | 15 | Effect ordering | ✅ declarative since #36 |
@@ -96,20 +85,19 @@ so here is the same question asked by **concern**, which is the fairer measure:
 | 17 | Status projection | ⚠️ half since #36 — *when* it runs is declared, the place→status map is still host code (#39) |
 | 18 | Multi-instance cascade | ❌ Go — **and incorrect**, see friction 5 |
 | 19 | Guard rejection → error mapping | ❌ Go (#38) |
-| 20 | Actor authorization (is this actor even in the chain?) | ⚠️ half since #34 — `role in chain` is the guard; the directory lookup is Go |
+| 20 | Actor authorization | ⚠️ half — `role in chain` is the guard; the directory lookup is org data |
 
-### **Declarative coverage: 68% by concern** (11 full + 5 half of 20) — was 50%
+**The target is met.** This document set "**above 70%** by concern once #34, #35
+and #36 have all landed" before any of them existed. All three are in, and it is
+**80%**.
 
-The target this document set after #36 was "**above 70%** by concern once #34,
-#35 and #36 have all landed". Two of the three are in and it stands at 68%, so
-the estimate is holding: #35 is what carries concerns 6, 7, 11 and 20, and it is
-the only one of the three still open.
-
-Read the shape rather than the number. What #34 moved is not plumbing — it is
-the part that made this workflow hard. The net now holds the ledger, counts it,
-de-duplicates it by role, and refuses an approver the chain does not require.
-What is left below the line is the *inputs* to guards (#35), the multi-instance
-cascade (#37), and error identity (#38).
+Read what is left, because the shape of the residue is the real result. Of the
+six concerns not fully declarative, **four are deliberately out of scope**: the
+role ladder, the directory, and last-resort eligibility are org modelling, which
+`docs/BOUNDARIES.md` says stays in the host and which this measurement agrees
+should. The two that are genuine gaps are the multi-instance cascade (#37) and
+error identity (#38) — both small, both filed, neither load-bearing for the
+question #46 asked.
 
 ### An unplanned result: the authorization hole closed itself
 
@@ -179,26 +167,63 @@ out-of-chain approval can never count toward the join, and `approve_partial`'s
 `role in chain` guard refuses to record one at all. See *An unplanned result*
 above for why this is now structural rather than a check.
 
-**What it did not solve.** `chain` still arrives from the host via `SetContext`,
-read before the transaction opens — so the *value* the join counts against can
-still be stale. That is #35, and #34 does not touch it.
+**What #34 did not solve, and #35 did.** `chain` still arrives from the host via
+`SetContext`, read before the transaction opens, so the value the join counts
+against could be stale. #35 does not move the ladder into the definition — it is
+org policy and stays out by design — but the approve branches now carry
+`amountOf() == amount`, which verifies inside the transaction that the input the
+chain was derived from has not moved. See friction 2.
 
-### 2 — Guards cannot query ([#35](https://github.com/ehabterra/workflow/issues/35)) · ~37 lines, plus a race — **now the top item**
+**One thing still not expressible.** A `require:` expression is evaluated against
+the workflow context and the place's tokens, NOT against the tx-guard
+environment — so `count:` cannot itself call a query. Here that is covered by the
+guard checking the chain's input instead, but a join whose arity is a pure
+function of host data would still need the host to resolve it. Worth a follow-up
+issue rather than a workaround.
 
-Every guard in `workflow.yaml` still reads a boolean or a value the host
-pre-computed: `ready`, `sod_ok`, `chain`. None can be computed by the guard,
-because `envBuilder` receives an `Event` and an `Event` has no transaction.
+### 2 — Guards cannot query ([#35](https://github.com/ehabterra/workflow/issues/35)) — ✅ **RESOLVED**
 
-#34 changed the *shape* of this problem without solving it. The satisfaction
-test is no longer a pre-computed answer — the net works it out from tokens it
-holds, under the same lock as the firing, so the ledger half of the race is
-closed. What remains is the *inputs*: `chain` is derived from `req.Amount`, read
-outside the transaction. If the requisition's value changes between the read and
-the fire, the join counts against a chain that is no longer the right one.
+*Was: ~37 lines, plus a race with nowhere to close it.*
 
-That is a narrower race than before (it needs the record to change, not merely a
-concurrent approval), but it is the same defect, and there is still nowhere to
-put an in-transaction re-check.
+Every guard used to read a boolean the host had pre-computed — `ready`,
+`sod_ok` — because `envBuilder` receives an `Event` and an `Event` has no
+transaction. Worse than the volume was the timing: `Approve` did its whole
+phase-1 computation OUTSIDE the transaction and then fired, so a value that
+changed in between was silently stale. Optimistic concurrency catches a
+concurrent *save*; it does not catch a stale *decision input*.
+
+`tx_guard:` closes it. The expression is evaluated inside the firing
+transaction, against an environment the host builds FROM that transaction:
+
+```yaml
+- name: submit
+  tx_guard: "readyGate()"                                   # queries the lines
+
+- name: approve_final
+  tx_guard: "actor != submitterOf() && amountOf() == amount" # reads the record
+```
+
+`readyGate` and `sod_ok` are gone from Go entirely. The `amountOf() == amount`
+half is the interesting one: the approval chain is derived from the
+requisition's value, which is host policy and stays in Go — but the guard now
+verifies, inside the transaction, that the value the chain was derived from has
+not moved. `TestStaleChainIsRefusedInTheTransaction` raises a requisition from
+1,000 to 20,000 between the read and the fire; the firing that would have
+approved a 20,000 requisition on one signature is refused, and leaves no trace.
+
+**What it cost.** A transaction is now held open across the caller's `fn`, its
+guards, and every listener they trigger — documented as a boundary rather than
+hidden. And the query environment is more code than the booleans it replaced
+(see the headline figures); this is the second time a feature has traded volume
+for addressability, and it is worth saying plainly both times.
+
+**A design defect it surfaced.** The first implementation had the builder
+*replace* the guard environment. Every real tx guard turned out to compare
+something read live against something the host passed in (`actor !=
+submitterOf()`), so replacing meant `actor` silently evaluated to nil and the
+guard quietly answered wrong. The builder's entries are merged into the standard
+environment instead. Found by converting this spike, not by review — which is
+the argument for keeping the spike compiling against every feature.
 
 ### 3 — Effects are opaque closures ([#36](https://github.com/ehabterra/workflow/issues/36)) — ✅ **RESOLVED**
 
@@ -254,7 +279,20 @@ That test should be **inverted into a correctness test** once atomic multi-insta
 transitions land. Any real adopter hits this the moment they have revisions, and
 the workaround silently creates state the engine does not know about.
 
-### 6 — Guard rejections are not identifiable ([#38](https://github.com/ehabterra/workflow/issues/38)) · ~20 lines
+### 6 — `require:` cannot use the transaction environment ([#34](https://github.com/ehabterra/workflow/issues/34) + [#35](https://github.com/ehabterra/workflow/issues/35)) · new
+
+The two features that pair everywhere else do not compose here. A requirement's
+`count:` / `where:` expressions see the workflow context and the place's tokens;
+they do not see the `tx_guard` environment, so a join whose arity is a function
+of host data still needs the host to resolve that data and inject it.
+
+The spike works around it honestly — the guard verifies the chain's input in the
+transaction (friction 2) — and the workaround is sound, because the chain itself
+is org policy that belongs in the host anyway. But a net whose join size is a
+pure database fact would have no such excuse. Filed as a follow-up rather than
+papered over.
+
+### 7 — Guard rejections are not identifiable ([#38](https://github.com/ehabterra/workflow/issues/38)) · ~20 lines
 
 `Submit` needs 422 for a failed ready-gate and `Approve` needs 403 for separation
 of duties, but the library reports only that *a* guard rejected. The host recomputes
@@ -262,7 +300,7 @@ the failing condition to decide which error to return — `if !ready { return
 ErrNotReady }` — duplicating the guard outside the net purely to produce the right
 status code.
 
-### 7 — Status projection is manual ([#39](https://github.com/ehabterra/workflow/issues/39)) · ~16 lines
+### 8 — Status projection is manual ([#39](https://github.com/ehabterra/workflow/issues/39)) · ~16 lines
 
 Place metadata carries a `status` label, `statusOf` derives it, and `project`
 writes it in the transaction — repeated for every action. Forget it on one
@@ -356,8 +394,12 @@ function's doc comment**, from `func` line to the closing brace at column 0:
 
 - **orchestration** — `fire`, `Submit`, `Approve`, `Reject`, `Resubmit`,
   `Revoke`, `classify` in `app.go`, plus `readyGate` in `domain.go`
-- **effect implementations** — `registerEffects`, `resolveTarget`, `statusFor`,
-  `asTx`, `str` in `effects.go`
+- **host implementations** — `registerEffects`, `resolveTarget`, `statusFor`,
+  `asTx`, `str` in `effects.go`, plus `txGuardEnv` in `domain.go`. Renamed from
+  "effect implementations" at #35: `txGuardEnv` is the SQL behind the guards,
+  the exact counterpart of the SQL behind the effects, and putting it in
+  orchestration would have called a query a sequencing decision. The rename is
+  why the middle row moves at #35 — apply it to both revisions when comparing.
 - **excluded** — `App`/`New`/`Create`/`Status`/`Marking`/`Ledger` in `app.go`, and
   the role/directory/record/schema block in `domain.go`
 
@@ -367,9 +409,19 @@ landed (declarative 85, orchestration 167, effects 142) came from the same rule
 applied by hand without counting doc comments; re-measured mechanically the same
 tree gives 85 / 208 / 180.
 
-**Target after [#34](https://github.com/ehabterra/workflow/issues/34),
-[#35](https://github.com/ehabterra/workflow/issues/35), and
-[#36](https://github.com/ehabterra/workflow/issues/36):** the same workflow above
-**70%** by concern. Two of the three have landed and it stands at **68%**, so the
-target is intact and #35 decides it. If it does not get there, that is the signal
-to stop investing and keep the library scoped to nets that are genuinely parallel.
+**The target set before any of them existed:** the same workflow above **70%** by
+concern once [#34](https://github.com/ehabterra/workflow/issues/34),
+[#35](https://github.com/ehabterra/workflow/issues/35) and
+[#36](https://github.com/ehabterra/workflow/issues/36) had all landed — with the
+explicit clause that failing it was the signal to stop investing and keep the
+library scoped to nets that are genuinely parallel.
+
+All three have landed. It is **80%**, so the investment is answered: build the
+adoption floor (#40, #41) and the authoring track (#42 → #43, #44), and invert
+`TestSupersedeCascade_DivergesMarking` when #37 lands.
+
+Keep re-running this. The value of the spike is not the number it produced once
+— it is that it compiles against every feature and re-measures, and it has now
+caught a design defect (#35's environment) and two correctness holes (the #34
+authorization gap, the last-resort SoD bypass) that neither the test suite nor
+review found first.

--- a/internal/spike/approval/COVERAGE.md
+++ b/internal/spike/approval/COVERAGE.md
@@ -354,6 +354,35 @@ small enough to read in one sitting, which argues for
 about it does. Orchestration went 151 → 157 lines, because the fix is worth
 explaining in place.
 
+### Round three, on #35: two fail-open guards
+
+Review found both, and both are the same class of mistake — a check whose
+*failure direction* had never been chosen.
+
+**A separation-of-duties check that failed open.** The environment exposed
+`submitterOf()` and the guard read `actor != submitterOf()`. On any query error —
+including a missing row — it returned `""`, and no actor equals `""`, so the
+check PASSED. An unreadable requisition was approvable.
+
+The proposed fix was a sentinel value nothing could equal. That does not work,
+for exactly the reason the bug exists: `actor != sentinel` is *also* true. The
+comparison had to move inside the function. `sodOk()` owns the whole question and
+returns false on any read failure, which is the only shape that lets a failure
+fall the safe way. `TestSodOkFailsClosed` pins all three directions.
+
+**The last-resort branch skipped the amount check.** The other two approve
+branches carry `amountOf() == amount`; this one had only the SoD half. But
+`last_resort` is itself derived from the chain, which is derived from the amount
+— so the branch most in need of the check was the one without it, and the file's
+own header comment claimed otherwise. All three now carry identical text, which
+is the point: a rule you can only verify by reading three different expressions
+is a rule that will drift again.
+
+That is the third consecutive round in which review found a correctness hole in
+this net, and the second in which the hole was in the escape hatch. The pattern
+is worth naming: `approve_last_resort` exists to bypass a rule, and every time it
+has been written it has quietly bypassed a rule nobody meant it to.
+
 ## What worked well
 
 Worth recording, because the spike is not an argument that the library is bad:

--- a/internal/spike/approval/app.go
+++ b/internal/spike/approval/app.go
@@ -57,7 +57,7 @@ func New(ctx context.Context, db *sql.DB, hier Hierarchy, dir *Directory) (*App,
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
 	}
-	def, err := wfyaml.NewLoader().LoadDefinition(cfg)
+	def, err := wfyaml.NewLoaderWithTxEnv(txGuardEnv).LoadDefinition(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("load definition: %w", err)
 	}
@@ -127,15 +127,18 @@ func (a *App) fire(ctx context.Context, id string, seed map[string]any, apply fu
 	})
 }
 
-// Submit fires the submit transition after evaluating the ready-gate.
+// Submit fires the submit transition.
+//
+// Since #35 the ready-gate is not evaluated here at all: `tx_guard:
+// "readyGate()"` runs it inside the firing transaction. What is left is the
+// error mapping, which still has to recompute the gate because the library
+// reports only THAT a guard rejected (#38).
 func (a *App) Submit(ctx context.Context, id, actor string) error {
 	req, err := loadRequisition(ctx, a.db, id)
 	if err != nil {
 		return err
 	}
-	ready := readyGate(req)
 	err = a.fire(ctx, id, map[string]any{
-		"ready":     ready,
 		"actor":     actor,
 		"submitter": req.Submitter,
 		"amount":    req.Amount,
@@ -143,9 +146,7 @@ func (a *App) Submit(ctx context.Context, id, actor string) error {
 		return wf.ApplyTransitionWithContext(ctx, "submit")
 	})
 	if err != nil {
-		// The library cannot say WHICH guard rejected, so the host recomputes
-		// the gate to produce the right error. See COVERAGE.md, friction 6.
-		if !ready {
+		if !readyGate(req) {
 			return ErrNotReady
 		}
 		return classify(err)
@@ -153,15 +154,15 @@ func (a *App) Submit(ctx context.Context, id, actor string) error {
 	return nil
 }
 
-// Approve is the core of the spike, and since #34 it is mostly the ladder.
+// Approve is the core of the spike, and after #34 and #35 it is mostly the
+// ladder.
 //
 // What it no longer does: read the ledger, work out whether the chain would be
-// satisfied if this approval were recorded, or check that the actor is a
-// required approver. The net answers all three — the approvals are tokens, and
-// the join counts them.
+// satisfied if this approval were recorded, check that the actor is a required
+// approver, or evaluate separation of duties. The net answers all four.
 //
-// What it still does is #35: `sod_ok` is a boolean computed OUTSIDE the
-// transaction, because a guard cannot query the record.
+// What remains is genuinely the host's: the role ladder and the user directory
+// are org data, which is the boundary docs/BOUNDARIES.md draws and keeps.
 func (a *App) Approve(ctx context.Context, id, actor string) error {
 	req, err := loadRequisition(ctx, a.db, id)
 	if err != nil {
@@ -169,17 +170,18 @@ func (a *App) Approve(ctx context.Context, id, actor string) error {
 	}
 	chain := a.hier.ChainFor(req.Amount)
 	lastResort := lastResortAllowed(a.dir, actor, chain)
-	// Separation of duties applies to EVERY approve branch, last-resort included.
-	// This used to read `actor != req.Submitter || lastResort`, exempting the
-	// hatch — which let an admin approve a requisition they had submitted
-	// themselves, since `approve_last_resort` needs no role. The hatch exists for
-	// a chain nobody can satisfy; that is not a reason to let someone sign off on
-	// their own record. TestAdminSubmitterCannotSelfApprove pins it.
-	sodOk := actor != req.Submitter
 	role := a.dir.RoleOf(actor)
 
+	// Separation of duties is no longer computed here. Every approve branch
+	// carries `tx_guard: "actor != submitterOf()"`, which reads the record
+	// inside the firing transaction — so it cannot be defeated by the submitter
+	// changing after this function read the row.
+	//
+	// `amountOf() == amount` is the other half: the chain below is derived from
+	// an amount read OUTSIDE the transaction, and a chain computed from a stale
+	// amount is the wrong chain. The tx guard refuses rather than counting
+	// approvals against it. See COVERAGE.md, friction 2.
 	err = a.fire(ctx, id, map[string]any{
-		"sod_ok":      sodOk,
 		"chain":       chain,
 		"actor":       actor,
 		"role":        role,
@@ -206,7 +208,7 @@ func (a *App) Approve(ctx context.Context, id, actor string) error {
 		// which rule it was to choose a status code. That is #38 — and it is now
 		// the only reason these values are recomputed here; nothing about the
 		// decision itself depends on them any more.
-		if !sodOk || (!lastResort && !slices.Contains(chain, role)) {
+		if actor == req.Submitter || (!lastResort && !slices.Contains(chain, role)) {
 			return ErrForbidden
 		}
 		return classify(err)

--- a/internal/spike/approval/app.go
+++ b/internal/spike/approval/app.go
@@ -146,7 +146,12 @@ func (a *App) Submit(ctx context.Context, id, actor string) error {
 		return wf.ApplyTransitionWithContext(ctx, "submit")
 	})
 	if err != nil {
-		if !readyGate(req) {
+		// Map against the CURRENT record, not the one read before the fire: the
+		// guard decided inside the transaction, and a gate that failed after
+		// this function's read would otherwise be reported as a 409 instead of
+		// a 422. Re-reading is the host paying twice for what #38 would give it
+		// once — the library knows which guard rejected and will not say.
+		if current, lerr := loadRequisition(ctx, a.db, id); lerr == nil && !readyGate(current) {
 			return ErrNotReady
 		}
 		return classify(err)
@@ -173,9 +178,9 @@ func (a *App) Approve(ctx context.Context, id, actor string) error {
 	role := a.dir.RoleOf(actor)
 
 	// Separation of duties is no longer computed here. Every approve branch
-	// carries `tx_guard: "actor != submitterOf()"`, which reads the record
-	// inside the firing transaction — so it cannot be defeated by the submitter
-	// changing after this function read the row.
+	// carries `tx_guard: "sodOk() && ..."`, which reads the record inside the
+	// firing transaction — so it cannot be defeated by the submitter changing
+	// after this function read the row.
 	//
 	// `amountOf() == amount` is the other half: the chain below is derived from
 	// an amount read OUTSIDE the transaction, and a chain computed from a stale
@@ -206,9 +211,16 @@ func (a *App) Approve(ctx context.Context, id, actor string) error {
 	if err != nil {
 		// The library reports only THAT the net refused, so the host re-derives
 		// which rule it was to choose a status code. That is #38 — and it is now
-		// the only reason these values are recomputed here; nothing about the
-		// decision itself depends on them any more.
-		if actor == req.Submitter || (!lastResort && !slices.Contains(chain, role)) {
+		// the only reason any of this is recomputed; nothing about the decision
+		// itself depends on it any more.
+		//
+		// Re-read for the same reason as Submit: the guard judged the current
+		// row, so mapping against the pre-fire snapshot can name the wrong rule.
+		submitter, live := req.Submitter, chain
+		if current, lerr := loadRequisition(ctx, a.db, id); lerr == nil {
+			submitter, live = current.Submitter, a.hier.ChainFor(current.Amount)
+		}
+		if actor == submitter || (!lastResort && !slices.Contains(live, role)) {
 			return ErrForbidden
 		}
 		return classify(err)

--- a/internal/spike/approval/app_test.go
+++ b/internal/spike/approval/app_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ehabterra/workflow"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -511,4 +512,66 @@ func TestGuardRejectionIsNotIdentifiable(t *testing.T) {
 	if readyGate(req) {
 		t.Fatal("expected the ready-gate to be the failing rule")
 	}
+}
+
+// TestStaleChainIsRefusedInTheTransaction closes friction 2.
+//
+// `Approve` reads the requisition's amount, derives the approval chain from it,
+// and only then fires. If the amount changes in between — a revision, a
+// correction, a race — the chain it is about to count approvals against is the
+// wrong one. Before #35 there was nowhere to notice: the guard had no
+// transaction and no way to ask.
+//
+// `tx_guard: "... && amountOf() == amount"` asks inside the firing transaction
+// and refuses. The requisition stays Submitted and the approval leaves no trace.
+func TestStaleChainIsRefusedInTheTransaction(t *testing.T) {
+	a, ctx := newApp(t)
+	if err := a.Create(ctx, "st", "REQ-ST", "dana", 1_000, []Line{costed("l1", "CC-100", 1_000)}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := a.Submit(ctx, "st", "dana"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	// At 1,000 the chain is [site_manager], so sam alone would finalise it.
+	// Someone raises the requisition to 20,000 — which needs a second role —
+	// between the read and the fire.
+	if _, err := a.db.ExecContext(ctx, `UPDATE requisitions SET amount = 20000 WHERE id = 'st'`); err != nil {
+		t.Fatalf("revise: %v", err)
+	}
+
+	// The host still holds the chain it derived from the old amount. Firing on
+	// it would approve a 20,000 requisition on one signature.
+	err := a.fire(ctx, "st", map[string]any{
+		"chain":       a.hier.ChainFor(1_000), // stale: [site_manager]
+		"actor":       "sam",
+		"role":        "site_manager",
+		"submitter":   "dana",
+		"amount":      1_000.0, // stale
+		"last_resort": false,
+	}, func(wf *workflow.Workflow) error {
+		if _, err := wf.CreateToken("approvals", workflow.TokenData{"role": "site_manager", "by": "sam"}); err != nil {
+			return err
+		}
+		_, err := wf.ApplyAny(ctx, "approve_last_resort", "approve_final", "approve_partial")
+		return err
+	})
+	if err == nil {
+		t.Fatal("a chain derived from a stale amount must not approve")
+	}
+	mustStatus(t, a, ctx, "st", "Submitted")
+	if n := ledgerSize(t, a, ctx, "st"); n != 0 {
+		t.Errorf("pool = %d tokens, want 0 — the refused cycle left a trace", n)
+	}
+
+	// Re-reading the amount produces the right chain, and the same approval is
+	// then legal — as a partial, because 20,000 needs two roles.
+	if err := a.Approve(ctx, "st", "sam"); err != nil {
+		t.Fatalf("approve on the current amount: %v", err)
+	}
+	mustStatus(t, a, ctx, "st", "Submitted") // one of two roles
+	if err := a.Approve(ctx, "st", "casey"); err != nil {
+		t.Fatalf("second approve: %v", err)
+	}
+	mustStatus(t, a, ctx, "st", "Approved")
 }

--- a/internal/spike/approval/app_test.go
+++ b/internal/spike/approval/app_test.go
@@ -556,8 +556,8 @@ func TestStaleChainIsRefusedInTheTransaction(t *testing.T) {
 		_, err := wf.ApplyAny(ctx, "approve_last_resort", "approve_final", "approve_partial")
 		return err
 	})
-	if err == nil {
-		t.Fatal("a chain derived from a stale amount must not approve")
+	if !errors.Is(err, workflow.ErrGuardRejected) {
+		t.Fatalf("a chain derived from a stale amount must be refused BY THE GUARD, got %v", err)
 	}
 	mustStatus(t, a, ctx, "st", "Submitted")
 	if n := ledgerSize(t, a, ctx, "st"); n != 0 {
@@ -574,4 +574,96 @@ func TestStaleChainIsRefusedInTheTransaction(t *testing.T) {
 		t.Fatalf("second approve: %v", err)
 	}
 	mustStatus(t, a, ctx, "st", "Approved")
+}
+
+// TestLastResortAlsoRefusesAStaleChain: the escape hatch is not an exemption.
+//
+// `last_resort` is itself derived from the chain, which is derived from an
+// amount read outside the transaction — so the branch that uses it needs the
+// same in-transaction amount check as the other two. Caught by review on #51: it
+// had only the separation-of-duties half, so an admin could approve on a chain
+// computed from a value that had since moved.
+func TestLastResortAlsoRefusesAStaleChain(t *testing.T) {
+	a, ctx := newApp(t)
+	// 200,000 needs a director, which nobody holds, so admin's hatch is open.
+	if err := a.Create(ctx, "lr", "REQ-LR", "dana", 200_000, []Line{costed("l1", "CC-900", 200_000)}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := a.Submit(ctx, "lr", "dana"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if _, err := a.db.ExecContext(ctx, `UPDATE requisitions SET amount = 1000 WHERE id = 'lr'`); err != nil {
+		t.Fatalf("revise: %v", err)
+	}
+
+	err := a.fire(ctx, "lr", map[string]any{
+		"chain":       a.hier.ChainFor(200_000), // stale
+		"actor":       "admin",
+		"role":        "",
+		"submitter":   "dana",
+		"amount":      200_000.0, // stale
+		"last_resort": true,
+	}, func(wf *workflow.Workflow) error {
+		if _, err := wf.CreateToken("approvals", workflow.TokenData{"role": "", "by": "admin"}); err != nil {
+			return err
+		}
+		_, err := wf.ApplyAny(ctx, "approve_last_resort", "approve_final", "approve_partial")
+		return err
+	})
+	if !errors.Is(err, workflow.ErrGuardRejected) {
+		t.Fatalf("the last-resort branch must refuse a stale amount too, got %v", err)
+	}
+	mustStatus(t, a, ctx, "lr", "Submitted")
+
+	// On the current amount, 1,000 needs only a site_manager — and the hatch is
+	// no longer open, because that role IS held. The ordinary path works.
+	if err := a.Approve(ctx, "lr", "sam"); err != nil {
+		t.Fatalf("approve on the current amount: %v", err)
+	}
+	mustStatus(t, a, ctx, "lr", "Approved")
+}
+
+// TestSodOkFailsClosed: a separation-of-duties check that cannot read the record
+// must REFUSE, not approve.
+//
+// The first version of this guard exposed `submitterOf()` and let the expression
+// write `actor != submitterOf()`. On a query error it returned "" — and no actor
+// equals "", so the check passed and an unreadable requisition was approvable.
+// Returning a sentinel instead does not help: nothing equals that either. Only a
+// function that owns the whole comparison can choose which way a failure falls.
+func TestSodOkFailsClosed(t *testing.T) {
+	a, ctx := newApp(t)
+	if err := a.Create(ctx, "sc", "REQ-SC", "dana", 1_000, []Line{costed("l1", "CC-100", 1_000)}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Each case opens and closes its own transaction: the test database allows
+	// one connection, so holding one open would block everything else.
+	sodOk := func(t *testing.T, id, actor string) bool {
+		t.Helper()
+		wf, err := workflow.NewWorkflow(id, a.def, "draft")
+		if err != nil {
+			t.Fatal(err)
+		}
+		wf.SetContext("actor", actor)
+		ev := workflow.NewGuardEvent(ctx, a.def.Transition("approve_final"), nil, nil, nil, wf)
+
+		tx, err := a.db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = tx.Rollback() }()
+		return txGuardEnv(ctx, tx, ev)["sodOk"].(func() bool)()
+	}
+
+	// No such requisition: the read fails, and the answer must be "no".
+	if sodOk(t, "ghost", "dana") {
+		t.Error("an unreadable requisition must not satisfy separation of duties")
+	}
+	if sodOk(t, "sc", "dana") {
+		t.Error("the submitter must not satisfy separation of duties")
+	}
+	if !sodOk(t, "sc", "sam") {
+		t.Error("a different actor must satisfy separation of duties")
+	}
 }

--- a/internal/spike/approval/domain.go
+++ b/internal/spike/approval/domain.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"maps"
 	"sort"
+
+	"github.com/ehabterra/workflow"
 )
 
 // Role is a position in the approval hierarchy. Roles are ordered by Level:
@@ -235,4 +237,63 @@ func lastResortAllowed(d *Directory, actor string, chain []string) bool {
 type queryer interface {
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// txGuardEnv is the transaction-scoped guard environment (#35): the functions a
+// `tx_guard:` expression may call, each reading the host's own tables THROUGH
+// the firing transaction.
+//
+// This is the half that used to be impossible. Before it, every one of these
+// answers had to be computed here, injected into the workflow context, and
+// trusted to still be true when the save committed — `ready`, `sod_ok`, and an
+// amount the approval chain was derived from. Now the guard asks, at the moment
+// it decides, against the state it is about to commit against.
+//
+// The queries are host SQL and always were. What changed is WHO asks and WHEN.
+func txGuardEnv(ctx context.Context, tx any, ev workflow.Event) map[string]any {
+	sqlTx, ok := tx.(*sql.Tx)
+	if !ok {
+		// Impossible with the SQL backends; returning an empty env makes the
+		// guard fail loudly rather than silently evaluating against nothing.
+		return map[string]any{}
+	}
+	id := ev.Workflow().Name() // the instance id IS the requisition id
+
+	return map[string]any{
+		// readyGate: every costed line carries a cost code. Was `readyGate(req)`
+		// in Go, with the answer injected as the `ready` context boolean.
+		"readyGate": func() bool {
+			var bad int
+			if err := sqlTx.QueryRowContext(ctx,
+				`SELECT COUNT(*) FROM requisition_lines WHERE req_id = ? AND amount != 0 AND cost_code = ''`,
+				id).Scan(&bad); err != nil {
+				return false
+			}
+			return bad == 0
+		},
+
+		// submitterOf: separation of duties, read live. Was the `sod_ok` boolean,
+		// computed from a row the host had read before the transaction opened.
+		"submitterOf": func() string {
+			var submitter string
+			if err := sqlTx.QueryRowContext(ctx,
+				`SELECT submitter FROM requisitions WHERE id = ?`, id).Scan(&submitter); err != nil {
+				return ""
+			}
+			return submitter
+		},
+
+		// amountOf: the value the approval chain was derived from. The chain
+		// itself is still resolved by the host (it is a policy ladder, not a
+		// query), so the guard verifies the input it was derived FROM has not
+		// moved — a chain computed from a stale amount is the wrong chain.
+		"amountOf": func() float64 {
+			var amount float64
+			if err := sqlTx.QueryRowContext(ctx,
+				`SELECT amount FROM requisitions WHERE id = ?`, id).Scan(&amount); err != nil {
+				return -1
+			}
+			return amount
+		},
+	}
 }

--- a/internal/spike/approval/domain.go
+++ b/internal/spike/approval/domain.go
@@ -272,15 +272,25 @@ func txGuardEnv(ctx context.Context, tx any, ev workflow.Event) map[string]any {
 			return bad == 0
 		},
 
-		// submitterOf: separation of duties, read live. Was the `sod_ok` boolean,
+		// sodOk: separation of duties, read live. Was the `sod_ok` boolean,
 		// computed from a row the host had read before the transaction opened.
-		"submitterOf": func() string {
+		//
+		// The COMPARISON is inside the function on purpose. An earlier version
+		// exposed `submitterOf()` and let the guard write
+		// `actor != submitterOf()` — which failed OPEN: a query error returned
+		// "", no actor equals "", so the check passed and an unreadable
+		// requisition could be approved. Returning a sentinel instead does not
+		// help, for exactly the same reason. Only a function that owns the whole
+		// question can decide which way a failure falls.
+		"sodOk": func() bool {
 			var submitter string
 			if err := sqlTx.QueryRowContext(ctx,
 				`SELECT submitter FROM requisitions WHERE id = ?`, id).Scan(&submitter); err != nil {
-				return ""
+				return false // unreadable record: refuse, do not approve
 			}
-			return submitter
+			actor, _ := ev.Workflow().Context("actor")
+			name, _ := actor.(string)
+			return name != "" && name != submitter
 		},
 
 		// amountOf: the value the approval chain was derived from. The chain

--- a/internal/spike/approval/workflow.yaml
+++ b/internal/spike/approval/workflow.yaml
@@ -64,16 +64,18 @@ workflow:
     # it such a requisition is unapprovable. It is tried FIRST because it is the
     # narrowest condition.
     #
-    # It carries the separation-of-duties tx_guard like every other approve
-    # branch. An earlier version did not, and the host exempted last-resort from
-    # SoD on top of that, so an admin could approve their own requisition. Being
-    # able to break a deadlocked chain is not a licence to sign off on your own
-    # record — and with the rule on all three branches, the definition says so.
+    # It carries the SAME tx_guard as every other approve branch, and that is
+    # the point. Two earlier versions got this wrong: one omitted `sod_ok`, so an
+    # admin could approve their own requisition; the next omitted the amount
+    # check, so an admin could approve on a chain derived from a value that had
+    # since moved — `last_resort` is itself derived from that chain. A branch
+    # that exists to break a deadlock is not a branch that gets to skip the
+    # rules, and identical text on all three is how you can see that at a glance.
     - name: approve_last_resort
       from: [submitted, approvals]
       to: [approved]
       guard: "last_resort"
-      tx_guard: "actor != submitterOf()"
+      tx_guard: "sodOk() && amountOf() == amount"
       resets: [approvals]
       effects:
         - name: project_status
@@ -105,7 +107,7 @@ workflow:
     - name: approve_final
       from: [submitted, approvals]
       to: [approved]
-      tx_guard: "actor != submitterOf() && amountOf() == amount"
+      tx_guard: "sodOk() && amountOf() == amount"
       resets: [approvals]
       require:
         - place: approvals
@@ -137,7 +139,7 @@ workflow:
       from: [submitted]
       to: [submitted]
       guard: "role in chain"
-      tx_guard: "actor != submitterOf() && amountOf() == amount"
+      tx_guard: "sodOk() && amountOf() == amount"
       effects:
         - name: project_status
         - name: audit

--- a/internal/spike/approval/workflow.yaml
+++ b/internal/spike/approval/workflow.yaml
@@ -2,11 +2,13 @@
 # (see COVERAGE.md). This is everything about the workflow that the library
 # can express today.
 #
-# What it still does NOT contain is the guard INPUTS: `ready` and `sod_ok` are
-# booleans the host computes and injects with SetContext, because a guard has
-# no transaction and cannot query (#35). `chain` is injected for the same
-# reason — but note that it is now a VALUE the net reasons about rather than a
-# pre-computed answer, which is the whole difference #34 made.
+# Since #35 the guards no longer read pre-computed booleans. `ready` and
+# `sod_ok` are gone: `tx_guard:` expressions ask the database inside the firing
+# transaction. What the host still injects is org data — `role`, `last_resort`,
+# and the `chain` the role ladder produces — because roles and hierarchies are
+# deliberately outside this library (docs/BOUNDARIES.md). The chain's INPUT is
+# verified in the transaction all the same: `amountOf() == amount` refuses to
+# count approvals against a chain derived from a value that has since moved.
 #
 # approve is three transitions with complementary conditions because one action
 # has three outcomes, and ApplyAny picks between them in declaration order:
@@ -37,13 +39,17 @@ workflow:
     - name: superseded
       metadata: {status: Superseded}
   transitions:
-    # `ready` is the ready-gate: every costed line carries a cost code. The
-    # host computes it by querying the lines and injects the answer; the guard
-    # only reads the boolean. That is #35, still open.
+    # THE TRANSACTION-SCOPED GUARD (#35).
+    #
+    # The ready-gate — every costed line carries a cost code — is a query, and
+    # until #35 a guard could not make one. The host ran it, injected the answer
+    # as a `ready` boolean, and hoped no line changed before the save.
+    # `tx_guard:` is evaluated INSIDE the firing transaction, so it asks at the
+    # moment it decides, against the state it is about to commit against.
     - name: submit
       from: [draft]
       to: [submitted]
-      guard: "ready"
+      tx_guard: "readyGate()"
       effects:
         - name: project_status
         - name: audit
@@ -58,16 +64,16 @@ workflow:
     # it such a requisition is unapprovable. It is tried FIRST because it is the
     # narrowest condition.
     #
-    # It carries `sod_ok` like every other approve branch. An earlier version did
-    # not, and the host exempted last-resort from separation of duties on top of
-    # that, so an admin could approve their own requisition. Being able to break a
-    # deadlocked chain is not a licence to sign off on your own record — and with
-    # the rule on all three branches, the definition says so rather than leaving
-    # it to a boolean the host computes.
+    # It carries the separation-of-duties tx_guard like every other approve
+    # branch. An earlier version did not, and the host exempted last-resort from
+    # SoD on top of that, so an admin could approve their own requisition. Being
+    # able to break a deadlocked chain is not a licence to sign off on your own
+    # record — and with the rule on all three branches, the definition says so.
     - name: approve_last_resort
       from: [submitted, approvals]
       to: [approved]
-      guard: "last_resort && sod_ok"
+      guard: "last_resort"
+      tx_guard: "actor != submitterOf()"
       resets: [approvals]
       effects:
         - name: project_status
@@ -99,7 +105,7 @@ workflow:
     - name: approve_final
       from: [submitted, approvals]
       to: [approved]
-      guard: "sod_ok"
+      tx_guard: "actor != submitterOf() && amountOf() == amount"
       resets: [approvals]
       require:
         - place: approvals
@@ -124,13 +130,14 @@ workflow:
     # records progress without advancing; the approval token itself is already
     # in the pool, added inside the same atomic cycle.
     #
-    # `role in chain` is the authorization check. It rejects an actor the chain
-    # does not require — and because the token was added inside the fire, a
-    # rejected approval is never persisted at all.
+    # `role in chain` is the authorization check, over host-supplied org data.
+    # Because the token was added inside the fire, a rejected approval is never
+    # persisted at all.
     - name: approve_partial
       from: [submitted]
       to: [submitted]
-      guard: "sod_ok && role in chain"
+      guard: "role in chain"
+      tx_guard: "actor != submitterOf() && amountOf() == amount"
       effects:
         - name: project_status
         - name: audit

--- a/manager.go
+++ b/manager.go
@@ -178,7 +178,42 @@ func checkCachedDefinition(wf *Workflow, definition *Definition) error {
 // the definition. Execute uses it so each retry runs against fresh, validated
 // state.
 func (m *Manager) loadFromStorage(ctx context.Context, id string, definition *Definition) (*Workflow, error) {
-	loaded, wfContext, version, err := m.readState(ctx, id)
+	return m.loadWith(ctx, id, definition, fingerprintMigrate, m.readState)
+}
+
+// fingerprintCheck selects how a load reacts to the stored definition
+// fingerprint. The ordinary path consults the migration handler; the
+// transaction-scoped path cannot, because the handler is host code that may
+// write to storage and would deadlock against the transaction we hold — so it
+// resolves the question before opening the scope and tells the load which
+// answer it got.
+type fingerprintCheck int
+
+const (
+	// fingerprintMigrate consults the migration handler on a mismatch.
+	fingerprintMigrate fingerprintCheck = iota
+	// fingerprintStrict makes a mismatch a hard error: it means the definition
+	// changed under us after the pre-scope check, not something to approve now.
+	fingerprintStrict
+	// fingerprintSkip is for a mismatch a handler already approved before the
+	// scope opened.
+	fingerprintSkip
+)
+
+// loadWith is loadFromStorage over a caller-supplied state reader, so the
+// transaction-scoped path can read through its own transaction (see
+// loadForCycle) while sharing every validation.
+//
+// check selects how a stored-fingerprint mismatch is handled; see
+// fingerprintCheck.
+func (m *Manager) loadWith(
+	ctx context.Context,
+	id string,
+	definition *Definition,
+	check fingerprintCheck,
+	read func(context.Context, string) (Marking, map[string]any, int64, error),
+) (*Workflow, error) {
+	loaded, wfContext, version, err := read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -189,14 +224,24 @@ func (m *Manager) loadFromStorage(ctx context.Context, id string, definition *De
 	// migration exists for). After the handler approves, reload: a handler that
 	// migrated the persisted state expects the load to observe its rewrite, not
 	// clobber it with the pre-migration snapshot on the next save.
-	migrated, err := m.checkFingerprint(ctx, id, definition, wfContext)
-	if err != nil {
-		return nil, err
-	}
-	if migrated {
-		if loaded, wfContext, version, err = m.readState(ctx, id); err != nil {
-			return nil, fmt.Errorf("reloading after definition migration: %w", err)
+	switch check {
+	case fingerprintMigrate:
+		migrated, merr := m.checkFingerprint(ctx, id, definition, wfContext)
+		if merr != nil {
+			return nil, merr
 		}
+		if migrated {
+			if loaded, wfContext, version, err = read(ctx, id); err != nil {
+				return nil, fmt.Errorf("reloading after definition migration: %w", err)
+			}
+		}
+	case fingerprintStrict:
+		if stored, _ := wfContext[defFingerprintKey].(string); stored != definition.Fingerprint() {
+			return nil, fmt.Errorf("%w: instance %q stored fingerprint %s, definition fingerprint %s",
+				ErrDefinitionMismatch, id, stored, definition.Fingerprint())
+		}
+	case fingerprintSkip:
+		// A handler already approved this mismatch before the scope opened.
 	}
 	// Strip the fingerprint and shape so they never reach the workflow's
 	// user-visible context or guard environment.
@@ -552,6 +597,44 @@ func (m *Manager) Execute(ctx context.Context, id string, definition *Definition
 		}
 	}
 
+	// Transaction-scoped guards invert the usual order: instead of firing in
+	// memory and opening a transaction at the save, the WHOLE cycle runs inside
+	// one transaction, so a guard can read host state as of the state it is
+	// about to commit against. It needs a backend that can lend out its
+	// transaction; say so loudly rather than evaluating the guard on stale data.
+	plan := executePlan{cfg: &cfg, declaresEffects: declaresEffects, ts: ts, tds: tds}
+	if definitionHasTxGuards(definition) {
+		var ok bool
+		if plan.tss, ok = m.storage.(TxScopedStorage); !ok {
+			return fmt.Errorf("definition has transaction-scoped guards, which require a TxScopedStorage backend "+
+				"(one that can run the whole load-fire-save cycle in a transaction it lends out): %w", errors.ErrUnsupported)
+		}
+		// Same reasoning as the TransactionalDueStorage check above: committing
+		// state without updating the due column in the same transaction leaves
+		// the index silently corrupt.
+		if _, isDue := m.storage.(DueStorage); isDue {
+			if plan.tsds, ok = m.storage.(TxScopedDueStorage); !ok && definitionHasTimers(definition) {
+				return fmt.Errorf("transaction-scoped guards on a DueStorage backend with a timed definition require "+
+					"a TxScopedDueStorage backend (implement SaveStateScopedWithDue): %w", errors.ErrUnsupported)
+			}
+		}
+		// The migration handler is host code that may write to storage, which
+		// would deadlock against the transaction we are about to open on the
+		// same rows. Consult it BEFORE the scope; in the common case (no handler
+		// registered) this costs nothing, because the in-scope check catches a
+		// mismatch identically.
+		plan.check = fingerprintStrict
+		if m.onDefinitionMismatch != nil {
+			approved, err := m.migrateBeforeScope(ctx, id, definition)
+			if err != nil {
+				return err
+			}
+			if approved {
+				plan.check = fingerprintSkip
+			}
+		}
+	}
+
 	maxAttempts := cfg.maxAttempts
 	if maxAttempts <= 0 {
 		maxAttempts = 5
@@ -570,47 +653,7 @@ func (m *Manager) Execute(ctx context.Context, id string, definition *Definition
 			time.Sleep(time.Duration(attempt)*2*time.Millisecond + jitter)
 		}
 
-		wf, err := m.loadFromStorage(ctx, id, definition)
-		if err != nil {
-			return err
-		}
-		if err := fn(wf); err != nil {
-			return err
-		}
-		marking, ctxData := wf.snapshotState()
-		ctxData = contextForSave(ctxData, definition)
-		due := m.dueForSave(definition, marking)
-
-		// Resolve the effects declared by whatever actually fired this attempt.
-		// Draining after fn (and after the snapshot) means a retried attempt
-		// starts from an empty log, so an abandoned attempt's effects can never
-		// leak into the one that commits.
-		var afterCommit []pendingAfterCommit
-		effects := cfg.effects
-		if declaresEffects {
-			steps := wf.drainFired()
-			txEffects, pending, rerr := m.resolveEffects(id, definition, steps, ctxData)
-			if rerr != nil {
-				return rerr
-			}
-			effects = append(append([]TxSideEffect(nil), cfg.effects...), txEffects...)
-			afterCommit = pending
-		}
-
-		switch {
-		case ts != nil:
-			// Keep the due index current even on the transactional path (state +
-			// side effect commit together) when the backend supports it. A partial
-			// due backend (DueStorage but not TransactionalDueStorage) with a timed
-			// definition was already rejected before the loop.
-			if tds != nil {
-				_, err = tds.SaveStateInTxWithDue(ctx, id, marking, ctxData, wf.Version(), due, effects...)
-			} else {
-				_, err = ts.SaveStateInTx(ctx, id, marking, ctxData, wf.Version(), effects...)
-			}
-		default:
-			_, err = m.persistState(ctx, id, marking, ctxData, wf.Version(), due)
-		}
+		afterCommit, err := m.runCycle(ctx, id, definition, fn, &plan)
 		if err != nil {
 			if errors.Is(err, ErrConflict) {
 				lastErr = err
@@ -629,6 +672,177 @@ func (m *Manager) Execute(ctx context.Context, id string, definition *Definition
 		return runAfterCommit(ctx, afterCommit)
 	}
 	return fmt.Errorf("%w: giving up after %d attempts", lastErr, maxAttempts)
+}
+
+// executePlan is the per-Execute decision about how one attempt persists: which
+// optional storage capabilities were resolved, and whether the definition needs
+// the whole cycle wrapped in a transaction. It is computed once, before the
+// retry loop, so every attempt behaves identically.
+type executePlan struct {
+	cfg             *executeConfig
+	declaresEffects bool
+
+	ts  TransactionalStorage
+	tds TransactionalDueStorage
+
+	// tss is non-nil when the definition has transaction-scoped guards; tsds is
+	// additionally non-nil when the backend also maintains the due index.
+	tss  TxScopedStorage
+	tsds TxScopedDueStorage
+
+	// check is how the in-scope load treats a stored-fingerprint mismatch.
+	check fingerprintCheck
+}
+
+// txScope is an open transaction that one cycle runs inside, or nil for the
+// ordinary path where the fire happens in memory and the transaction opens only
+// at the save.
+type txScope struct {
+	tss  TxScopedStorage
+	tsds TxScopedDueStorage
+	tx   any
+
+	// check is how the in-scope load treats the stored fingerprint, decided
+	// before the scope opened (see migrateBeforeScope).
+	check fingerprintCheck
+}
+
+// runCycle performs one load → fire → save attempt, opening a transaction
+// around the whole of it when the definition has transaction-scoped guards. It
+// returns the after-commit effects the caller must run once the state has
+// actually committed.
+func (m *Manager) runCycle(
+	ctx context.Context,
+	id string,
+	definition *Definition,
+	fn func(*Workflow) error,
+	p *executePlan,
+) ([]pendingAfterCommit, error) {
+	if p.tss == nil {
+		return m.cycle(ctx, nil, id, definition, fn, p)
+	}
+
+	var afterCommit []pendingAfterCommit
+	err := p.tss.BeginScope(ctx, func(ctx context.Context, tx any) error {
+		var err error
+		afterCommit, err = m.cycle(ctx, &txScope{tss: p.tss, tsds: p.tsds, tx: tx, check: p.check}, id, definition, fn, p)
+		return err
+	})
+	if err != nil {
+		// The scope rolled back, so nothing this attempt produced was committed
+		// — including the after-commit effects it had resolved.
+		return nil, err
+	}
+	return afterCommit, nil
+}
+
+// cycle is the body of one attempt. sc is nil on the ordinary path; when it is
+// set, the load, the guards, the save, and the effects all run inside sc.tx.
+func (m *Manager) cycle(
+	ctx context.Context,
+	sc *txScope,
+	id string,
+	definition *Definition,
+	fn func(*Workflow) error,
+	p *executePlan,
+) ([]pendingAfterCommit, error) {
+	wf, err := m.loadForCycle(ctx, sc, id, definition)
+	if err != nil {
+		return nil, err
+	}
+
+	if sc != nil {
+		// Bind for the duration of the fire only. A guard reached through a
+		// workflow value that outlived the scope must not find a committed
+		// transaction waiting for it.
+		wf.bindTx(sc.tx)
+		defer wf.bindTx(nil)
+	}
+	if err := fn(wf); err != nil {
+		return nil, err
+	}
+
+	marking, ctxData := wf.snapshotState()
+	ctxData = contextForSave(ctxData, definition)
+	due := m.dueForSave(definition, marking)
+
+	// Resolve the effects declared by whatever actually fired this attempt.
+	// Draining after fn (and after the snapshot) means a retried attempt
+	// starts from an empty log, so an abandoned attempt's effects can never
+	// leak into the one that commits.
+	var afterCommit []pendingAfterCommit
+	effects := p.cfg.effects
+	if p.declaresEffects {
+		steps := wf.drainFired()
+		txEffects, pending, rerr := m.resolveEffects(id, definition, steps, ctxData)
+		if rerr != nil {
+			return nil, rerr
+		}
+		effects = append(append([]TxSideEffect(nil), p.cfg.effects...), txEffects...)
+		afterCommit = pending
+	}
+
+	switch {
+	case sc != nil:
+		// Save into the very transaction the guards read from, then run the
+		// effects in it too. Same atomicity guarantee as SaveStateInTx — the
+		// difference is only who opened the transaction.
+		if sc.tsds != nil {
+			_, err = sc.tsds.SaveStateScopedWithDue(ctx, sc.tx, id, marking, ctxData, wf.Version(), due)
+		} else {
+			_, err = sc.tss.SaveStateScoped(ctx, sc.tx, id, marking, ctxData, wf.Version())
+		}
+		for _, effect := range effects {
+			if err != nil {
+				break
+			}
+			err = effect(ctx, sc.tx)
+		}
+	case p.ts != nil:
+		// Keep the due index current even on the transactional path (state +
+		// side effect commit together) when the backend supports it. A partial
+		// due backend (DueStorage but not TransactionalDueStorage) with a timed
+		// definition was already rejected before the loop.
+		if p.tds != nil {
+			_, err = p.tds.SaveStateInTxWithDue(ctx, id, marking, ctxData, wf.Version(), due, effects...)
+		} else {
+			_, err = p.ts.SaveStateInTx(ctx, id, marking, ctxData, wf.Version(), effects...)
+		}
+	default:
+		_, err = m.persistState(ctx, id, marking, ctxData, wf.Version(), due)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return afterCommit, nil
+}
+
+// loadForCycle loads the instance for one attempt, reading through the scope's
+// transaction when there is one so the marking and version a firing decides on
+// come from the same snapshot its guards read.
+func (m *Manager) loadForCycle(ctx context.Context, sc *txScope, id string, definition *Definition) (*Workflow, error) {
+	if sc == nil {
+		return m.loadFromStorage(ctx, id, definition)
+	}
+	return m.loadWith(ctx, id, definition, sc.check, func(ctx context.Context, id string) (Marking, map[string]any, int64, error) {
+		loaded, wfContext, version, err := sc.tss.LoadStateScoped(ctx, sc.tx, id)
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("failed to load workflow state: %w", err)
+		}
+		return loaded, wfContext, version, nil
+	})
+}
+
+// migrateBeforeScope runs the definition-fingerprint check, and therefore the
+// migration handler, outside any transaction of ours. It reports whether a
+// mismatch was found AND approved, so the in-scope load knows not to re-check
+// against a fingerprint the handler deliberately accepted. See the call site.
+func (m *Manager) migrateBeforeScope(ctx context.Context, id string, definition *Definition) (bool, error) {
+	_, wfContext, _, err := m.readState(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	return m.checkFingerprint(ctx, id, definition, wfContext)
 }
 
 // GetWorkflow gets a workflow instance, loading it fresh from storage (or from

--- a/mermaid.go
+++ b/mermaid.go
@@ -328,10 +328,22 @@ func renderDiagram(def *Definition, initial []Place, current map[Place]bool, tok
 		// branch). XOR-splits (alternative guarded transitions out of one
 		// place) need no gateway: the place is the choice point.
 		outLabel := ""
+		guards := make([]string, 0, 2)
 		if g, ok := t.Metadata("guard"); ok {
 			if gs, ok := g.(string); ok && gs != "" {
-				outLabel = "|\"❰ " + prettifyGuard(gs) + " ❱\"|"
+				guards = append(guards, prettifyGuard(gs))
 			}
+		}
+		// A transaction-scoped guard gates the firing exactly like a plain one;
+		// it is marked with ⛁ because WHEN it is evaluated differs — inside the
+		// firing transaction, against live host state.
+		if g, ok := t.Metadata(txGuardMeta); ok {
+			if gs, ok := g.(string); ok && gs != "" {
+				guards = append(guards, "⛁ "+prettifyGuard(gs))
+			}
+		}
+		if len(guards) > 0 {
+			outLabel = "|\"❰ " + strings.Join(guards, " ❱<br/>❰ ") + " ❱\"|"
 		}
 		if len(t.To()) > 1 {
 			fid := "f_" + nodeID(t.Name())

--- a/storage/scoped.go
+++ b/storage/scoped.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Ehab Terra
+// SPDX-License-Identifier: MIT
+
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/ehabterra/workflow"
+)
+
+// Transaction-scoped cycles (workflow.TxScopedStorage).
+//
+// The ordinary write path fires a transition in memory and opens a transaction
+// only to save. That leaves nowhere for a guard to read from: anything it needs
+// must have been resolved before the transaction existed, and may be stale by
+// the time it commits. These methods let the Manager borrow a transaction and
+// run the WHOLE load → fire → save cycle inside it, so a transaction-scoped
+// guard (workflow.NewTxExpressionConstraint) can query as of the state the save
+// is about to be checked against.
+//
+// They are thin: BeginScope is RunInTx, and the load/save are the existing
+// *sql.Tx methods behind an `any` so the Manager stays backend-agnostic.
+
+// scopeTx recovers the concrete transaction the Manager is handing back. It can
+// only fail if a caller passes a handle from a different backend, which is a
+// programming error worth naming precisely rather than panicking on.
+func scopeTx(tx any) (*sql.Tx, error) {
+	sqlTx, ok := tx.(*sql.Tx)
+	if !ok {
+		return nil, fmt.Errorf("storage: transaction-scoped call needs a *sql.Tx, got %T", tx)
+	}
+	if sqlTx == nil {
+		return nil, fmt.Errorf("storage: transaction-scoped call needs a non-nil *sql.Tx")
+	}
+	return sqlTx, nil
+}
+
+// --- SQLite ---
+
+// BeginScope implements workflow.TxScopedStorage: it opens a transaction, hands
+// it to fn as an any, and commits only if fn returns nil (rolling back on error
+// or panic).
+func (s *SQLiteStorage) BeginScope(ctx context.Context, fn func(context.Context, any) error) error {
+	return RunInTx(ctx, s.db, func(tx *sql.Tx) error {
+		return fn(ctx, tx)
+	})
+}
+
+// LoadStateScoped implements workflow.TxScopedStorage: LoadState through the
+// caller's transaction.
+func (s *SQLiteStorage) LoadStateScoped(ctx context.Context, tx any, id string) (workflow.Marking, map[string]any, int64, error) {
+	sqlTx, err := scopeTx(tx)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	return s.LoadStateTx(ctx, sqlTx, id)
+}
+
+// SaveStateScoped implements workflow.TxScopedStorage: the version-guarded save
+// through the caller's transaction. It does not touch the due index — see
+// SaveStateScopedWithDue.
+func (s *SQLiteStorage) SaveStateScoped(ctx context.Context, tx any, id string, marking workflow.Marking, ctxData map[string]any, expectedVersion int64) (int64, error) {
+	sqlTx, err := scopeTx(tx)
+	if err != nil {
+		return 0, err
+	}
+	return s.saveState(ctx, sqlTx, id, marking, ctxData, expectedVersion, nil, false)
+}
+
+// SaveStateScopedWithDue implements workflow.TxScopedDueStorage: the save and
+// the due-index update commit with everything else in the caller's transaction.
+func (s *SQLiteStorage) SaveStateScopedWithDue(ctx context.Context, tx any, id string, marking workflow.Marking, ctxData map[string]any, expectedVersion int64, due *time.Time) (int64, error) {
+	sqlTx, err := scopeTx(tx)
+	if err != nil {
+		return 0, err
+	}
+	return s.saveState(ctx, sqlTx, id, marking, ctxData, expectedVersion, due, true)
+}
+
+// --- Postgres ---
+
+// BeginScope implements workflow.TxScopedStorage (see the SQLite method).
+func (s *PostgresStorage) BeginScope(ctx context.Context, fn func(context.Context, any) error) error {
+	return RunInTx(ctx, s.db, func(tx *sql.Tx) error {
+		return fn(ctx, tx)
+	})
+}
+
+// LoadStateScoped implements workflow.TxScopedStorage: LoadState through the
+// caller's transaction.
+func (s *PostgresStorage) LoadStateScoped(ctx context.Context, tx any, id string) (workflow.Marking, map[string]any, int64, error) {
+	sqlTx, err := scopeTx(tx)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	return s.LoadStateTx(ctx, sqlTx, id)
+}
+
+// SaveStateScoped implements workflow.TxScopedStorage: the version-guarded save
+// through the caller's transaction.
+func (s *PostgresStorage) SaveStateScoped(ctx context.Context, tx any, id string, marking workflow.Marking, ctxData map[string]any, expectedVersion int64) (int64, error) {
+	sqlTx, err := scopeTx(tx)
+	if err != nil {
+		return 0, err
+	}
+	return s.saveState(ctx, sqlTx, id, marking, ctxData, expectedVersion, nil, false)
+}
+
+// SaveStateScopedWithDue implements workflow.TxScopedDueStorage.
+func (s *PostgresStorage) SaveStateScopedWithDue(ctx context.Context, tx any, id string, marking workflow.Marking, ctxData map[string]any, expectedVersion int64, due *time.Time) (int64, error) {
+	sqlTx, err := scopeTx(tx)
+	if err != nil {
+		return 0, err
+	}
+	return s.saveState(ctx, sqlTx, id, marking, ctxData, expectedVersion, due, true)
+}
+
+// Compile-time proof that both backends satisfy the scoped contracts.
+var (
+	_ workflow.TxScopedDueStorage = (*SQLiteStorage)(nil)
+	_ workflow.TxScopedDueStorage = (*PostgresStorage)(nil)
+)

--- a/storagetest/storagetest.go
+++ b/storagetest/storagetest.go
@@ -341,6 +341,144 @@ func Run(t *testing.T, newStore Factory) {
 	if _, ok := newStore(t).(workflow.DueStorage); ok {
 		runDue(t, newStore)
 	}
+
+	// Transaction-scoped cycle conformance, only if the backend supports it.
+	if _, ok := newStore(t).(workflow.TxScopedStorage); ok {
+		runScoped(t, newStore)
+	}
+}
+
+// runScoped exercises workflow.TxScopedStorage: the backend must lend out a
+// transaction in which a load and a version-guarded save behave exactly as they
+// do outside one — and which rolls everything back if the caller says so. This
+// is what lets a transaction-scoped guard read the state its own cycle is about
+// to commit against.
+func runScoped(t *testing.T, newStore Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	scoped := func(t *testing.T) workflow.TxScopedStorage {
+		ts, ok := newStore(t).(workflow.TxScopedStorage)
+		if !ok {
+			t.Fatal("store does not implement TxScopedStorage")
+		}
+		return ts
+	}
+
+	t.Run("Scoped/LoadAndSaveInsideOneTransaction", func(t *testing.T) {
+		s := scoped(t)
+		if _, err := s.SaveState(ctx, "wf", mk("draft"), map[string]any{"n": 1}, 0); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+
+		err := s.BeginScope(ctx, func(ctx context.Context, tx any) error {
+			m, c, version, err := s.LoadStateScoped(ctx, tx, "wf")
+			if err != nil {
+				return fmt.Errorf("LoadStateScoped: %w", err)
+			}
+			if places := m.Places(); len(places) != 1 || places[0] != "draft" {
+				return fmt.Errorf("LoadStateScoped marking = %v, want [draft]", places)
+			}
+			if c["n"] == nil {
+				return fmt.Errorf("LoadStateScoped dropped the context: %v", c)
+			}
+			_, err = s.SaveStateScoped(ctx, tx, "wf", mk("review"), c, version)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("BeginScope: %v", err)
+		}
+
+		m, _, _, err := s.LoadState(ctx, "wf")
+		if err != nil {
+			t.Fatalf("load after commit: %v", err)
+		}
+		if places := m.Places(); len(places) != 1 || places[0] != "review" {
+			t.Fatalf("after commit = %v, want [review]", places)
+		}
+	})
+
+	t.Run("Scoped/RollsBackOnError", func(t *testing.T) {
+		s := scoped(t)
+		if _, err := s.SaveState(ctx, "wf", mk("draft"), nil, 0); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+
+		sentinel := errors.New("caller said no")
+		err := s.BeginScope(ctx, func(ctx context.Context, tx any) error {
+			if _, err := s.SaveStateScoped(ctx, tx, "wf", mk("review"), nil, 1); err != nil {
+				return err
+			}
+			return sentinel // e.g. a guard rejected after the write
+		})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("BeginScope should surface the caller's error, got %v", err)
+		}
+
+		m, _, version, err := s.LoadState(ctx, "wf")
+		if err != nil {
+			t.Fatalf("load after rollback: %v", err)
+		}
+		if places := m.Places(); len(places) != 1 || places[0] != "draft" {
+			t.Fatalf("after rollback = %v, want [draft] — the scoped save was not undone", places)
+		}
+		if version != 1 {
+			t.Fatalf("version after rollback = %d, want 1", version)
+		}
+	})
+
+	t.Run("Scoped/VersionGuardStillApplies", func(t *testing.T) {
+		s := scoped(t)
+		if _, err := s.SaveState(ctx, "wf", mk("draft"), nil, 0); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		err := s.BeginScope(ctx, func(ctx context.Context, tx any) error {
+			_, err := s.SaveStateScoped(ctx, tx, "wf", mk("review"), nil, 99) // stale
+			return err
+		})
+		if !errors.Is(err, workflow.ErrConflict) {
+			t.Fatalf("a stale scoped save must return ErrConflict, got %v", err)
+		}
+	})
+
+	t.Run("Scoped/RejectsAForeignTransactionHandle", func(t *testing.T) {
+		s := scoped(t)
+		err := s.BeginScope(ctx, func(ctx context.Context, _ any) error {
+			_, _, _, err := s.LoadStateScoped(ctx, "not a transaction", "wf")
+			return err
+		})
+		if err == nil {
+			t.Fatal("a handle from another backend must be reported, not assumed")
+		}
+	})
+
+	// Scoped due-index conformance, only if the backend maintains one.
+	if _, ok := newStore(t).(workflow.TxScopedDueStorage); ok {
+		t.Run("Scoped/Due/CommitsWithState", func(t *testing.T) {
+			s, ok := newStore(t).(workflow.TxScopedDueStorage)
+			if !ok {
+				t.Fatal("store does not implement TxScopedDueStorage")
+			}
+			if _, err := s.SaveState(ctx, "wf", mk("draft"), nil, 0); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			due := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+			err := s.BeginScope(ctx, func(ctx context.Context, tx any) error {
+				_, err := s.SaveStateScopedWithDue(ctx, tx, "wf", mk("review"), nil, 1, &due)
+				return err
+			})
+			if err != nil {
+				t.Fatalf("BeginScope: %v", err)
+			}
+			ids, err := s.ListDue(ctx, due, 0)
+			if err != nil {
+				t.Fatalf("ListDue: %v", err)
+			}
+			if want := []string{"wf"}; !reflect.DeepEqual(ids, want) {
+				t.Fatalf("ListDue = %v, want %v — the due index did not commit with the scoped save", ids, want)
+			}
+		})
+	}
 }
 
 // runDue exercises the workflow.DueStorage contract: the maintained next-due

--- a/storagetest/storagetest.go
+++ b/storagetest/storagetest.go
@@ -398,6 +398,20 @@ func runScoped(t *testing.T, newStore Factory) {
 		}
 	})
 
+	t.Run("Scoped/LoadMissingReturnsNotFound", func(t *testing.T) {
+		// Manager.loadForCycle relies on the same not-found contract inside a
+		// scope as outside one; a backend that leaked a driver-specific error
+		// here would surface from Execute as something no caller can match.
+		s := scoped(t)
+		err := s.BeginScope(ctx, func(ctx context.Context, tx any) error {
+			_, _, _, err := s.LoadStateScoped(ctx, tx, "nope")
+			return err
+		})
+		if !errors.Is(err, workflow.ErrWorkflowNotFound) {
+			t.Fatalf("LoadStateScoped(missing) = %v, want ErrWorkflowNotFound", err)
+		}
+	})
+
 	t.Run("Scoped/RollsBackOnError", func(t *testing.T) {
 		s := scoped(t)
 		if _, err := s.SaveState(ctx, "wf", mk("draft"), nil, 0); err != nil {

--- a/transition.go
+++ b/transition.go
@@ -315,6 +315,17 @@ func (t *Transition) Metadata(key string) (any, bool) {
 	return value, ok
 }
 
+// needsTx reports whether any of this transition's constraints must be
+// evaluated inside the firing transaction (see TxScopedConstraint).
+func (t *Transition) needsTx() bool {
+	for _, c := range t.constraints {
+		if tc, ok := c.(TxScopedConstraint); ok && tc.NeedsTx() {
+			return true
+		}
+	}
+	return false
+}
+
 // validate validates the transition against all constraints (internal method)
 func (t *Transition) validate(event Event) error {
 	for _, constraint := range t.constraints {

--- a/txguard_test.go
+++ b/txguard_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ehabterra/workflow"
 	"github.com/ehabterra/workflow/storage"
@@ -45,8 +46,11 @@ func txGuardNet(t *testing.T, expr string, builder workflow.TxEnvBuilder) *workf
 	return def
 }
 
-// txGuardFixture wires a real SQLite backend plus a host table the guard reads.
-func txGuardFixture(t *testing.T, expr string) (*workflow.Manager, *workflow.Definition, *sql.DB) {
+// txGuardBackend wires a real SQLite backend plus the host table the guard
+// reads, and the environment that reads it. The environment queries through the
+// transaction it is handed — not through the *sql.DB — which is the whole point:
+// it sees the state this cycle will commit against.
+func txGuardBackend(t *testing.T) (*storage.SQLiteStorage, *sql.DB, workflow.TxEnvBuilder) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -68,9 +72,7 @@ func txGuardFixture(t *testing.T, expr string) (*workflow.Manager, *workflow.Def
 		t.Fatal(err)
 	}
 
-	// The env reads through the transaction it is handed — not through the *sql.DB
-	// — which is the whole point: it sees the state this cycle will commit against.
-	def := txGuardNet(t, expr, func(ctx context.Context, tx any, ev workflow.Event) map[string]any {
+	env := func(ctx context.Context, tx any, ev workflow.Event) map[string]any {
 		sqlTx := tx.(*sql.Tx)
 		return map[string]any{
 			"approvedCount": func() int {
@@ -82,9 +84,16 @@ func txGuardFixture(t *testing.T, expr string) (*workflow.Manager, *workflow.Def
 				return n
 			},
 		}
-	})
+	}
+	return store, db, env
+}
 
-	return workflow.NewManager(workflow.NewRegistry(), store), def, db
+// txGuardFixture is txGuardBackend plus the single-transition net most of these
+// tests use.
+func txGuardFixture(t *testing.T, expr string) (*workflow.Manager, *workflow.Definition, *sql.DB) {
+	t.Helper()
+	store, db, env := txGuardBackend(t)
+	return workflow.NewManager(workflow.NewRegistry(), store), txGuardNet(t, expr, env), db
 }
 
 func approveDoc(t *testing.T, db *sql.DB, doc string) {
@@ -225,33 +234,7 @@ func TestTxGuardDecidesBeforeEffectsRun(t *testing.T) {
 // a firing that was already chosen.
 func TestTxGuardRoutesApplyAny(t *testing.T) {
 	ctx := context.Background()
-	db, err := sql.Open("sqlite3", "file:"+t.Name()+"?mode=memory&cache=shared")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-	db.SetMaxOpenConns(1)
-
-	store, err := storage.NewSQLiteStorage(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := store.EnsureSchema(ctx); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.ExecContext(ctx, `CREATE TABLE approvals (doc TEXT NOT NULL)`); err != nil {
-		t.Fatal(err)
-	}
-
-	env := func(ctx context.Context, tx any, ev workflow.Event) map[string]any {
-		sqlTx := tx.(*sql.Tx)
-		return map[string]any{"approvedCount": func() int {
-			var n int
-			_ = sqlTx.QueryRowContext(ctx, `SELECT COUNT(*) FROM approvals WHERE doc = ?`,
-				ev.Workflow().Name()).Scan(&n)
-			return n
-		}}
-	}
+	store, db, env := txGuardBackend(t)
 	mustTx := func(e string) *workflow.ExpressionConstraint {
 		c, err := workflow.NewTxExpressionConstraint(e, env)
 		if err != nil {
@@ -293,13 +276,57 @@ func TestTxGuardRoutesApplyAny(t *testing.T) {
 	}
 }
 
+// conflictOnce wraps a TxScopedStorage and fails the FIRST scoped save with
+// ErrConflict, so Execute's retry path can be exercised deterministically. A
+// real contending writer cannot be used here: the scope holds SQLite's single
+// writer for the whole cycle, so a second writer would block rather than race.
+type conflictOnce struct {
+	workflow.TxScopedDueStorage
+	scopes int
+	failed bool
+}
+
+func (c *conflictOnce) BeginScope(ctx context.Context, fn func(context.Context, any) error) error {
+	c.scopes++
+	return c.TxScopedDueStorage.BeginScope(ctx, fn)
+}
+
+func (c *conflictOnce) SaveStateScoped(ctx context.Context, tx any, id string, m workflow.Marking, ctxData map[string]any, expected int64) (int64, error) {
+	if c.conflict() {
+		return 0, workflow.ErrConflict
+	}
+	return c.TxScopedDueStorage.SaveStateScoped(ctx, tx, id, m, ctxData, expected)
+}
+
+// SaveStateScopedWithDue must be wrapped too: the Manager prefers it over
+// SaveStateScoped for any backend that maintains a due index, so overriding only
+// the plain one would silently never be called.
+func (c *conflictOnce) SaveStateScopedWithDue(ctx context.Context, tx any, id string, m workflow.Marking, ctxData map[string]any, expected int64, due *time.Time) (int64, error) {
+	if c.conflict() {
+		return 0, workflow.ErrConflict
+	}
+	return c.TxScopedDueStorage.SaveStateScopedWithDue(ctx, tx, id, m, ctxData, expected, due)
+}
+
+func (c *conflictOnce) conflict() bool {
+	if c.failed {
+		return false
+	}
+	c.failed = true
+	return true
+}
+
 // TestTxGuardRetriesReDecideOnEachAttempt: Execute retries the whole cycle on
-// ErrConflict and each attempt opens a NEW transaction, so the guard is
-// re-evaluated rather than reusing an answer from the losing attempt.
+// ErrConflict, and each attempt opens a NEW transaction — so the guard is
+// evaluated again rather than reusing an answer from the losing attempt, which
+// was computed against state that did not commit.
 func TestTxGuardRetriesReDecideOnEachAttempt(t *testing.T) {
 	ctx := context.Background()
-	mgr, def, db := txGuardFixture(t, "approvedCount() >= 2")
+	store, db, env := txGuardBackend(t)
+	def := txGuardNet(t, "approvedCount() >= 2", env)
 
+	wrapped := &conflictOnce{TxScopedDueStorage: store}
+	mgr := workflow.NewManager(workflow.NewRegistry(), wrapped)
 	if _, err := mgr.CreateWorkflow(ctx, "doc-5", def, "draft"); err != nil {
 		t.Fatal(err)
 	}
@@ -318,12 +345,25 @@ func TestTxGuardRetriesReDecideOnEachAttempt(t *testing.T) {
 	if err := mgr.Execute(ctx, "doc-5", def, func(wf *workflow.Workflow) error {
 		return wf.ApplyTransitionWithContext(ctx, "publish")
 	}); err != nil {
-		t.Fatal(err)
+		t.Fatalf("execute should succeed on the retry: %v", err)
 	}
+
 	mu.Lock()
 	defer mu.Unlock()
-	if evaluations != 1 {
-		t.Fatalf("uncontended cycle should evaluate the guard once, got %d", evaluations)
+	if evaluations != 2 {
+		t.Fatalf("guard evaluations = %d, want 2 (one per attempt)", evaluations)
+	}
+	if wrapped.scopes != 2 {
+		t.Fatalf("scopes opened = %d, want 2 — each attempt must get its own transaction", wrapped.scopes)
+	}
+
+	// The winning attempt committed.
+	wf, err := mgr.LoadWorkflow(ctx, "doc-5", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if places := wf.CurrentPlaces(); len(places) != 1 || places[0] != "published" {
+		t.Fatalf("want [published], got %v", places)
 	}
 }
 

--- a/txguard_test.go
+++ b/txguard_test.go
@@ -1,0 +1,506 @@
+// Copyright (c) 2026 Ehab Terra
+// SPDX-License-Identifier: MIT
+
+package workflow_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/ehabterra/workflow"
+	"github.com/ehabterra/workflow/storage"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// txGuardNet is the shape #35 exists for: whether the transition may fire is a
+// fact about HOST data, not about the marking. Before tx-scoped guards the host
+// had to read that fact, hand it in as a context boolean, and hope nothing
+// changed before the save.
+//
+//	publish : draft -> published    tx_guard: "approvedCount() >= 2"
+//
+// `approvedCount` reads the host's own table through the firing transaction.
+func txGuardNet(t *testing.T, expr string, builder workflow.TxEnvBuilder) *workflow.Definition {
+	t.Helper()
+	publish := workflow.MustNewTransition("publish",
+		[]workflow.Place{"draft"}, []workflow.Place{"published"})
+	c, err := workflow.NewTxExpressionConstraint(expr, builder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publish.AddConstraint(c)
+	publish.SetMetadata("tx_guard", expr)
+
+	def, err := workflow.NewDefinition(
+		[]workflow.Place{"draft", "published"},
+		[]workflow.Transition{*publish},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return def
+}
+
+// txGuardFixture wires a real SQLite backend plus a host table the guard reads.
+func txGuardFixture(t *testing.T, expr string) (*workflow.Manager, *workflow.Definition, *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := sql.Open("sqlite3", "file:"+t.Name()+"?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1) // one shared in-memory database behind one lock
+
+	store, err := storage.NewSQLiteStorage(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.EnsureSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, `CREATE TABLE approvals (doc TEXT NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// The env reads through the transaction it is handed — not through the *sql.DB
+	// — which is the whole point: it sees the state this cycle will commit against.
+	def := txGuardNet(t, expr, func(ctx context.Context, tx any, ev workflow.Event) map[string]any {
+		sqlTx := tx.(*sql.Tx)
+		return map[string]any{
+			"approvedCount": func() int {
+				var n int
+				if err := sqlTx.QueryRowContext(ctx,
+					`SELECT COUNT(*) FROM approvals WHERE doc = ?`, ev.Workflow().Name()).Scan(&n); err != nil {
+					return -1
+				}
+				return n
+			},
+		}
+	})
+
+	return workflow.NewManager(workflow.NewRegistry(), store), def, db
+}
+
+func approveDoc(t *testing.T, db *sql.DB, doc string) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO approvals (doc) VALUES (?)`, doc); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestTxGuardReadsHostStateInsideTheFiringTransaction is the headline: the guard
+// consults the host's own table, with no value pre-computed into the context.
+func TestTxGuardReadsHostStateInsideTheFiringTransaction(t *testing.T) {
+	ctx := context.Background()
+	mgr, def, db := txGuardFixture(t, "approvedCount() >= 2")
+
+	if _, err := mgr.CreateWorkflow(ctx, "doc-1", def, "draft"); err != nil {
+		t.Fatal(err)
+	}
+
+	fire := func() error {
+		return mgr.Execute(ctx, "doc-1", def, func(wf *workflow.Workflow) error {
+			return wf.ApplyTransitionWithContext(ctx, "publish")
+		})
+	}
+
+	// One approval is not enough — and the rejection rolls the cycle back, so
+	// nothing is persisted.
+	approveDoc(t, db, "doc-1")
+	if err := fire(); !errors.Is(err, workflow.ErrGuardRejected) {
+		t.Fatalf("one approval: want ErrGuardRejected, got %v", err)
+	}
+	wf, err := mgr.LoadWorkflow(ctx, "doc-1", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if places := wf.CurrentPlaces(); len(places) != 1 || places[0] != "draft" {
+		t.Fatalf("a rejected firing must not persist, got %v", places)
+	}
+
+	// The second approval flips the answer with no change to the workflow.
+	approveDoc(t, db, "doc-1")
+	if err := fire(); err != nil {
+		t.Fatalf("two approvals: %v", err)
+	}
+	wf, err = mgr.LoadWorkflow(ctx, "doc-1", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if places := wf.CurrentPlaces(); len(places) != 1 || places[0] != "published" {
+		t.Fatalf("want [published], got %v", places)
+	}
+}
+
+// TestTxGuardRejectsWhenTheInputChangedAfterThePreRead is the acceptance
+// criterion of #35, stated exactly: a host that resolved its decision BEFORE the
+// transaction opened would fire on a value that is no longer true. The
+// tx-scoped guard re-reads inside the transaction and refuses.
+func TestTxGuardRejectsWhenTheInputChangedAfterThePreRead(t *testing.T) {
+	ctx := context.Background()
+	mgr, def, db := txGuardFixture(t, "approvedCount() >= 2")
+
+	if _, err := mgr.CreateWorkflow(ctx, "doc-2", def, "draft"); err != nil {
+		t.Fatal(err)
+	}
+	approveDoc(t, db, "doc-2")
+	approveDoc(t, db, "doc-2")
+
+	// The host reads its precondition here — two approvals, publish is legal —
+	// and this is the value a pre-#35 implementation would have injected into
+	// the workflow context and fired on.
+	var preRead int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM approvals WHERE doc = 'doc-2'`).Scan(&preRead); err != nil {
+		t.Fatal(err)
+	}
+	if preRead < 2 {
+		t.Fatalf("fixture: want the pre-read to say publish is legal, got %d", preRead)
+	}
+
+	// ...and then an approval is withdrawn before the fire.
+	if _, err := db.Exec(`DELETE FROM approvals WHERE doc = 'doc-2'`); err != nil {
+		t.Fatal(err)
+	}
+
+	err := mgr.Execute(ctx, "doc-2", def, func(wf *workflow.Workflow) error {
+		return wf.ApplyTransitionWithContext(ctx, "publish")
+	})
+	if !errors.Is(err, workflow.ErrGuardRejected) {
+		t.Fatalf("the guard must re-decide inside the transaction, got %v", err)
+	}
+
+	wf, err := mgr.LoadWorkflow(ctx, "doc-2", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if places := wf.CurrentPlaces(); len(places) != 1 || places[0] != "draft" {
+		t.Fatalf("stale pre-read must not publish, got %v", places)
+	}
+}
+
+// TestTxGuardDecidesBeforeEffectsRun pins the phase ordering, which matters now
+// that guards and effects share one transaction: the guard still runs during the
+// fire, BEFORE any effect writes. An effect cannot make a guard true.
+func TestTxGuardDecidesBeforeEffectsRun(t *testing.T) {
+	ctx := context.Background()
+	mgr, def, db := txGuardFixture(t, "approvedCount() >= 2")
+
+	if _, err := mgr.CreateWorkflow(ctx, "doc-3", def, "draft"); err != nil {
+		t.Fatal(err)
+	}
+	approveDoc(t, db, "doc-3")
+
+	// An effect writes the second approval into the cycle's own transaction. If
+	// effects ran before the decision, the guard would see two and publish.
+	err := mgr.Execute(ctx, "doc-3", def, func(wf *workflow.Workflow) error {
+		return wf.ApplyTransitionWithContext(ctx, "publish")
+	}, workflow.WithTxSideEffect(func(ctx context.Context, tx any) error {
+		_, err := tx.(*sql.Tx).ExecContext(ctx, `INSERT INTO approvals (doc) VALUES ('doc-3')`)
+		return err
+	}))
+	// The guard ran before the effect, so it still saw one approval: effects are
+	// a post-decision phase, and this pins that ordering.
+	if !errors.Is(err, workflow.ErrGuardRejected) {
+		t.Fatalf("guards decide before effects run, got %v", err)
+	}
+
+	// And because the whole cycle rolled back, the effect's insert is gone too.
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM approvals WHERE doc = 'doc-3'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("the rolled-back cycle left %d approvals, want 1", n)
+	}
+}
+
+// TestTxGuardRoutesApplyAny: because the WHOLE fire happens inside the
+// transaction, a tx-scoped guard can route an ApplyAny branch — not merely veto
+// a firing that was already chosen.
+func TestTxGuardRoutesApplyAny(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite3", "file:"+t.Name()+"?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+
+	store, err := storage.NewSQLiteStorage(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.EnsureSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, `CREATE TABLE approvals (doc TEXT NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+
+	env := func(ctx context.Context, tx any, ev workflow.Event) map[string]any {
+		sqlTx := tx.(*sql.Tx)
+		return map[string]any{"approvedCount": func() int {
+			var n int
+			_ = sqlTx.QueryRowContext(ctx, `SELECT COUNT(*) FROM approvals WHERE doc = ?`,
+				ev.Workflow().Name()).Scan(&n)
+			return n
+		}}
+	}
+	mustTx := func(e string) *workflow.ExpressionConstraint {
+		c, err := workflow.NewTxExpressionConstraint(e, env)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+
+	full := workflow.MustNewTransition("publish_full", []workflow.Place{"draft"}, []workflow.Place{"published"})
+	full.AddConstraint(mustTx("approvedCount() >= 2"))
+	full.SetMetadata("tx_guard", "approvedCount() >= 2")
+	partial := workflow.MustNewTransition("publish_preview", []workflow.Place{"draft"}, []workflow.Place{"preview"})
+	partial.AddConstraint(mustTx("approvedCount() >= 1"))
+	partial.SetMetadata("tx_guard", "approvedCount() >= 1")
+
+	def, err := workflow.NewDefinition(
+		[]workflow.Place{"draft", "preview", "published"},
+		[]workflow.Transition{*full, *partial},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr := workflow.NewManager(workflow.NewRegistry(), store)
+	if _, err := mgr.CreateWorkflow(ctx, "doc-4", def, "draft"); err != nil {
+		t.Fatal(err)
+	}
+
+	approveDoc(t, db, "doc-4")
+	var fired string
+	if err := mgr.Execute(ctx, "doc-4", def, func(wf *workflow.Workflow) error {
+		var err error
+		fired, err = wf.ApplyAny(ctx, "publish_full", "publish_preview")
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if fired != "publish_preview" {
+		t.Fatalf("one approval should route to the preview branch, got %q", fired)
+	}
+}
+
+// TestTxGuardRetriesReDecideOnEachAttempt: Execute retries the whole cycle on
+// ErrConflict and each attempt opens a NEW transaction, so the guard is
+// re-evaluated rather than reusing an answer from the losing attempt.
+func TestTxGuardRetriesReDecideOnEachAttempt(t *testing.T) {
+	ctx := context.Background()
+	mgr, def, db := txGuardFixture(t, "approvedCount() >= 2")
+
+	if _, err := mgr.CreateWorkflow(ctx, "doc-5", def, "draft"); err != nil {
+		t.Fatal(err)
+	}
+	approveDoc(t, db, "doc-5")
+	approveDoc(t, db, "doc-5")
+
+	var mu sync.Mutex
+	evaluations := 0
+	def.AddGuardEventListener(func(ev *workflow.GuardEvent) error {
+		mu.Lock()
+		evaluations++
+		mu.Unlock()
+		return nil
+	})
+
+	if err := mgr.Execute(ctx, "doc-5", def, func(wf *workflow.Workflow) error {
+		return wf.ApplyTransitionWithContext(ctx, "publish")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if evaluations != 1 {
+		t.Fatalf("uncontended cycle should evaluate the guard once, got %d", evaluations)
+	}
+}
+
+// --- refusals ---
+
+// TestTxGuardOutsideATransactionRefuses: a guard that exists because staleness
+// is wrong must not answer from stale state when nobody gave it a transaction.
+func TestTxGuardOutsideATransactionRefuses(t *testing.T) {
+	def := txGuardNet(t, "ok()", func(ctx context.Context, tx any, ev workflow.Event) map[string]any {
+		return map[string]any{"ok": func() bool { return true }}
+	})
+	wf, err := workflow.NewWorkflow("bare", def, "draft")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := wf.ApplyTransition("publish"); !errors.Is(err, workflow.ErrNoTransaction) {
+		t.Fatalf("bare Apply: want ErrNoTransaction, got %v", err)
+	}
+	if err := wf.CanTransition("publish"); !errors.Is(err, workflow.ErrNoTransaction) {
+		t.Fatalf("bare Can: want ErrNoTransaction, got %v", err)
+	}
+	if places := wf.CurrentPlaces(); len(places) != 1 || places[0] != "draft" {
+		t.Fatalf("nothing should have moved, got %v", places)
+	}
+}
+
+// TestTxGuardOnNonScopedStorageRefuses: the capability is checked up front,
+// before anything fires, so an unsupported backend is a clear error rather than
+// a guard failure halfway through.
+func TestTxGuardOnNonScopedStorageRefuses(t *testing.T) {
+	ctx := context.Background()
+	def := txGuardNet(t, "ok()", func(ctx context.Context, tx any, ev workflow.Event) map[string]any {
+		return map[string]any{"ok": func() bool { return true }}
+	})
+	mgr := workflow.NewManager(workflow.NewRegistry(), newMemStore())
+	if _, err := mgr.CreateWorkflow(ctx, "w", def, "draft"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := mgr.Execute(ctx, "w", def, func(wf *workflow.Workflow) error {
+		return wf.ApplyTransitionWithContext(ctx, "publish")
+	})
+	if !errors.Is(err, errors.ErrUnsupported) {
+		t.Fatalf("want errors.ErrUnsupported, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "TxScopedStorage") {
+		t.Errorf("the error should name the missing capability, got %q", err)
+	}
+}
+
+func TestNewTxExpressionConstraintRejectsMalformed(t *testing.T) {
+	builder := func(ctx context.Context, tx any, ev workflow.Event) map[string]any { return nil }
+	if _, err := workflow.NewTxExpressionConstraint("", builder); err == nil {
+		t.Error("empty expression should be rejected")
+	}
+	if _, err := workflow.NewTxExpressionConstraint("ok()", nil); err == nil {
+		t.Error("nil builder should be rejected")
+	}
+	if _, err := workflow.NewTxExpressionConstraint("len(", builder); err == nil {
+		t.Error("uncompilable expression should be rejected")
+	}
+}
+
+// TestTxGuardIsFingerprintedAndDiagrammed: a tx guard decides when the net may
+// fire, so it is structure — and it must be visible, since a reader cannot see
+// it in the arcs.
+func TestTxGuardIsFingerprintedAndDiagrammed(t *testing.T) {
+	builder := func(ctx context.Context, tx any, ev workflow.Event) map[string]any { return nil }
+	build := func(expr string) *workflow.Definition {
+		t.Helper()
+		tr := workflow.MustNewTransition("publish", []workflow.Place{"draft"}, []workflow.Place{"published"})
+		if expr != "" {
+			c, err := workflow.NewTxExpressionConstraint(expr, builder)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tr.AddConstraint(c)
+			tr.SetMetadata("tx_guard", expr)
+		}
+		def, err := workflow.NewDefinition(
+			[]workflow.Place{"draft", "published"}, []workflow.Transition{*tr})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return def
+	}
+
+	none, one, other := build("").Fingerprint(), build("a()").Fingerprint(), build("b()").Fingerprint()
+	if one == none {
+		t.Error("adding a tx guard must move the fingerprint")
+	}
+	if one == other {
+		t.Error("changing the tx guard expression must move the fingerprint")
+	}
+	if one != build("a()").Fingerprint() {
+		t.Error("fingerprints must be stable")
+	}
+
+	diagram := build("approvedCount() >= 2").Diagram()
+	if !strings.Contains(diagram, "⛁") || !strings.Contains(diagram, "approvedCount()") {
+		t.Errorf("the diagram should show the tx guard:\n%s", diagram)
+	}
+}
+
+// TestTxGuardMigrationRunsOutsideTheScope: the migration handler is host code
+// that may write to storage, so consulting it while our own transaction is open
+// on the same rows would deadlock. It runs before the scope instead.
+func TestTxGuardMigrationRunsOutsideTheScope(t *testing.T) {
+	ctx := context.Background()
+	mgr, def, db := txGuardFixture(t, "approvedCount() >= 1")
+
+	// Persist under one definition...
+	if _, err := mgr.CreateWorkflow(ctx, "doc-6", def, "draft"); err != nil {
+		t.Fatal(err)
+	}
+	approveDoc(t, db, "doc-6")
+
+	// ...then drive it with a structurally different one.
+	changed := txGuardNet(t, "approvedCount() >= 1", func(ctx context.Context, tx any, ev workflow.Event) map[string]any {
+		return map[string]any{"approvedCount": func() int { return 1 }}
+	})
+	changed.Places = append(changed.Places, "archived")
+	if changed.Fingerprint() == def.Fingerprint() {
+		t.Fatal("fixture: the two definitions should differ structurally")
+	}
+
+	store, err := storage.NewSQLiteStorage(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var seen *workflow.DefinitionDiff
+	migrating := workflow.NewManager(workflow.NewRegistry(), store,
+		workflow.WithDefinitionMigration(func(ctx context.Context, mismatch workflow.DefinitionMismatch) error {
+			seen = mismatch.Diff
+			return nil // approve
+		}))
+
+	if err := migrating.Execute(ctx, "doc-6", changed, func(wf *workflow.Workflow) error {
+		return wf.ApplyTransitionWithContext(ctx, "publish")
+	}); err != nil {
+		t.Fatalf("execute after approved migration: %v", err)
+	}
+	if seen == nil {
+		t.Fatal("the migration handler was never consulted")
+	}
+	if len(seen.PlacesAdded) != 1 || seen.PlacesAdded[0] != "archived" {
+		t.Errorf("diff should report the added place, got %v", seen)
+	}
+}
+
+// TestTxGuardEnvIsAddedToTheStandardEnvironment: a tx guard is nearly always a
+// comparison between something read live and something the host passed in, so
+// the builder's entries are added to the usual environment rather than
+// replacing it. (Found by using the feature: replacing it turned every such
+// guard into a silent nil comparison.)
+func TestTxGuardEnvIsAddedToTheStandardEnvironment(t *testing.T) {
+	ctx := context.Background()
+	mgr, def, db := txGuardFixture(t, "approvedCount() >= threshold")
+
+	if _, err := mgr.CreateWorkflow(ctx, "doc-7", def, "draft"); err != nil {
+		t.Fatal(err)
+	}
+	approveDoc(t, db, "doc-7")
+
+	// `threshold` is a plain context value; `approvedCount()` comes from the
+	// builder. Both must resolve in the same expression.
+	if err := mgr.Execute(ctx, "doc-7", def, func(wf *workflow.Workflow) error {
+		wf.SetContext("threshold", 5)
+		return wf.ApplyTransitionWithContext(ctx, "publish")
+	}); !errors.Is(err, workflow.ErrGuardRejected) {
+		t.Fatalf("threshold 5: want ErrGuardRejected, got %v", err)
+	}
+	if err := mgr.Execute(ctx, "doc-7", def, func(wf *workflow.Workflow) error {
+		wf.SetContext("threshold", 1)
+		return wf.ApplyTransitionWithContext(ctx, "publish")
+	}); err != nil {
+		t.Fatalf("threshold 1: %v", err)
+	}
+}

--- a/workflow.go
+++ b/workflow.go
@@ -38,6 +38,13 @@ type Workflow struct {
 	// persisted, and ignored by non-versioned backends.
 	version int64
 
+	// activeTx is the transaction the current firing cycle runs inside, bound by
+	// Manager.Execute for the duration of the caller's fn when the definition
+	// has transaction-scoped guards (see TxScopedStorage). It is nil at every
+	// other moment, and a tx-scoped guard evaluated while it is nil fails with
+	// ErrNoTransaction rather than silently reading outside the transaction.
+	activeTx any
+
 	// fired logs the transitions applied to this instance, in order, with the
 	// marking either side of each. Manager.Execute drains it after the caller's
 	// function returns to resolve the effects those transitions declare.
@@ -79,6 +86,23 @@ func (w *Workflow) setVersion(v int64) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.version = v
+}
+
+// bindTx binds (or, with nil, releases) the transaction the current firing
+// cycle runs inside. Manager.Execute owns the lifetime: it binds before calling
+// the caller's fn and releases before the scope closes, so a workflow value that
+// outlives the cycle can never hand a committed transaction to a guard.
+func (w *Workflow) bindTx(tx any) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.activeTx = tx
+}
+
+// tx returns the transaction bound to the current firing cycle, or nil.
+func (w *Workflow) tx() any {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.activeTx
 }
 
 // setClock pins the token-stamping clock (used by Manager.FireDue so tokens
@@ -200,6 +224,49 @@ type TransactionalStorage interface {
 	// Effects run in order after the state write; each receives the
 	// backend-specific transaction handle.
 	SaveStateInTx(ctx context.Context, id string, marking Marking, context map[string]any, expectedVersion int64, effects ...TxSideEffect) (newVersion int64, err error)
+}
+
+// TxScopedStorage is an optional interface a Storage backend may implement to
+// run a WHOLE load → fire → save cycle inside one transaction that the caller
+// drives. It is what lets a guard read host state as of the firing transaction
+// (see NewTxExpressionConstraint): ordinarily a fire happens entirely in memory
+// and the transaction only opens at the save, so there is nowhere for a guard to
+// look.
+//
+// The trade is real and deliberate: on this path a database transaction stays
+// open across the caller's fn, its guards, and every event listener they
+// trigger. Keep that code short and free of network calls — see
+// docs/BOUNDARIES.md.
+type TxScopedStorage interface {
+	TransactionalStorage
+
+	// BeginScope opens a transaction, invokes fn with the backend-specific
+	// handle (the SQL backends pass a *sql.Tx), and commits only if fn returns
+	// nil — rolling back on error or panic. Nesting is not supported.
+	BeginScope(ctx context.Context, fn func(ctx context.Context, tx any) error) error
+
+	// LoadStateScoped is LoadState within the caller's transaction, so the
+	// marking and version a firing decides on come from the same snapshot the
+	// guards read.
+	LoadStateScoped(ctx context.Context, tx any, id string) (marking Marking, context map[string]any, version int64, err error)
+
+	// SaveStateScoped is SaveState within the caller's transaction. Version
+	// checking is unchanged: a stale writer still gets ErrConflict.
+	SaveStateScoped(ctx context.Context, tx any, id string, marking Marking, context map[string]any, expectedVersion int64) (newVersion int64, err error)
+}
+
+// TxScopedDueStorage composes a tx-scoped save with the next-due index — the
+// scoped counterpart of DueStorage.SaveStateWithDue. A backend that is both a
+// TxScopedStorage and a DueStorage MUST implement it, for the same reason
+// TransactionalDueStorage exists: committing state without updating the due
+// column in the same transaction silently corrupts the index.
+type TxScopedDueStorage interface {
+	TxScopedStorage
+	DueStorage
+
+	// SaveStateScopedWithDue behaves like SaveStateScoped but also records the
+	// instance's next-due time (nil clears it).
+	SaveStateScopedWithDue(ctx context.Context, tx any, id string, marking Marking, context map[string]any, expectedVersion int64, due *time.Time) (newVersion int64, err error)
 }
 
 // DueStorage is an optional interface a Storage backend may implement to

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -106,6 +106,8 @@ workflow:
       from: [string]        # Required: Source places
       to: [string]          # Required: Target places
       guard: string         # Optional: Expression guard
+      tx_guard: string      # Optional: Expression evaluated INSIDE the firing transaction
+                            #   (needs yaml.NewLoaderWithTxEnv + a TxScopedStorage backend)
       after: string         # Optional: Timeout duration, e.g. "72h" (host-driven timers)
       from_any: bool        # Optional: OR-input — enabled by ANY one marked input, consuming only it
       resets: [string]      # Optional: Places cleared when this transition fires (cancellation region)

--- a/yaml/config.go
+++ b/yaml/config.go
@@ -90,6 +90,7 @@ type TransitionConfig struct {
 	From         []string       `yaml:"from"`
 	To           []string       `yaml:"to"`
 	Guard        string         `yaml:"guard,omitempty"`         // Expression string
+	TxGuard      string         `yaml:"tx_guard,omitempty"`      // Expression evaluated INSIDE the firing transaction (needs a Loader TxEnvBuilder)
 	After        string         `yaml:"after,omitempty"`         // Timeout duration, e.g. "72h" (Go time.ParseDuration)
 	Resets       []string       `yaml:"resets,omitempty"`        // Places cleared when this transition fires (cancellation region)
 	FromAny      bool           `yaml:"from_any,omitempty"`      // OR-input: enabled by ANY one marked from-place; consumes only it

--- a/yaml/loader.go
+++ b/yaml/loader.go
@@ -15,6 +15,13 @@ import (
 type Loader struct {
 	// EnvBuilder allows customizing the expression evaluation environment
 	EnvBuilder func(workflow.Event) map[string]any
+
+	// TxEnvBuilder builds the environment for `tx_guard:` expressions, which are
+	// evaluated INSIDE the firing transaction and can therefore query host state
+	// as of the state the save is about to be checked against. A definition that
+	// uses `tx_guard:` without one fails to load — there would be nothing for the
+	// expression to call.
+	TxEnvBuilder workflow.TxEnvBuilder
 }
 
 // NewLoader creates a new YAML loader.
@@ -26,6 +33,19 @@ func NewLoader() *Loader {
 func NewLoaderWithEnv(envBuilder func(workflow.Event) map[string]any) *Loader {
 	return &Loader{
 		EnvBuilder: envBuilder,
+	}
+}
+
+// NewLoaderWithTxEnv creates a loader that can compile `tx_guard:` expressions:
+// guards evaluated inside the firing transaction, against an environment the
+// builder assembles from that transaction.
+//
+// Definitions loaded this way must be driven with Manager.Execute against a
+// workflow.TxScopedStorage backend; see workflow.TxEnvBuilder for the contract
+// (including what happens across ErrConflict retries).
+func NewLoaderWithTxEnv(txEnvBuilder workflow.TxEnvBuilder) *Loader {
+	return &Loader{
+		TxEnvBuilder: txEnvBuilder,
 	}
 }
 
@@ -98,6 +118,26 @@ func (l *Loader) LoadDefinition(config *Config) (*workflow.Definition, error) {
 			transition.AddConstraint(exprConstraint)
 			// Store guard string in metadata for diagram generation
 			transition.SetMetadata("guard", transConfig.Guard)
+		}
+
+		// Transaction-scoped guard: evaluated inside the firing transaction, so
+		// it can consult host state rather than a value read before the
+		// transaction opened. Without a builder there is nothing for it to call,
+		// so refuse at load rather than at the first firing.
+		if transConfig.TxGuard != "" {
+			if l.TxEnvBuilder == nil {
+				return nil, fmt.Errorf("transition '%s': tx_guard needs a loader built with NewLoaderWithTxEnv "+
+					"(the expression is evaluated inside the firing transaction and has nothing to query without one)",
+					transConfig.Name)
+			}
+			txConstraint, err := workflow.NewTxExpressionConstraint(transConfig.TxGuard, l.TxEnvBuilder)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create tx_guard constraint for transition '%s': %w", transConfig.Name, err)
+			}
+			transition.AddConstraint(txConstraint)
+			// Structural: the expression is part of the definition fingerprint
+			// and is rendered on the diagram, like a plain guard.
+			transition.SetMetadata("tx_guard", transConfig.TxGuard)
 		}
 
 		// Add timeout if provided ("after: 72h" — host-driven timers, roadmap M4)

--- a/yaml/txguard_test.go
+++ b/yaml/txguard_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Ehab Terra
+// SPDX-License-Identifier: MIT
+
+package yaml_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/workflow"
+	"github.com/ehabterra/workflow/yaml"
+)
+
+const txGuardYAML = `
+workflow:
+  name: doc
+  initial_marking: draft
+  transitions:
+    - name: publish
+      from: [draft]
+      to: [published]
+      guard: "hasRole('editor')"
+      tx_guard: "approvedCount() >= 2"
+`
+
+// TestTxGuardFromYAML: both guards wire up, and the tx-scoped one is recorded
+// as structure so it reaches the fingerprint and the diagram.
+func TestTxGuardFromYAML(t *testing.T) {
+	cfg, err := yaml.LoadConfigFromBytes([]byte(txGuardYAML))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	loader := yaml.NewLoaderWithTxEnv(func(ctx context.Context, tx any, ev workflow.Event) map[string]any {
+		return map[string]any{"approvedCount": func() int { return 0 }}
+	})
+	def, err := loader.LoadDefinition(cfg)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	tr := def.Transition("publish")
+	if v, ok := tr.Metadata("tx_guard"); !ok || v != "approvedCount() >= 2" {
+		t.Fatalf("tx_guard metadata = %v (ok=%v)", v, ok)
+	}
+	if v, ok := tr.Metadata("guard"); !ok || v != "hasRole('editor')" {
+		t.Fatalf("the plain guard must survive alongside it, got %v (ok=%v)", v, ok)
+	}
+	if !strings.Contains(def.Diagram(), "approvedCount()") {
+		t.Error("the diagram should show the tx guard")
+	}
+
+	// Both are structural: changing either moves the fingerprint.
+	other, err := yaml.LoadConfigFromBytes([]byte(
+		strings.Replace(txGuardYAML, ">= 2", ">= 3", 1)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherDef, err := loader.LoadDefinition(other)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def.Fingerprint() == otherDef.Fingerprint() {
+		t.Error("changing the tx_guard expression must move the fingerprint")
+	}
+}
+
+// TestTxGuardWithoutABuilderIsRejectedAtLoad: a tx_guard has nothing to call
+// without a TxEnvBuilder, so the failure belongs at load, not at the first
+// firing of the branch that uses it.
+func TestTxGuardWithoutABuilderIsRejectedAtLoad(t *testing.T) {
+	cfg, err := yaml.LoadConfigFromBytes([]byte(txGuardYAML))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	_, err = yaml.NewLoader().LoadDefinition(cfg)
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	if !strings.Contains(err.Error(), "NewLoaderWithTxEnv") {
+		t.Fatalf("the error should say how to fix it, got %v", err)
+	}
+}
+
+// TestTxGuardMalformedExpressionIsRejectedAtLoad mirrors the plain-guard rule.
+func TestTxGuardMalformedExpressionIsRejectedAtLoad(t *testing.T) {
+	cfg, err := yaml.LoadConfigFromBytes([]byte(`
+workflow:
+  name: doc
+  initial_marking: draft
+  transitions:
+    - name: publish
+      from: [draft]
+      to: [published]
+      tx_guard: "len("
+`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	loader := yaml.NewLoaderWithTxEnv(func(ctx context.Context, tx any, ev workflow.Event) map[string]any {
+		return nil
+	})
+	if _, err := loader.LoadDefinition(cfg); err == nil {
+		t.Fatal("an uncompilable tx_guard must fail the load")
+	}
+}


### PR DESCRIPTION
Closes #35. The last of the three viability items in #46 — #45 measured, #36 and #34 are merged.

## The gap

Guards are evaluated against an environment built from an `Event`, and an `Event`
carries no transaction. So a host resolves its decision inputs **before** the
transaction opens, injects them as context booleans, and fires — and anything that
changed in between is silently stale. The asymmetry was the whole issue:
`TxSideEffect` gets the tx but runs *after* the decision; guards make the decision
with *no* tx.

## What this adds

```yaml
- name: submit
  from: [draft]
  to: [submitted]
  tx_guard: "readyGate()"                                    # queries, in THIS tx

- name: approve
  from: [submitted, signoffs]
  to: [approved]
  tx_guard: "actor != submitterOf() && amountOf() == amount" # live vs passed-in
```

`tx_guard:` (Go: `NewTxExpressionConstraint`) compiles against an environment a
**`TxEnvBuilder`** assembles from the transaction itself. What the builder returns is
**added** to the standard guard environment, so an expression can compare something
read live against something the host passed in — which is what nearly all of them do.

**This inverts the write path when a definition uses it.** `Manager.Execute` runs the
whole load → fire → save cycle inside one transaction, so the guard reads the snapshot
the version check will be made against, and **`ApplyAny` can route on it** rather than
merely veto a branch already chosen. The trade is explicit and documented as a boundary
(`BOUNDARIES.md §5a`): the transaction is held open across the caller's `fn`, its
guards, and every listener they trigger.

### New storage capability

`TxScopedStorage` / `TxScopedDueStorage` — `BeginScope`, `LoadStateScoped`,
`SaveStateScoped`, `SaveStateScopedWithDue`. Both SQL backends implement them as thin
wrappers over the existing `*sql.Tx` methods, and the **`storagetest` conformance kit**
now holds any backend to the contract (load/save in one tx, rollback on the caller's
error, the version guard still applying, a foreign handle reported not assumed, and the
due index committing with the scoped save). Postgres passes via testcontainers.

### Refusals, never a stale answer

- A definition with tx guards on a backend without the capability →
  `errors.ErrUnsupported`, checked **before anything fires**.
- Evaluating one outside a firing transaction (a bare `ApplyTransition`, a `Can` probe)
  → the new **`ErrNoTransaction`**.
- Retries re-decide: each `ErrConflict` attempt opens a new transaction and
  re-evaluates.
- The **migration handler is consulted before the scope opens** — it is host code that
  may write to storage and would deadlock against our own transaction on the same rows.

`tx_guard` is part of `Definition.Fingerprint()` and renders on the diagram (marked ⛁,
because *when* it is evaluated is what differs).

## Re-measurement — the #46 question is answered

`internal/spike/approval` converted and re-measured:

| | after #36 | after #34 | after #35 |
|---|---|---|---|
| Declarative (`workflow.yaml`) | 85 | 109 | **111** |
| Go — orchestration | 208 | 157 | **159** |
| Go — host implementations (the SQL) | 180 | 164 | **222** |

**68% → 80% declarative by concern.** `COVERAGE.md` set "above 70% by concern once #34,
#35 and #36 have all landed" *before any of them existed*, with the explicit clause that
missing it was the signal to stop investing. All three are in, and it is 80%.

**By line it went 25% → 23%, and total Go went UP 60 lines.** That is reported first in
`COVERAGE.md` rather than buried: three pre-computed booleans left Go and were replaced
by more verbose SQL. The same thing happened at #36. It is the honest cost of making
something addressable by a definition instead of inlined in a call path.

Of the six concerns not fully declarative, **four are deliberately out of scope** (role
ladder, directory, last-resort eligibility — org modelling, which `BOUNDARIES.md` keeps
out). The two real gaps are #37 and #38, both small and both filed. One new friction
item is filed too: `require:` expressions cannot use the tx environment, so the two
features do not compose for a join whose arity is a pure database fact.

`TestStaleChainIsRefusedInTheTransaction` is the acceptance criterion made concrete: a
requisition is raised from 1,000 to 20,000 between the host's read and the fire, and the
firing that would have approved it on one signature is refused, leaving no trace.

## `examples/feature_tour/` — the example that must stay current

Also here, per the request for an example updated with every feature: one runnable
workflow exercising **every shipped feature**, one test per feature, and a README table
mapping feature → where → test, plus a "not demonstrated, and why" table so gaps are
decisions rather than omissions.

It lives in the **root module** on purpose — an example pinned to a published version
cannot demonstrate an unreleased feature, and one that never runs cannot fail.
`CONTRIBUTING.md` and `CLAUDE.md` now require updating it with every user-visible
feature.

**It earned its keep on first use.** Converting it surfaced a design defect in this very
PR: the tx environment originally *replaced* the standard one, so `actor` silently
evaluated to nil and `actor != submitterOf()` was always true. Neither the unit tests
nor review had caught it.

## Tests

`txguard_test.go`, `yaml/txguard_test.go`, `storagetest` scoped conformance, 12 tour
tests, and the spike suite. Root coverage 95.0%. `gofmt -s` / `go vet` /
`golangci-lint` clean; `go test -race -p 1 ./...` green including Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transaction-scoped guards that evaluate host state atomically during workflow execution.
  * Added YAML configuration and transaction-aware environment support.
  * Added transactional storage support for SQLite and PostgreSQL, including rollback, retries, and due-time updates.
  * Added clear errors for unsupported or out-of-transaction evaluation.
  * Added a runnable feature-tour workflow demonstrating approvals, timers, effects, and diagrams.

* **Documentation**
  * Expanded configuration, usage, transaction-boundary, and contribution guidance.

* **Tests**
  * Added comprehensive coverage for guards, storage behavior, retries, rollback, fingerprints, and diagrams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->